### PR TITLE
Call vertex `usage` functions with graph.

### DIFF
--- a/pacman/model/partitionable_graph/abstract_partitionable_vertex.py
+++ b/pacman/model/partitionable_graph/abstract_partitionable_vertex.py
@@ -67,26 +67,25 @@ class AbstractPartitionableVertex(AbstractConstrainedVertex):
         self.add_constraint(max_atom_per_core_constraint)
 
     @abstractmethod
-    def get_sdram_usage_for_atoms(self, vertex_slice, vertex_in_edges):
+    def get_sdram_usage_for_atoms(self, vertex_slice, graph):
         """method for calculating sdram usage of a collection of atoms
 
         :param vertex_slice: the vertex vertex_slice which determines\
          which atoms are being represented by this vertex
-        :param vertex_in_edges: the incomign edges of this vertex for
-        calcualting sdram usage
+        :param graph: A reference to the graph containing this vertex
         :type vertex_slice: pacman.model.graph_mapper.slice.Slice
-        :type vertex_in_edges: iterable of edges
         :return a int value for sdram usage
         :rtype: int
         :raise None: this emthod raises no known exception
         """
 
     @abstractmethod
-    def get_dtcm_usage_for_atoms(self, vertex_slice):
+    def get_dtcm_usage_for_atoms(self, vertex_slice, graph):
         """method for caulculating dtcm usage for a coltection of atoms
 
         :param vertex_slice: the vertex vertex_slice which determines\
          which atoms are being represented by this vertex
+        :param graph: A reference to the graph containing this vertex.
         :type vertex_slice: pacman.model.graph_mapper.slice.Slice
         :return a int value for sdram usage
         :rtype: int
@@ -94,11 +93,12 @@ class AbstractPartitionableVertex(AbstractConstrainedVertex):
         """
 
     @abstractmethod
-    def get_cpu_usage_for_atoms(self, vertex_slice):
+    def get_cpu_usage_for_atoms(self, vertex_slice, graph):
         """Gets the CPU requirements for a range of atoms
 
         :param vertex_slice: the vertex vertex_slice which determines\
          which atoms are being represented by this vertex
+        :param graph: A reference to the graph containing this vertex.
         :type vertex_slice: pacman.model.graph_mapper.slice.Slice
         :return a int value for sdram usage
         :rtype: int
@@ -115,24 +115,23 @@ class AbstractPartitionableVertex(AbstractConstrainedVertex):
         :raise None: does not raise any knwon exception
         """
 
-    def get_resources_used_by_atoms(self, vertex_slice, vertex_in_edges):
+    def get_resources_used_by_atoms(self, vertex_slice, graph):
         """returns the separate resource requirements for a range of atoms
         in a resource object with a assumption object that tracks any
         assumptions made by the model when estimating resource requirement
 
         :param vertex_slice: the low value of atoms to calculate resources from
-        :param vertex_in_edges: the edges going into this vertex.
+        :param graph: A reference to the graph containing this vertex.
         :type vertex_slice: pacman.model.graph_mapper.slice.Slice
-        :type vertex_in_edges: list of edges
         :return: a Resource container that contains a CPUCyclesPerTickResource,
         DTCMResource and SDRAMResource
         :rtype: ResourceContainer
         :raise None: this method does not raise any known exception
         """
