### PR TITLE
Same chip as constraint

### DIFF
--- a/integration_tests/test_same_chip_constraint.py
+++ b/integration_tests/test_same_chip_constraint.py
@@ -1,0 +1,63 @@
+from pacman.model.graphs.machine.impl.machine_graph import MachineGraph
+from spinn_machine.virtual_machine import VirtualMachine
+from pacman.model.graphs.machine.impl.machine_vertex import MachineVertex
+from pacman.model.resources.resource_container import ResourceContainer
+from pacman.model.constraints.placer_constraints\
+    .placer_same_chip_as_constraint import PlacerSameChipAsConstraint
+from pacman.operations.placer_algorithms.one_to_one_placer \
+    import OneToOnePlacer
+from pacman.operations.placer_algorithms.radial_placer import RadialPlacer
+import random
+import unittest
+
+
+class TestSameChipConstraint(unittest.TestCase):
+
+    def _do_test(self, placer):
+        machine = VirtualMachine(width=8, height=8)
+        graph = MachineGraph("Test")
+
+        vertices = [
+            MachineVertex(
+                resources_required=ResourceContainer(), label="v{}".format(i))
+            for i in range(100)
+        ]
+        for vertex in vertices:
+            graph.add_vertex(vertex)
+
+        same_vertices = [
+            MachineVertex(
+                resources_required=ResourceContainer(),
+                label="same{}".format(i))
+            for i in range(10)
+        ]
+        for vertex in same_vertices:
+            graph.add_vertex(vertex)
+            for i in range(0, random.randint(1, 5)):
+                vertex.add_constraint(
+                    PlacerSameChipAsConstraint(
+                        vertices[random.randint(0, 99)]))
+
+        placements = placer(graph, machine)
+        for same in same_vertices:
+            print "{0.vertex.label}, {0.x}, {0.y}, {0.p}: {1}".format(
+                placements.get_placement_of_vertex(same),
+                ["{0.vertex.label}, {0.x}, {0.y}, {0.p}".format(
+                    placements.get_placement_of_vertex(constraint.vertex))
+                 for constraint in same.constraints]
+            )
+            placement = placements.get_placement_of_vertex(same)
+            for constraint in same.constraints:
+                if isinstance(constraint, PlacerSameChipAsConstraint):
+                    other_placement = placements.get_placement_of_vertex(
+                        constraint.vertex)
+                    self.assert_(
+                        other_placement.x == placement.x and
+                        other_placement.y == placement.y,
+                        "Vertex was not placed on the same chip as requested")
+
+    def test_one_to_one(self):
+        self._do_test(OneToOnePlacer())
+
+    def test_radial(self):
+        self._do_test(RadialPlacer())

--- a/integration_tests/test_same_chip_constraint.py
+++ b/integration_tests/test_same_chip_constraint.py
@@ -4,6 +4,7 @@ from pacman.model.graphs.machine.impl.machine_vertex import MachineVertex
 from pacman.model.resources.resource_container import ResourceContainer
 from pacman.model.constraints.placer_constraints\
     .placer_same_chip_as_constraint import PlacerSameChipAsConstraint
+from pacman.operations.rig_algorithms.rig_place import RigPlace
 from pacman.operations.placer_algorithms.one_to_one_placer \
     import OneToOnePlacer
 from pacman.operations.placer_algorithms.radial_placer import RadialPlacer
@@ -61,3 +62,6 @@ class TestSameChipConstraint(unittest.TestCase):
 
     def test_radial(self):
         self._do_test(RadialPlacer())
+
+    def test_rig(self):
+        self._do_test(RigPlace())

--- a/pacman/model/graphs/abstract_virtual_vertex.py
+++ b/pacman/model/graphs/abstract_virtual_vertex.py
@@ -31,10 +31,12 @@ class AbstractVirtualVertex(AbstractVertex):
     def virtual_chip_x(self):
         """ The x-coordinate of the virtual chip where this vertex is to be\
             placed
+            :return int
         """
 
     @abstractproperty
     def virtual_chip_y(self):
         """ The y-coordinate of the virtual chip where this vertex is to be\
             placed
+            :return int
         """

--- a/pacman/model/graphs/machine/impl/machine_vertex.py
+++ b/pacman/model/graphs/machine/impl/machine_vertex.py
@@ -66,9 +66,11 @@ class MachineVertex(AbstractMachineVertex):
         return self._resources_required
 
     def __str__(self):
+        if self._label is None:
+            return self.__repr__()
         return self._label
 
     def __repr__(self):
