### PR TITLE
Turn vertex slices into Python slices.

### DIFF
--- a/pacman/model/graph_mapper/slice.py
+++ b/pacman/model/graph_mapper/slice.py
@@ -1,17 +1,38 @@
-class Slice(object):
+import collections
 
-    def __init__(self, lo_atom, hi_atom):
-        self._lo_atom = lo_atom
-        self._hi_atom = hi_atom
+from pacman.exceptions import PacmanValueError
 
-    @property
-    def lo_atom(self):
-        return self._lo_atom
 
-    @property
-    def hi_atom(self):
-        return self._hi_atom
+class Slice(collections.namedtuple('Slice', 
+                                   'lo_atom hi_atom n_atoms as_slice')):
+    """Represents a slice of a vertex.
 
-    @property
-    def n_atoms(self):
-        return (self._hi_atom - self.lo_atom) + 1
+    :attr int lo_atom: The lowest atom represented in the slice.
+    :attr int hi_atom: The highest atom represented in the slice.
+    :attr int n_atoms: The number of atoms represented by the slice.
+    :attr as_slice: This slice represented as a :py:func:`slice` object (for
+                    use in indexing lists, arrays, etc.)
+    """
+    def __new__(cls, lo_atom, hi_atom):
+        """Create a new Slice object.
+
+        :param int lo_atom: Index of the lowest atom to represent.
+        :param int hi_atom: Index of the highest atom to represent.
+        :raises PacmanValueError: If the bounds of the slice are invalid.
+        """
+        if lo_atom < 0:
+            raise PacmanValueError('lo_atom < 0')
+        if hi_atom < lo_atom:
+            raise PacmanValueError(
+                'hi_atom {:d} < lo_atom {:d}'.format(hi_atom,lo_atom))
+
+        # Number of atoms represented by this slice
+        n_atoms = hi_atom - lo_atom + 1
+
+        # Slice for accessing arrays of values
+        as_slice = slice(lo_atom, hi_atom + 1)
+
+        # Create the Slice object as a `namedtuple` with these pre-computed
+        # values filled in.
+        return super(cls, Slice).__new__(cls, lo_atom, hi_atom, n_atoms,
+                                         as_slice)

--- a/unittests/model_tests/test_graph_subraph_mapper.py
+++ b/unittests/model_tests/test_graph_subraph_mapper.py
@@ -1,6 +1,7 @@
 import unittest
 from pacman.model.graph_mapper.graph_mapper \
     import GraphMapper
+from pacman.model.graph_mapper.slice import Slice
 from pacman.model.partitionable_graph.abstract_partitionable_vertex import \
     AbstractPartitionableVertex
 from pacman.model.partitionable_graph.partitionable_edge import \
@@ -135,6 +136,51 @@ class TestGraphSubgraphMapper(unittest.TestCase):
             graph.get_partitionable_edge_from_partitioned_edge,
             subedges[1]
         )
+
+
+class TestSlice(unittest.TestCase):
+    """Tests that Slices expose the correct options and are immutable."""
+    def test_basic(self):
+        s = Slice(0, 10)
+        assert s.n_atoms == 11  # 10 - 0 + 1
+        assert s.lo_atom == 0   # As specified
+        assert s.hi_atom == 10  # As specified
+        assert s.as_slice == slice(0, 11)  # Slice object supported by arrays
+
+    def test_check_lo_atom_sanity(self):
+        # Check for value sanity
+        with self.assertRaises(ValueError):
+            # Check for negative atom
+            Slice(-1, 10)
+
+    def test_check_hi_atom_sanity(self):
+        with self.assertRaises(ValueError):
+            # Check for slice which goes backwards
+            Slice(5, 4)
+
+    def test_equal_hi_lo_atoms(self):
+        # This should be fine...
+        Slice(4, 4)
+
+    def test_immutability_lo_atom(self):
+        s = Slice(0, 10)
+        with self.assertRaises(AttributeError):
+            s.lo_atom = 3
+
+    def test_immutability_hi_atom(self):
+        s = Slice(0, 10)
+        with self.assertRaises(AttributeError):
+            s.hi_atom = 3
+
+    def test_immutability_n_atoms(self):
+        s = Slice(0, 10)
+        with self.assertRaises(AttributeError):
+            s.n_atoms = 3
+
+    def test_immutability_as_slice(self):
+        s = Slice(0, 10)
+        with self.assertRaises(AttributeError):
+            s.as_slice = slice(2, 10)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Converts the `Slice` object so that it subclasses from `namedtuple`.  This
allows precomputation of `n_atoms` and the creation of a Python `slice`.

The intended use of the additional slice object is something like this:

``` python
def do_something_with_slice(vertex_slice):
    # ...
    prepared_data[vertex_slice.as_slice]
    # ...
```

Allowing the vertex slice to be used directly to slice a Python array.  Saves
doing this:

``` python
def do_something_with_slice(vertex_slice):
    # ...
    prepared_data[vertex_slice.lo_atom:vertex_slice.hi_atom + 1]
    # ...
```