-        cpu_cycles = self.get_cpu_usage_for_atoms(vertex_slice)
-        dtcm_requirement = self.get_dtcm_usage_for_atoms(vertex_slice)
-        sdram_requirement = self.get_sdram_usage_for_atoms(vertex_slice,
-                                                           vertex_in_edges)
+        cpu_cycles = self.get_cpu_usage_for_atoms(vertex_slice, graph)
+        dtcm_requirement = self.get_dtcm_usage_for_atoms(vertex_slice, graph)
+        sdram_requirement = self.get_sdram_usage_for_atoms(vertex_slice, graph)
+
         # noinspection PyTypeChecker
         resources = ResourceContainer(cpu=CPUCyclesPerTickResource(cpu_cycles),
                                       dtcm=DTCMResource(dtcm_requirement),

--- a/pacman/operations/partition_algorithms/basic_partitioner.py
+++ b/pacman/operations/partition_algorithms/basic_partitioner.py
@@ -70,7 +70,7 @@ class BasicPartitioner(AbstractPartitionAlgorithm):
             # Compute atoms per core from resource availability
             incoming_edges = graph.incoming_edges_to_vertex(vertex)
             requirements = \
-                vertex.get_resources_used_by_atoms(0, 1, incoming_edges)
+                vertex.get_resources_used_by_atoms(0, 1, graph)
 
             #locate max SDRAM available. SDRAM is the only one that's changeable
             #during partitioning, as DTCM and cpu cycles are bespoke to a
@@ -128,7 +128,7 @@ class BasicPartitioner(AbstractPartitionAlgorithm):
                                                    " subvertex")
                 subvertex_usage = \
                     vertex.get_resources_used_by_atoms(
-                        counted, counted + alloc - 1, incoming_edges)
+                        counted, counted + alloc - 1, graph)
 
                 subvert = PartitionedVertex(counted, counted + alloc - 1,
                                             resources_required=subvertex_usage,

--- a/pacman/operations/partition_algorithms/partition_and_place_partitioner.py
+++ b/pacman/operations/partition_algorithms/partition_and_place_partitioner.py
@@ -309,8 +309,8 @@ py:class:'pacman.modelgraph_subgraph_mapper.graph_mapper.GraphMapper'
                 vertex_constraints=vertex.constraints, machine=machine)
             #get resources for vertexes
             vertex_slice = Slice(lo_atom, hi_atom)
-            used_resources = vertex.get_resources_used_by_atoms(
-                vertex_slice, graph.incoming_edges_to_vertex(vertex))
+            used_resources = vertex.get_resources_used_by_atoms(vertex_slice,
+                                                                graph)
             
             #figure max ratio
             ratio = self._find_max_ratio(used_resources, resources)
@@ -332,8 +332,7 @@ py:class:'pacman.modelgraph_subgraph_mapper.graph_mapper.GraphMapper'
                 # Find the new resource usage
                 hi_atom = lo_atom + new_n_atoms - 1
                 used_resources = \
-                    vertex.get_resources_used_by_atoms(
-                        vertex_slice, graph.incoming_edges_to_vertex(vertex))
+                    vertex.get_resources_used_by_atoms(vertex_slice, graph)
                 ratio = self._find_max_ratio(used_resources, resources)
 
             # If we couldn't partition, raise and exception
@@ -370,6 +369,7 @@ py:class:'pacman.modelgraph_subgraph_mapper.graph_mapper.GraphMapper'
 
         return used_placements, min_hi_atom
 
+    # ***TODO*** This method is completely out of date?
     def _scale_up_resource_usage(
             self, used_resources, hi_atom, lo_atom, max_atoms_per_core, vertex,
             partition_data_object, resources, ratio):

--- a/pacman/utilities/reports.py
+++ b/pacman/utilities/reports.py
@@ -227,7 +227,7 @@ def sdram_usage_per_chip(report_folder, hostname, placements, machine,
 
         vertex_slice = graph_mapper.get_subvertex_slice(subvert)
         requirements = \
-            vertex.get_resources_used_by_atoms(vertex_slice, vertex_in_edges)
+            vertex.get_resources_used_by_atoms(vertex_slice, graph)
 
         x, y, p = placement.x, placement.y, placement.p
         f_mem_used_by_core.write(


### PR DESCRIPTION
Replace the calls to vertex `usage` functions so that the full graph rather
than just the `in_edges` is supplied.  This is because `in_edges` is very
front-end specific (i.e., PyNN) whereas the graph should be general.
- [x] Modify PyNN front end appropriately