-        return (
-            "MachineVertex(resources_required={}, label={}, constraints={}"
-            .format(self._resources_required, self._label, self.constraints))
+        return\
+            "MachineVertex(resources_required={}, label={}, constraints={}"\
+            .format(self._resources_required, self._label, self.constraints)

--- a/pacman/operations/algorithms_metadata.xml
+++ b/pacman/operations/algorithms_metadata.xml
@@ -485,6 +485,27 @@
             <param_type>MemoryRoutingTableByPartition</param_type>
         </outputs>
     </algorithm>
+    <algorithm name="RigPlace">
+        <python_module>pacman.operations.rig_algorithms.rig_place</python_module>
+        <python_class>RigPlace</python_class>
+        <input_definitions>
+            <parameter>
+                <param_name>machine_graph</param_name>
+                <param_type>MemoryMachineGraph</param_type>
+            </parameter>
+            <parameter>
+                <param_name>machine</param_name>
+                <param_type>MemoryExtendedMachine</param_type>
+            </parameter>
+        </input_definitions>
+        <required_inputs>
+            <param_name>machine_graph</param_name>
+            <param_name>machine</param_name>
+        </required_inputs>
+        <outputs>
+            <param_type>MemoryPlacements</param_type>
+        </outputs>
+    </algorithm>
     <algorithm name="RigRoute">
         <python_module>pacman.operations.rig_algorithms.rig_route</python_module>
         <python_class>RigRoute</python_class>

--- a/pacman/operations/partition_algorithms/basic_partitioner.py
+++ b/pacman/operations/partition_algorithms/basic_partitioner.py
@@ -73,7 +73,7 @@ class BasicPartitioner(object):
             # Locate the maximum resources available
             max_resources_available = \
                 resource_tracker.get_maximum_constrained_resources_available(
-                    vertex, Slice(0, 1))
+                    requirements, vertex.constraints)
 
             # Find the ratio of each of the resources - if 0 is required,
             # assume the ratio is the max available
@@ -129,7 +129,7 @@ class BasicPartitioner(object):
 
                 # update allocated resources
                 resource_tracker.allocate_constrained_resources(
-                    resources, vertex, vertex_slice)
+                    resources, vertex.constraints)
 
             # update and end progress bars as needed
             progress_bar.update()

--- a/pacman/operations/partition_algorithms/partition_and_place_partitioner.py
+++ b/pacman/operations/partition_algorithms/partition_and_place_partitioner.py
@@ -246,7 +246,7 @@ class PartitionAndPlacePartitioner(object):
             # Re-allocate the existing resources
             (x, y, p, ip_tags, reverse_ip_tags) = \
                 resource_tracker.allocate_constrained_resources(
-                    new_resources, placed_vertex, vertex_slice)
+                    new_resources, placed_vertex.constraints)
             new_used_placements.append(
                 (placed_vertex, x, y, p, new_resources, ip_tags,
                  reverse_ip_tags))
@@ -290,14 +290,14 @@ class PartitionAndPlacePartitioner(object):
         for i in range(len(vertices)):
             vertex = vertices[i]
 
-            # get max resources available on machine
+            # get resources used by vertex
             vertex_slice = Slice(lo_atom, hi_atom)
+            used_resources = vertex.get_resources_used_by_atoms(vertex_slice)
+
+            # get max resources available on machine
             resources = \
                 resource_tracker.get_maximum_constrained_resources_available(
-                    vertex, vertex_slice)
-
-            # get resources used by vertex
-            used_resources = vertex.get_resources_used_by_atoms(vertex_slice)
+                    used_resources, vertex.constraints)
 
             # Work out the ratio of used to available resources
             ratio = self._find_max_ratio(used_resources, resources)
@@ -347,7 +347,7 @@ class PartitionAndPlacePartitioner(object):
             try:
                 (x, y, p, ip_tags, reverse_ip_tags) = \
                     resource_tracker.allocate_constrained_resources(
-                        used_resources, vertex, vertex_slice)
+                        used_resources, vertex.constraints)
                 used_placements.append(
                     (vertex, x, y, p, used_resources,
                      ip_tags, reverse_ip_tags))

--- a/pacman/operations/placer_algorithms/one_to_one_placer.py
+++ b/pacman/operations/placer_algorithms/one_to_one_placer.py
@@ -61,9 +61,12 @@ class OneToOnePlacer(RadialPlacer):
             else:
 
                 try:
