### PR TITLE
recording no state region

### DIFF
--- a/pacman/model/graphs/application/impl/application_vertex.py
+++ b/pacman/model/graphs/application/impl/application_vertex.py
@@ -17,9 +17,6 @@ class ApplicationVertex(AbstractApplicationVertex):
 
     __slots__ = [
 
-        # The resources required
-        "_resources_required",
-
         # The label
         "_label",
 
@@ -73,5 +70,5 @@ class ApplicationVertex(AbstractApplicationVertex):
 
     def __repr__(self):
         return (
-            "ApplicationVertex(resources_required={}, label={}, constraints={}"
-            .format(self._resources_required, self.constraints, self._label))
+            "ApplicationVertex(label={}, constraints={}"
+            .format(self.constraints, self._label))

--- a/pacman/model/graphs/machine/impl/machine_fpga_vertex.py
+++ b/pacman/model/graphs/machine/impl/machine_fpga_vertex.py
@@ -35,8 +35,8 @@ class MachineFPGAVertex(MachineVertex, AbstractFPGAVertex):
     @overrides(MachineVertex.resources_required)
     def resources_required(self):
         return ResourceContainer(
-                dtcm=DTCMResource(0), sdram=SDRAMResource(0),
-                cpu_cycles=CPUCyclesPerTickResource(0))
+            dtcm=DTCMResource(0), sdram=SDRAMResource(0),
+            cpu_cycles=CPUCyclesPerTickResource(0))
 
     @property
     @overrides(AbstractFPGAVertex.fpga_id)

--- a/pacman/model/graphs/machine/impl/machine_fpga_vertex.py
+++ b/pacman/model/graphs/machine/impl/machine_fpga_vertex.py
@@ -24,16 +24,19 @@ class MachineFPGAVertex(MachineVertex, AbstractFPGAVertex):
             self, fpga_id, fpga_link_id, board_address=None, label=None,
             constraints=None):
         MachineVertex.__init__(
-            self, ResourceContainer(
-                dtcm=DTCMResource(0), sdram=SDRAMResource(0),
-                cpu_cycles=CPUCyclesPerTickResource(0)),
-            label=label, constraints=constraints)
+            self, label=label, constraints=constraints)
 
         self._fpga_id = fpga_id
         self._fpga_link_id = fpga_link_id
         self._board_address = board_address
         self._virtual_chip_x = None
         self._virtual_chip_y = None
+
+    @overrides(MachineVertex.resources_required)
+    def resources_required(self):
+        return ResourceContainer(
+                dtcm=DTCMResource(0), sdram=SDRAMResource(0),
+                cpu_cycles=CPUCyclesPerTickResource(0))
 
     @property
     @overrides(AbstractFPGAVertex.fpga_id)

--- a/pacman/model/graphs/machine/impl/machine_fpga_vertex.py
+++ b/pacman/model/graphs/machine/impl/machine_fpga_vertex.py
@@ -32,6 +32,7 @@ class MachineFPGAVertex(MachineVertex, AbstractFPGAVertex):
         self._virtual_chip_x = None
         self._virtual_chip_y = None
 
