### PR TITLE
Use >= in _is_sdram_available

### DIFF
--- a/pacman/utilities/utility_objs/resource_tracker.py
+++ b/pacman/utilities/utility_objs/resource_tracker.py
@@ -188,10 +188,10 @@ class ResourceTracker(object):
         :rtype: bool
         """
         if key in self._sdram_tracker:
-            return ((chip.sdram.size - self._sdram_tracker[key]) >
+            return ((chip.sdram.size - self._sdram_tracker[key]) >=
                     resources.sdram.get_value())
         else:
-            return chip.sdram > resources.sdram.get_value()
+            return chip.sdram >= resources.sdram.get_value()
 
     def _sdram_available(self, chip, key):
         """ Return the amount of SDRAM available on a chip


### PR DESCRIPTION
This is mainly relevant for virtual populations that require 0 SDRAM on a virtual chip with 0 SDRAM, but is of course correct in general.