+                    resource_and_constraint_list = [
+                        (vertex.resources_required, vertex.constraints)
+                        for vertex in vertex_list]
                     allocations = \
                         resource_tracker.allocate_constrained_group_resources(
-                            vertex_list)
+                            resource_and_constraint_list)
 
                     # allocate cores to vertices
                     for vertex, (x, y, p, _, _) in zip(
@@ -91,7 +94,7 @@ class OneToOnePlacer(RadialPlacer):
         # Create and store a new placement anywhere on the board
         (x, y, p, _, _) = resource_tracker.\
             allocate_constrained_resources(
-                vertex.resources_required, vertex, None)
+                vertex.resources_required, vertex.constraints)
         placement = Placement(vertex, x, y, p)
         placements.add_placement(placement)
         progress_bar.update()

--- a/pacman/operations/placer_algorithms/one_to_one_placer.py
+++ b/pacman/operations/placer_algorithms/one_to_one_placer.py
@@ -138,15 +138,30 @@ class OneToOnePlacer(RadialPlacer):
 
         for vertex in vertices:
             if vertex not in found_list:
+
+                # verts that are one to one connected with vertex and are not
+                # forced off chip
                 connected_vertices = self._find_one_to_one_vertices(
                     vertex, machine_graph)
-                new_list = {
-                    v for v in connected_vertices if v not in found_list}
 
-                same_chip_vertices = {
-                    v for vert in new_list
-                    for v in same_chip_vertex_groups[vert]
-                    if v not in new_list}
+                # create list for each vertex thats connected havent already
+                #  been seen before
+                new_list = set()
+                for found_vertex in connected_vertices:
+                    if found_vertex not in found_list:
+                        new_list.add(found_vertex)
+
+                # looks for verts that have same chip constraints but not found
+                # by the one to one connection search.
+                same_chip_vertices = list()
+                for found_vertex in new_list:
+                    for same_chip_constrained_vertex in \
+                            same_chip_vertex_groups[found_vertex]:
+                        if same_chip_constrained_vertex not in new_list:
+                            same_chip_vertices.append(
+                                same_chip_constrained_vertex)
+
+                # add these newly found verts to the list
                 new_list.update(same_chip_vertices)
 
                 sorted_vertices.append(new_list)

--- a/pacman/operations/placer_algorithms/one_to_one_placer.py
+++ b/pacman/operations/placer_algorithms/one_to_one_placer.py
@@ -7,8 +7,9 @@ from pacman.operations.placer_algorithms import RadialPlacer
 from pacman.utilities.utility_objs.resource_tracker import ResourceTracker
 
 from spinn_machine.utilities.progress_bar import ProgressBar
-import traceback
 from pacman.utilities.algorithm_utilities import placer_algorithm_utilities
+from pacman.model.constraints.placer_constraints\
+    .placer_same_chip_as_constraint import PlacerSameChipAsConstraint
 
 
 class OneToOnePlacer(RadialPlacer):
@@ -24,24 +25,32 @@ class OneToOnePlacer(RadialPlacer):
     def __call__(self, machine_graph, machine):
 
         # check that the algorithm can handle the constraints
-        self._check_constraints(machine_graph.vertices)
+        self._check_constraints(
+            machine_graph.vertices,
+            additional_placement_constraints={PlacerSameChipAsConstraint})
 
+        # Get which vertices must be placed on the same chip as another vertex
+        same_chip_vertex_groups = placer_algorithm_utilities\
+            .get_same_chip_vertex_groups(machine_graph.vertices)
         sorted_vertices = self._sort_vertices_for_one_to_one_connection(
-            machine_graph)
+            machine_graph, same_chip_vertex_groups)
 
-        placements = Placements()
-
-        self._do_allocation(sorted_vertices, placements, machine)
+        placements = self._do_allocation(
+            sorted_vertices, machine, same_chip_vertex_groups)
 
         return placements
 
-    def _do_allocation(self, vertices, placements, machine):
+    def _do_allocation(
+            self, vertices, machine, same_chip_vertex_groups):
+
+        placements = Placements()
 
         # Iterate over vertices and generate placements
         progress_bar = ProgressBar(
             len(vertices), "Placing graph vertices")
         resource_tracker = ResourceTracker(
             machine, self._generate_radial_chips(machine))
+        all_vertices_placed = set()
 
         # iterate over vertices
         for vertex_list in vertices:
@@ -50,14 +59,14 @@ class OneToOnePlacer(RadialPlacer):
             # (for one to one placement)
             max_cores_on_chip = \
                 resource_tracker.most_avilable_cores_on_a_chip()
