### PR TITLE
Changes to Placements to make errors clearer.

### DIFF
--- a/pacman/exceptions.py
+++ b/pacman/exceptions.py
@@ -127,3 +127,23 @@ class PacmanNotExistException(PacmanException):
         :type problem: str
         """
         PacmanException.__init__(self, problem)
+
+
+class PacmanSubvertexAlreadyPlacedError(ValueError):
+    """Indicates multiple placements are being made for a subvertex."""
+    pass
+
+
+class PacmanSubvertexNotPlacedError(KeyError):
+    """Indicates no placements are made for a subvertex."""
+    pass
+
+
+class PacmanProcessorAlreadyOccupiedError(ValueError):
+    """Indicates multiple placements are being made to a processor."""
+    pass
+
+
+class PacmanProcessorNotOccupiedError(KeyError):
+    """Indicates that no placement has been made to a processor."""
+    pass


### PR DESCRIPTION
I've gone through to make some Flake8 corrections

I've added some Error types (`SubvertexAlreadyPlacedError` and `ProcessorAlreadyOccupied`) which I think make it clearer what errors have occurred.  From the point of view of calling code it makes sense to have different Errors raised for different types of error, it makes catching specific exceptions easier.  My preference is for these to live in the module that raises them, but I'm prepared for them to move if so desired.

Additionally, `get_placement_of_subvertex` raises a `KeyError` if the subvertex has not been placed.  This seems to be in line with what would be expected.

Finally, I re-ordered `get_subvertex_on_processor` such that `None` was returned from within the conditional (making it explicit why None was returned).  I don't think querying the placement for a processor that does not have one should raise an Exception.
