### PR TITLE
Remove unused function from vertex.

### DIFF
--- a/pacman/model/partitionable_graph/abstract_partitionable_vertex.py
+++ b/pacman/model/partitionable_graph/abstract_partitionable_vertex.py
@@ -156,33 +156,6 @@ class AbstractPartitionableVertex(AbstractConstrainedVertex):
                 current_found_max_atoms_per_core = constraint.size
         return current_found_max_atoms_per_core
 
-    def create_subvertex(self, resources_required, label=None,
-                         additional_constraints=list()):
-        """ Creates a subvertex of this vertex.  Can be overridden in vertex\
-            subclasses to create an subvertex instance that contains detailed\
-            information
-
-        :param label: The label to give the subvertex.  If not given, and the\
-                    vertex has no label, no label will be given to the\
-                    subvertex.  If not given and the vertex has a label, a\
-                    default label will be given to the subvertex
-        :type label: str
-        :param additional_constraints: An iterable of constraints from the\
-                    subvertex over-and-above those of the vertex
-        :type additional_constraints: iterable of\
-                    :py:class:`pacman.model.constraints.abstract_constraint\
-                    .AbstractConstraint`
-        :raise pacman.exceptions.PacmanInvalidParameterException:
-                    * If lo_atom or hi_atom are out of range
-                    * If one of the constraints is invalid
-        """
-        # Combine the AbstractConstrainedVertex and PartitionedVertex constraints
-        additional_constraints.extend(self.constraints)
-
-        return PartitionedVertex(label=label,
-                                 resources_required=resources_required,
-                                 constraints=additional_constraints)
-
     @property
     def n_atoms(self):
         """ The number of atoms in the vertex


### PR DESCRIPTION
As far as I can tell `create_subvertex` is not used and will not be used.  It should be removed.