-            if max_cores_on_chip % 2 != 0:
-                max_cores_on_chip -= 1
 
             # if too many one to ones to fit on a chip, allocate individually
             if len(vertex_list) > max_cores_on_chip:
                 for vertex in vertex_list:
                     self._allocate_individual(
-                        vertex, placements, progress_bar, resource_tracker)
+                        vertex, placements, resource_tracker,
+                        same_chip_vertex_groups, all_vertices_placed)
+                    progress_bar.update()
             else:
 
                 try:
@@ -77,30 +86,44 @@ class OneToOnePlacer(RadialPlacer):
                 except exceptions.PacmanValueError or \
                         exceptions.PacmanException or \
                         exceptions.PacmanInvalidParameterException:
-                    traceback.print_exc()
 
                     # If something goes wrong, try to allocate each
                     # individually
                     for vertex in vertex_list:
                         self._allocate_individual(
-                            vertex, placements, progress_bar,
-                            resource_tracker)
+                            vertex, placements, resource_tracker,
+                            same_chip_vertex_groups, all_vertices_placed)
+                        progress_bar.update()
         progress_bar.end()
+        return placements
 
     @staticmethod
     def _allocate_individual(
-            vertex, placements, progress_bar, resource_tracker):
+            vertex, placements, resource_tracker, same_chip_vertex_groups,
+            all_vertices_placed):
+        if vertex not in all_vertices_placed:
+            vertices = same_chip_vertex_groups[vertex]
 
-        # Create and store a new placement anywhere on the board
-        (x, y, p, _, _) = resource_tracker.\
-            allocate_constrained_resources(
-                vertex.resources_required, vertex.constraints)
-        placement = Placement(vertex, x, y, p)
-        placements.add_placement(placement)
-        progress_bar.update()
+            if len(vertices) > 1:
+                resources = \
+                    resource_tracker.allocate_constrained_group_resources([
+                        (vert.resources_required, vert.constraints)
+                        for vert in vertices
+                    ])
+                for (x, y, p, _, _), vert in zip(resources, vertices):
+                    placement = Placement(vert, x, y, p)
+                    placements.add_placement(placement)
+                    all_vertices_placed.add(vert)
+            else:
+                (x, y, p, _, _) = resource_tracker.\
+                    allocate_constrained_resources(
+                        vertex.resources_required, vertex.constraints)
+                placement = Placement(vertex, x, y, p)
+                placements.add_placement(placement)
+                all_vertices_placed.add(vertex)
 
     def _sort_vertices_for_one_to_one_connection(
-            self, machine_graph):
+            self, machine_graph, same_chip_vertex_groups):
         """
 
         :param machine_graph: the graph to place
@@ -117,10 +140,16 @@ class OneToOnePlacer(RadialPlacer):
             if vertex not in found_list:
                 connected_vertices = self._find_one_to_one_vertices(
                     vertex, machine_graph)
-                new_list = [
-                    v for v in connected_vertices if v not in found_list]
+                new_list = {
+                    v for v in connected_vertices if v not in found_list}
+                same_chip_vertices = {
+                    v for vert in new_list
+                    for group in same_chip_vertex_groups.get(vert)
+                    for v in group if v not in new_list}
+                new_list.update(same_chip_vertices)
+
                 sorted_vertices.append(new_list)
-                found_list.update(set(new_list))
+                found_list.update(new_list)
 
         # locate vertices which have no output or input, and add them for
         # placement

--- a/pacman/operations/placer_algorithms/one_to_one_placer.py
+++ b/pacman/operations/placer_algorithms/one_to_one_placer.py
@@ -142,10 +142,11 @@ class OneToOnePlacer(RadialPlacer):
                     vertex, machine_graph)
                 new_list = {
                     v for v in connected_vertices if v not in found_list}
+
                 same_chip_vertices = {
                     v for vert in new_list
-                    for group in same_chip_vertex_groups.get(vert)
-                    for v in group if v not in new_list}
+                    for v in same_chip_vertex_groups[vert]
+                    if v not in new_list}
                 new_list.update(same_chip_vertices)
 
                 sorted_vertices.append(new_list)

--- a/pacman/operations/placer_algorithms/radial_placer.py
+++ b/pacman/operations/placer_algorithms/radial_placer.py
@@ -26,8 +26,6 @@ class RadialPlacer(object):
         machine choosing chips radiating in a circle from the boot chip
     """
 
-    __slots__ = []
-
     def __call__(self, machine_graph, machine):
 
         # check that the algorithm can handle the constraints
@@ -42,8 +40,15 @@ class RadialPlacer(object):
         progress_bar = ProgressBar(len(vertices), "Placing graph vertices")
         resource_tracker = ResourceTracker(
             machine, self._generate_radial_chips(machine))