+    @property
     @overrides(MachineVertex.resources_required)
     def resources_required(self):
         return ResourceContainer(

--- a/pacman/model/graphs/machine/impl/machine_spinnaker_link_vertex.py
+++ b/pacman/model/graphs/machine/impl/machine_spinnaker_link_vertex.py
@@ -29,6 +29,7 @@ class MachineSpiNNakerLinkVertex(MachineVertex, AbstractSpiNNakerLinkVertex):
         self._virtual_chip_x = None
         self._virtual_chip_y = None
 
+    @property
     @overrides(MachineVertex.resources_required)
     def resources_required(self):
         return ResourceContainer(

--- a/pacman/model/graphs/machine/impl/machine_spinnaker_link_vertex.py
+++ b/pacman/model/graphs/machine/impl/machine_spinnaker_link_vertex.py
@@ -32,8 +32,8 @@ class MachineSpiNNakerLinkVertex(MachineVertex, AbstractSpiNNakerLinkVertex):
     @overrides(MachineVertex.resources_required)
     def resources_required(self):
         return ResourceContainer(
-                dtcm=DTCMResource(0), sdram=SDRAMResource(0),
-                cpu_cycles=CPUCyclesPerTickResource(0))
+            dtcm=DTCMResource(0), sdram=SDRAMResource(0),
+            cpu_cycles=CPUCyclesPerTickResource(0))
 
     @property
     @overrides(AbstractSpiNNakerLinkVertex.spinnaker_link_id)

--- a/pacman/model/graphs/machine/impl/machine_spinnaker_link_vertex.py
+++ b/pacman/model/graphs/machine/impl/machine_spinnaker_link_vertex.py
@@ -23,15 +23,17 @@ class MachineSpiNNakerLinkVertex(MachineVertex, AbstractSpiNNakerLinkVertex):
     def __init__(
             self, spinnaker_link_id, board_address=None, label=None,
             constraints=None):
-        MachineVertex.__init__(
-            self, ResourceContainer(
-                dtcm=DTCMResource(0), sdram=SDRAMResource(0),
-                cpu_cycles=CPUCyclesPerTickResource(0)),
-            label=label, constraints=constraints)
+        MachineVertex.__init__(self, label=label, constraints=constraints)
         self._spinnaker_link_id = spinnaker_link_id
         self._board_address = board_address
         self._virtual_chip_x = None
         self._virtual_chip_y = None
+
+    @overrides(MachineVertex.resources_required)
+    def resources_required(self):
+        return ResourceContainer(
+                dtcm=DTCMResource(0), sdram=SDRAMResource(0),
+                cpu_cycles=CPUCyclesPerTickResource(0))
 
     @property
     @overrides(AbstractSpiNNakerLinkVertex.spinnaker_link_id)

--- a/pacman/model/graphs/machine/impl/machine_vertex.py
+++ b/pacman/model/graphs/machine/impl/machine_vertex.py
@@ -12,9 +12,6 @@ class MachineVertex(AbstractMachineVertex):
 
     __slots__ = [
 
-        # The resources required
-        "_resources_required",
-
         # The label
         "_label",
 
@@ -22,12 +19,8 @@ class MachineVertex(AbstractMachineVertex):
         "_constraints"
     ]
 
-    def __init__(self, resources_required, label=None, constraints=None):
+    def __init__(self, label=None, constraints=None):
         """
-        :param resources_required:\
-            The maximum resources needed for the vertex
-        :type resources_required:\
-            :py:class:`pacman.models.resources.resource_container.ResourceContainer`
         :param label: The optional name of the vertex
         :type label: str
         :param constraints: The optional initial constraints of the vertex
@@ -37,7 +30,6 @@ class MachineVertex(AbstractMachineVertex):
         :raise pacman.exceptions.PacmanInvalidParameterException:
                     * If one of the constraints is not valid
         """
-        self._resources_required = resources_required
         self._label = label
 
         AbstractMachineVertex.__init__(self)
@@ -60,15 +52,10 @@ class MachineVertex(AbstractMachineVertex):
     def label(self):
         return self._label
 
-    @property
-    @overrides(AbstractMachineVertex.resources_required)
-    def resources_required(self):
-        return self._resources_required
-
     def __str__(self):
         return self._label
 
     def __repr__(self):
         return (
-            "MachineVertex(resources_required={}, label={}, constraints={}"
-            .format(self._resources_required, self._label, self.constraints))
+            "MachineVertex(label={}, constraints={}"
+            .format(self._label, self.constraints))

--- a/pacman/model/graphs/machine/impl/simple_machine_vertex.py
+++ b/pacman/model/graphs/machine/impl/simple_machine_vertex.py
@@ -1,0 +1,18 @@
+from pacman.model.graphs.machine.impl.machine_vertex import MachineVertex
+from pacman.model.decorators.overrides import overrides
+from pacman.model.graphs.machine.abstract_machine_vertex \
+    import AbstractMachineVertex
+
+
+class SimpleMachineVertex(MachineVertex):
+    """ A MachineVertex that stores its own resources
+    """
+
+    def __init__(self, resources, label=None, constraints=None):
+        MachineVertex.__init__(self, label=label, constraints=constraints)
+        self._resources = resources
+
+    @property
+    @overrides(AbstractMachineVertex.resources_required)
+    def resources_required(self):
+        return self._resources

--- a/pacman/utilities/utility_objs/resource_tracker.py
+++ b/pacman/utilities/utility_objs/resource_tracker.py
@@ -1005,14 +1005,16 @@ class ResourceTracker(object):
                     return results
 
         # If no chip is available, raise an exception
-        n_cores, n_chips, max_sdram = self._available_resources(usable_chips)
+        n_cores, n_chips, max_sdram, n_tags = self._available_resources(
+            usable_chips)
         raise exceptions.PacmanValueError(
             "No resources available to allocate the given group resources"
             " within the given constraints:\n"
             "    Request for {} cores on a single chip with SDRAM: {}\n"
             "    Resources available which meet constraints:"
-            "        {} Cores on {} chips, largest SDRAM space: {}".format(
-                len(group_resources), total_sdram, n_cores, n_chips,
+            "        {} Cores and {} tags on {} chips,"
+            " largest SDRAM space: {}".format(
+                len(group_resources), total_sdram, n_cores, n_tags, n_chips,
                 max_sdram))
 
     def allocate_resources(self, resources, chips=None,


### PR DESCRIPTION
this set of branches works to remove the state region from recording. 

-IntroLab
-PACMAN
-FEC
-SPY
-GFE
-External
- [x] handle python code
- [x] modded the graph to remove resources required issues (nice little refactor)
- [x] handle c code changes
- [x] test basic reads for v (use synfire)
- [x] test basic read for gsyn (use synfire)
- [x] test basic read for spikes (use synfire)
- [x] test multiple reads and writes (use synfire)
- [x] test no reads and writes (use synfire)
- [x] test ssa recording (use synfire)
- [x] test poission recording (used pynn brunnel)
- [x] test poission no recording (use pynn brunnel)
- [x] test auto pause and resume battery of tests
- [x] test with live extraction (is being ignored as auto_pause-and_resume works)
- [x] test reload (use synfire) (has been disabled till a plan of action on it is decided)