+        vertices_on_same_chip = placer_algorithm_utilities\
+            .get_same_chip_vertex_groups(machine_graph.vertices)
+        all_vertices_placed = set()
         for vertex in vertices:
-            self._place_vertex(vertex, resource_tracker, machine, placements)
+            if vertex not in all_vertices_placed:
+                vertices_placed = self._place_vertex(
+                    vertex, resource_tracker, machine, placements,
+                    vertices_on_same_chip)
+                all_vertices_placed.update(vertices_placed)
             progress_bar.update()
         progress_bar.end()
         return placements
@@ -56,11 +61,15 @@ class RadialPlacer(object):
         ResourceTracker.check_constraints(
             vertices, additional_placement_constraints=placement_constraints)
 
-    def _place_vertex(self, vertex, resource_tracker, machine, placements):
+    def _place_vertex(
+            self, vertex, resource_tracker, machine, placements,
+            vertices_on_same_chip):
+
+        vertices = vertices_on_same_chip[vertex]
 
         # Check for the radial placement constraint
         radial_constraints = utility_calls.locate_constraints_of_type(
-            [vertex], PlacerRadialPlacementFromChipConstraint)
+            vertices, PlacerRadialPlacementFromChipConstraint)
         start_x = None
         start_y = None
         for constraint in radial_constraints:
@@ -74,14 +83,25 @@ class RadialPlacer(object):
                 raise PacmanPlaceException("Non-matching constraints")
         chips = None
         if start_x is not None and start_y is not None:
-            chips = self._generate_radial_chips(machine, resource_tracker,
-                                                start_x, start_y)
+            chips = self._generate_radial_chips(
+                machine, resource_tracker, start_x, start_y)
 
-        # Create and store a new placement
-        (x, y, p, _, _) = resource_tracker.allocate_constrained_resources(
-            vertex.resources_required, vertex.constraints, chips)
-        placement = Placement(vertex, x, y, p)
-        placements.add_placement(placement)
+        if len(vertices) > 1:
+            assigned_values = \
+                resource_tracker.allocate_constrained_group_resources([
+                    (vert.resources_required, vert.constraints)
+                    for vert in vertices
+                ])
+            for (x, y, p, _, _), vert in zip(assigned_values, vertices):
+                placement = Placement(vert, x, y, p)
+                placements.add_placement(placement)
+        else:
+            (x, y, p, _, _) = resource_tracker.allocate_constrained_resources(
+                vertex.resources_required, vertex.constraints, chips)
+            placement = Placement(vertex, x, y, p)
+            placements.add_placement(placement)
+
+        return vertices
 
     @staticmethod
     def _generate_radial_chips(

--- a/pacman/operations/placer_algorithms/radial_placer.py
+++ b/pacman/operations/placer_algorithms/radial_placer.py
@@ -79,7 +79,7 @@ class RadialPlacer(object):
 
         # Create and store a new placement
         (x, y, p, _, _) = resource_tracker.allocate_constrained_resources(
-            vertex.resources_required, vertex, None, chips)
+            vertex.resources_required, vertex.constraints, chips)
         placement = Placement(vertex, x, y, p)
         placements.add_placement(placement)
 

--- a/pacman/operations/placer_algorithms/radial_placer.py
+++ b/pacman/operations/placer_algorithms/radial_placer.py
@@ -3,6 +3,9 @@
 from pacman.model.constraints.placer_constraints.\
     placer_radial_placement_from_chip_constraint \
     import PlacerRadialPlacementFromChipConstraint
+from pacman.model.constraints.placer_constraints\
+    .placer_same_chip_as_constraint\
+    import PlacerSameChipAsConstraint
 from pacman.utilities.algorithm_utilities import placer_algorithm_utilities
 from pacman.model.placements.placements import Placements
 from pacman.model.placements.placement import Placement
@@ -55,7 +58,9 @@ class RadialPlacer(object):
 
     def _check_constraints(
             self, vertices, additional_placement_constraints=None):
-        placement_constraints = {PlacerRadialPlacementFromChipConstraint}
+        placement_constraints = {
+            PlacerRadialPlacementFromChipConstraint, PlacerSameChipAsConstraint
+        }
         if additional_placement_constraints is not None:
             placement_constraints.update(additional_placement_constraints)
         ResourceTracker.check_constraints(

--- a/pacman/operations/rig_algorithms/rig_place.py
+++ b/pacman/operations/rig_algorithms/rig_place.py
@@ -1,0 +1,48 @@
+from pacman.utilities import rig_converters
+from rig.place_and_route.place.sa import place
+from rig.place_and_route.allocate.greedy import allocate
+from spinn_machine.utilities.progress_bar import ProgressBar
+
+
+class RigPlace(object):
+    """ Performs placement and routing using rig algorithms; both are done\
+        to save conversion time
+    """
+
+    __slots__ = []
+
+    def __call__(self, machine_graph, machine):
+        progress_bar = ProgressBar(7, "Placing")
+
+        vertices_resources, nets, _ = \
+            rig_converters.convert_to_rig_graph(
+                machine_graph)
+        progress_bar.update()
+
+        rig_machine = rig_converters.convert_to_rig_machine(machine)
+        progress_bar.update()
+
+        rig_constraints = rig_converters.create_rig_machine_constraints(
+            machine)
+        progress_bar.update()
+
+        rig_constraints.extend(
+            rig_converters.create_rig_graph_constraints(
+                machine_graph, rig_machine))
+        progress_bar.update()
+
+        rig_placements = place(
+            vertices_resources, nets, rig_machine, rig_constraints)
+        progress_bar.update()
+
+        rig_allocations = allocate(
+            vertices_resources, nets, rig_machine, rig_constraints,
+            rig_placements)
+        progress_bar.update()
+
+        placements = rig_converters.convert_from_rig_placements(
+            rig_placements, rig_allocations, machine_graph)
+        progress_bar.update()
+        progress_bar.end()
+
+        return placements

--- a/pacman/operations/tag_allocator_algorithms/basic_tag_allocator.py
+++ b/pacman/operations/tag_allocator_algorithms/basic_tag_allocator.py
@@ -39,15 +39,15 @@ class BasicTagAllocator(object):
         tags = Tags()
         for placement in placements_with_tags:
             vertex = placement.vertex
+            resources = vertex.resources_required
 
             # Get the constraint details for the tags
             (board_address, ip_tags, reverse_ip_tags) = \
-                ResourceTracker.get_ip_tag_info(vertex, None)
+                ResourceTracker.get_ip_tag_info(resources, vertex.constraints)
 
             # Allocate the tags, first-come, first-served, using the
             # fixed placement of the vertex, and the required resources
             chips = [(placement.x, placement.y)]
-            resources = vertex.resources_required
             (_, _, _, returned_ip_tags, returned_reverse_ip_tags) = \
                 resource_tracker.allocate_resources(
                     resources, chips, placement.p, board_address, ip_tags,

--- a/pacman/utilities/algorithm_utilities/placer_algorithm_utilities.py
+++ b/pacman/utilities/algorithm_utilities/placer_algorithm_utilities.py
@@ -22,3 +22,64 @@ def sort_vertices_by_known_constraints(vertices):
         ConstraintOrder(PlacerBoardConstraint, 4),
         ConstraintOrder(PlacerRadialPlacementFromChipConstraint, 5)])
     return sorter.sort(vertices)
+
+
+def get_same_chip_vertex_groups(vertices):
+    """ Get a dictionary of vertex to vertex that must be placed on the same\
+        chip
+    """
+
+    # Dict of vertex to list of vertices on same chip
+    # (repeated lists expected)
+    same_chip_vertices = dict()
+
+    for vertex in vertices:
+
+        # Find all vertices that this vertex should be on the same chip as
+        same_as_vertices = list()
+        for constraint in vertex.constraints:
+            if isinstance(constraint, PlacerSameChipAsConstraint):
+                same_as_vertices.append(constraint.vertex)
+
+        if len(same_as_vertices) > 0:
+
+            # Go through vertices that this vertex should be on the same
+            # chip as
+            for same_as_vertex in same_as_vertices:
+
+                if (same_as_vertex not in same_chip_vertices and
+                        vertex not in same_chip_vertices):
+
+                    # Neither vertex has been seen, so add both to a new group
+                    group = [vertex, same_as_vertex]
+                    same_chip_vertices[vertex] = group
+                    same_chip_vertices[same_as_vertex] = group
+
+                elif vertex in same_chip_vertices:
+
+                    # The current vertex has been seen elsewhere, so add the
+                    # new vertex to the existing group
+                    group = same_chip_vertices[vertex]
+                    group.append(same_as_vertex)
+                    same_chip_vertices[same_as_vertex] = group
+
+                elif same_as_vertex in same_chip_vertices:
+
+                    # The other vertex has been seen elsewhere, so add this
+                    # vertex to the existing group
+                    group = same_chip_vertices[same_chip_vertices]
+                    group.append(vertex)
+                    same_chip_vertices[vertex] = group
+
+                else:
+
+                    # Both vertices have been seen elsewhere, so merge
+                    # their groups
+                    group_1 = same_chip_vertices[vertex]
+                    group_2 = same_chip_vertices[same_as_vertex]
+                    if group_1 != group_2:
+                        group_1.extend(group_2)
+                        for vert in group_2:
+                            same_chip_vertices[vert] = group_1
+
+        return same_chip_vertices

--- a/pacman/utilities/algorithm_utilities/placer_algorithm_utilities.py
+++ b/pacman/utilities/algorithm_utilities/placer_algorithm_utilities.py
@@ -67,7 +67,7 @@ def get_same_chip_vertex_groups(vertices):
 
                     # The other vertex has been seen elsewhere, so add this
                     # vertex to the existing group
-                    group = same_chip_vertices[same_chip_vertices]
+                    group = same_chip_vertices[same_as_vertex]
                     group.append(vertex)
                     same_chip_vertices[vertex] = group
 
@@ -81,5 +81,7 @@ def get_same_chip_vertex_groups(vertices):
                         group_1.extend(group_2)
                         for vert in group_2:
                             same_chip_vertices[vert] = group_1
+        else:
+            same_chip_vertices[vertex] = [vertex]
 
-        return same_chip_vertices
+    return same_chip_vertices

--- a/pacman/utilities/algorithm_utilities/placer_algorithm_utilities.py
+++ b/pacman/utilities/algorithm_utilities/placer_algorithm_utilities.py
@@ -81,7 +81,6 @@ def get_same_chip_vertex_groups(vertices):
                     group.add(vertex)
                     same_chip_vertices[vertex] = group
 
-
         else:
             same_chip_vertices[vertex] = {vertex}
 

--- a/pacman/utilities/algorithm_utilities/placer_algorithm_utilities.py
+++ b/pacman/utilities/algorithm_utilities/placer_algorithm_utilities.py
@@ -51,16 +51,26 @@ def get_same_chip_vertex_groups(vertices):
                         vertex not in same_chip_vertices):
 
                     # Neither vertex has been seen, so add both to a new group
-                    group = [vertex, same_as_vertex]
+                    group = {vertex, same_as_vertex}
                     same_chip_vertices[vertex] = group
                     same_chip_vertices[same_as_vertex] = group
+                elif (same_as_vertex in same_chip_vertices and
+                        vertex in same_chip_vertices):
+
+                    # Both vertices have been seen elsewhere, so merge
+                    # their groups
+                    group_1 = same_chip_vertices[vertex]
+                    group_2 = same_chip_vertices[same_as_vertex]
+                    group_1.update(group_2)
+                    for vert in group_1:
+                        same_chip_vertices[vert] = group_1
 
                 elif vertex in same_chip_vertices:
 
                     # The current vertex has been seen elsewhere, so add the
                     # new vertex to the existing group
                     group = same_chip_vertices[vertex]
-                    group.append(same_as_vertex)
+                    group.add(same_as_vertex)
                     same_chip_vertices[same_as_vertex] = group
 
                 elif same_as_vertex in same_chip_vertices:
@@ -68,20 +78,11 @@ def get_same_chip_vertex_groups(vertices):
                     # The other vertex has been seen elsewhere, so add this
                     # vertex to the existing group
                     group = same_chip_vertices[same_as_vertex]
-                    group.append(vertex)
+                    group.add(vertex)
                     same_chip_vertices[vertex] = group
 
-                else:
 
-                    # Both vertices have been seen elsewhere, so merge
-                    # their groups
-                    group_1 = same_chip_vertices[vertex]
-                    group_2 = same_chip_vertices[same_as_vertex]
-                    if group_1 != group_2:
-                        group_1.extend(group_2)
-                        for vert in group_2:
-                            same_chip_vertices[vert] = group_1
         else:
-            same_chip_vertices[vertex] = [vertex]
+            same_chip_vertices[vertex] = {vertex}
 
     return same_chip_vertices

--- a/pacman/utilities/algorithm_utilities/placer_algorithm_utilities.py
+++ b/pacman/utilities/algorithm_utilities/placer_algorithm_utilities.py
@@ -35,49 +35,52 @@ def get_same_chip_vertex_groups(vertices):
 
     for vertex in vertices:
 
-        # Find all vertices that this vertex should be on the same chip as
-        same_as_vertices = list()
+        # Find all vertices that have a same chip constraint associated with
+        #  this vertex
+        same_chip_as_vertices = list()
         for constraint in vertex.constraints:
             if isinstance(constraint, PlacerSameChipAsConstraint):
-                same_as_vertices.append(constraint.vertex)
+                same_chip_as_vertices.append(constraint.vertex)
 
-        if len(same_as_vertices) > 0:
+        if len(same_chip_as_vertices) > 0:
 
-            # Go through vertices that this vertex should be on the same
-            # chip as
-            for same_as_vertex in same_as_vertices:
-
-                if (same_as_vertex not in same_chip_vertices and
+            # Go through all the verts that want to be on the same chip as
+            # the top level vert
+            for same_as_chip_vertex in same_chip_as_vertices:
+                
+                # Neither vertex has been seen
+                if (same_as_chip_vertex not in same_chip_vertices and
                         vertex not in same_chip_vertices):
-
-                    # Neither vertex has been seen, so add both to a new group
-                    group = {vertex, same_as_vertex}
+                
+                    # add both to a new group
+                    group = {vertex, same_as_chip_vertex}
                     same_chip_vertices[vertex] = group
-                    same_chip_vertices[same_as_vertex] = group
-                elif (same_as_vertex in same_chip_vertices and
+                    same_chip_vertices[same_as_chip_vertex] = group
+                    
+                # Both vertices have been seen elsewhere
+                elif (same_as_chip_vertex in same_chip_vertices and
                         vertex in same_chip_vertices):
 
-                    # Both vertices have been seen elsewhere, so merge
-                    # their groups
+                    # merge their groups
                     group_1 = same_chip_vertices[vertex]
-                    group_2 = same_chip_vertices[same_as_vertex]
+                    group_2 = same_chip_vertices[same_as_chip_vertex]
                     group_1.update(group_2)
                     for vert in group_1:
                         same_chip_vertices[vert] = group_1
 
+                # The current vertex has been seen elsewhere
                 elif vertex in same_chip_vertices:
 
-                    # The current vertex has been seen elsewhere, so add the
-                    # new vertex to the existing group
+                    # add the new vertex to the existing group
                     group = same_chip_vertices[vertex]
-                    group.add(same_as_vertex)
-                    same_chip_vertices[same_as_vertex] = group
+                    group.add(same_as_chip_vertex)
+                    same_chip_vertices[same_as_chip_vertex] = group
 
-                elif same_as_vertex in same_chip_vertices:
+                # The other vertex has been seen elsewhere
+                elif same_as_chip_vertex in same_chip_vertices:
 
-                    # The other vertex has been seen elsewhere, so add this
-                    # vertex to the existing group
-                    group = same_chip_vertices[same_as_vertex]
+                    #  so add this vertex to the existing group
+                    group = same_chip_vertices[same_as_chip_vertex]
                     group.add(vertex)
                     same_chip_vertices[vertex] = group
 

--- a/pacman/utilities/utility_objs/resource_tracker.py
+++ b/pacman/utilities/utility_objs/resource_tracker.py
@@ -677,7 +677,7 @@ class ResourceTracker(object):
         else:
             self._sdram_tracker[key] += resources.sdram.get_value()
 
-    def _allocate_core(self, chip, key, processor_id, resources):
+    def _allocate_core(self, chip, key, processor_id):
         """ Allocates a core on the given chip
 
         :param chip: The chip to allocate the resources of
@@ -992,8 +992,7 @@ class ResourceTracker(object):
                     for resources, proc_id, ip_tags, reverse_ip_tags in zip(
                             group_resources, processor_ids, group_ip_tags,
                             group_reverse_ip_tags):
-                        processor_id = self._allocate_core(
-                            chip, key, proc_id, resources)
+                        processor_id = self._allocate_core(chip, key, proc_id)
                         self._allocate_sdram(chip, key, resources)
                         ip_tags_allocated = self._allocate_ip_tags(
                             board_address, ip_tags)
@@ -1056,8 +1055,7 @@ class ResourceTracker(object):
                                                 ip_tags) and
                     self._are_reverse_ip_tags_available(chip, board_address,
                                                         reverse_ip_tags)):
-                processor_id = self._allocate_core(
-                    chip, key, processor_id, resources)
+                processor_id = self._allocate_core(chip, key, processor_id)
                 self._allocate_sdram(chip, key, resources)
                 ip_tags_allocated = self._allocate_ip_tags(
                     board_address, ip_tags)


### PR DESCRIPTION
Adds support for specifying that a group of Machine vertices must be placed on the same chip.  Currently this is supported by the RadialPlacer and the OneToOnePlacer, as well as RigPlace.