### PR TITLE
Fix board addresses

### DIFF
--- a/integration_tests/test_tags_board_addresses.py
+++ b/integration_tests/test_tags_board_addresses.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import unittest
 from collections import defaultdict
 from spinn_machine.virtual_machine import VirtualMachine

--- a/integration_tests/test_tags_board_addresses.py
+++ b/integration_tests/test_tags_board_addresses.py
@@ -64,14 +64,14 @@ class TestTagsBoardAddresses(unittest.TestCase):
             SimpleMachineVertex(
                 ResourceContainer(iptags=[IPtagResource(
                     "127.0.0.1", port=tag, strip_sdp=True)]),
-                label="Eth Vertex {}".format(proc))
+                label="Ethernet Vertex {}".format(proc))
             for tag in eth_chip.tag_ids
         ]
         eth2_vertices = [
             SimpleMachineVertex(
                 ResourceContainer(iptags=[IPtagResource(
                     "127.0.0.1", port=10000 + tag, strip_sdp=True)]),
-                label="Eth 2 Vertex {}".format(proc))
+                label="Ethernet 2 Vertex {}".format(proc))
             for tag in range(n_extra_vertices)
         ]
         placements = Placements([

--- a/integration_tests/test_tags_board_addresses.py
+++ b/integration_tests/test_tags_board_addresses.py
@@ -1,0 +1,103 @@
+import unittest
+from collections import defaultdict
+from spinn_machine.virtual_machine import VirtualMachine
+from pacman.model.placements.placements import Placements
+from pacman.model.placements.placement import Placement
+from pacman.model.graphs.machine.impl.simple_machine_vertex \
+    import SimpleMachineVertex
+from pacman.model.resources.resource_container import ResourceContainer
+from pacman.model.resources.iptag_resource import IPtagResource
+from pacman.operations.tag_allocator_algorithms.basic_tag_allocator\
+    import BasicTagAllocator
+
+
+class TestTagsBoardAddresses(unittest.TestCase):
+    """ Tests for ip tags on different boards
+    """
+
+    def test_ip_tags(self):
+        machine = VirtualMachine(12, 12, with_wrap_arounds=True)
+        eth_chips = machine.ethernet_connected_chips
+        vertices = [
+            SimpleMachineVertex(
+                ResourceContainer(iptags=[IPtagResource(
+                    "127.0.0.1", port=None, strip_sdp=True)]),
+                label="Vertex {}".format(i))
+            for i in range(len(eth_chips))
+        ]
+        print "Created {} vertices".format(len(vertices))
+        placements = Placements([
+            Placement(vertex, chip.x, chip.y, 1)
+            for vertex, chip in zip(vertices, eth_chips)
+        ])
+        allocator = BasicTagAllocator()
+        _, _, tags = allocator(machine, placements)
+
+        for vertex, chip in zip(vertices, eth_chips):
+            iptags = tags.get_ip_tags_for_vertex(vertex)
+            self.assertEqual(
+                len(iptags), 1, "Incorrect number of tags assigned")
+            self.assertEqual(
+                iptags[0].destination_x, chip.x,
+                "Destination of tag incorrect")
+            self.assertEqual(
+                iptags[0].destination_y, chip.y,
+                "Destination of tag incorrect")
+            placement = placements.get_placement_of_vertex(vertex)
+            print placement, "has tag", iptags[0]
+
+    def test_too_many_ip_tags_for_1_board(self):
+        n_extra_vertices = 3
+        machine = VirtualMachine(12, 12, with_wrap_arounds=True)
+        eth_chips = machine.ethernet_connected_chips
+        eth_chip = eth_chips[0]
+        eth_chip_2 = machine.get_chip_at(eth_chip.x + 1, eth_chip.y + 1)
+        eth_procs = [
+            proc.processor_id for proc in eth_chip.processors
+            if not proc.is_monitor
+        ]
+        eth2_procs = [
+            proc.processor_id for proc in eth_chip_2.processors
+            if not proc.is_monitor
+        ]
+        eth_vertices = [
+            SimpleMachineVertex(
+                ResourceContainer(iptags=[IPtagResource(
+                    "127.0.0.1", port=tag, strip_sdp=True)]),
+                label="Eth Vertex {}".format(proc))
+            for tag in eth_chip.tag_ids
+        ]
+        eth2_vertices = [
+            SimpleMachineVertex(
+                ResourceContainer(iptags=[IPtagResource(
+                    "127.0.0.1", port=10000 + tag, strip_sdp=True)]),
+                label="Eth 2 Vertex {}".format(proc))
+            for tag in range(n_extra_vertices)
+        ]
+        placements = Placements([
+            Placement(vertex, eth_chip.x, eth_chip.y, proc)
+            for proc, vertex in zip(eth_procs, eth_vertices)
+        ])
+        placements.add_placements([
+            Placement(vertex, eth_chip_2.x, eth_chip_2.y, proc)
+            for proc, vertex in zip(eth2_procs, eth2_vertices)
+        ])
+        allocator = BasicTagAllocator()
+        _, _, tags = allocator(machine, placements)
+
+        tags_by_board = defaultdict(set)
+        for vertices in (eth_vertices, eth2_vertices):
+            for vertex in vertices:
+                iptags = tags.get_ip_tags_for_vertex(vertex)
+                self.assertEqual(
+                    len(iptags), 1, "Incorrect number of tags assigned")
+                placement = placements.get_placement_of_vertex(vertex)
+                print placement, "has tag", iptags[0]
+                self.assertFalse(
+                    iptags[0].tag in tags_by_board[iptags[0].board_address],
+                    "Tag used more than once")
+                tags_by_board[iptags[0].board_address].add(iptags[0].tag)
+
+        self.assertEqual(
+            len(tags_by_board[eth_chip.ip_address]), len(eth_chip.tag_ids),
+            "Wrong number of tags assigned to first Ethernet")

--- a/pacman/operations/tag_allocator_algorithms/basic_tag_allocator.py
+++ b/pacman/operations/tag_allocator_algorithms/basic_tag_allocator.py
@@ -64,10 +64,12 @@ class BasicTagAllocator(object):
 
             # Put the allocated ip tag information into the tag object
             if returned_ip_tags is not None:
-                for (tag_constraint, (board_address, tag)) in zip(
-                        ip_tags, returned_ip_tags):
+                for (tag_constraint,
+                        (board_address, tag, dest_x, dest_y)) in zip(
+                            ip_tags, returned_ip_tags):
                     ip_tag = IPTag(
-                        board_address=board_address, tag=tag,
+                        board_address=board_address, destination_x=dest_x,
+                        destination_y=dest_y, tag=tag,
                         ip_address=tag_constraint.ip_address,
                         port=tag_constraint.port,
                         strip_sdp=tag_constraint.strip_sdp,

--- a/pacman/utilities/utility_objs/resource_tracker.py
+++ b/pacman/utilities/utility_objs/resource_tracker.py
@@ -495,10 +495,12 @@ class ResourceTracker(object):
         return n_cores
 
     def _get_matching_ip_tag(
-            self, board_address, tag, ip_address, port, strip_sdp,
+            self, chip, board_address, tag, ip_address, port, strip_sdp,
             traffic_identifier):
         """ Attempt to locate a matching tag for the given details
 
+        :param chip: The chip which is the source of the data for the tag
+        :type chip: :py:class:`spinn_machine.chip.Chip` or None
         :param board_address: the board address to locate the chip on
         :type board_address: str or None
         :param tag: the tag id to locate
@@ -515,21 +517,57 @@ class ResourceTracker(object):
         :return: A board address, tag id, and port or None, None, None if none
         :rtype: tuple of (str, int, (int or None)) or (None, None, None)
         """
+
+        # If there is no tag for the given ip address - traffic identifier
+        # combination, return
         if ((ip_address, traffic_identifier) not in
                 self._ip_tags_address_traffic):
             return None, None, None
+
+        # If no board address is specified, try to allow use of the closest
+        # board
+        eth_chip = None
+        if board_address is None and chip is not None:
+            eth_chip = self._machine.get_chip_at(
+                chip.nearest_ethernet_x, chip.nearest_ethernet_y)
+
+        # Scan the existing allocated tags and see if any match the details
+        found_board = None
+        found_tag = None
+        found_port = None
         existing_tags = self._ip_tags_address_traffic[
             (ip_address, traffic_identifier)]
         for (other_board_address, other_tag) in existing_tags:
-            (other_stripe_sdp, other_port) = self._ip_tags_strip_sdp_and_port[
+            (other_strip_sdp, other_port) = self._ip_tags_strip_sdp_and_port[
                 (other_board_address, other_tag)]
             if (utility_calls.is_equal_or_None(
                     other_board_address, board_address) and
                     utility_calls.is_equal_or_None(other_tag, tag) and
-                    other_stripe_sdp == strip_sdp and
+                    other_strip_sdp == strip_sdp and
                     utility_calls.is_equal_or_None(other_port, port)):
-                return other_board_address, other_tag, other_port
-        return None, None, None
+
+                # If the existing tag is on the same board, return immediately
+                if (eth_chip is not None and
+                        other_board_address == eth_chip.ip_address):
+                    return other_board_address, other_tag, other_port
+
+                # Otherwise store the tag for possible later use
+                found_board = other_board_address
+                found_tag = other_tag
+                found_port = other_port
+
+        # If we got here, we didn't find an existing tag on the same board
+        # so check if the tag *could* be assigned to the current board
+        if eth_chip is not None:
+            if (eth_chip.ip_address in self._boards_with_ip_tags and
+                    (tag is None or tag in self._boards_with_ip_tags[
+                        eth_chip.ip_address])):
+
+                # If the tag is available, allow it to be used
+                return None, None, None
+
+        # Otherwise, return any matching existing tag
+        return found_board, found_tag, found_port
 
     def _is_tag_available(self, board_address, tag):
         """ Check if a tag is available given the constraints
@@ -577,7 +615,7 @@ class ResourceTracker(object):
 
         # If equivalent traffic is being used by another ip tag, re-use it
         (b_address, _, _) = self._get_matching_ip_tag(
-            board_address, tag, ip_address, port, strip_sdp,
+            None, board_address, tag, ip_address, port, strip_sdp,
             traffic_identifier)
         if b_address is not None:
             return True
@@ -585,12 +623,10 @@ class ResourceTracker(object):
         # Otherwise determine if another tag is available
         return self._is_tag_available(board_address, tag)
 
-    def _are_ip_tags_available(self, chip, board_address, ip_tags):
+    def _are_ip_tags_available(self, board_address, ip_tags):
         """ Check if the set of tags are available using the given chip,\
             given the constraints
 
-        :param chip: the chip to check
-        :type chip: :py:class:`spinn_machine.chip.Chip`
         :param board_address: the board to allocate ip tags on
         :type board_address: str or None
         :param ip_tags: The ip tag resource
@@ -602,18 +638,6 @@ class ResourceTracker(object):
         # If there are no tags to assign, declare that they are available
         if ip_tags is None or len(ip_tags) == 0:
             return True
-
-        # If there is a fixed board address and the chip is not on the board
-        # the tags are not available
-        if (board_address is not None and (chip.x, chip.y)
-                not in self._ethernet_area_codes[board_address]):
-            return False
-
-        # If board_address is None, set it to the chip board address
-        if board_address is None:
-            eth_chip = self._machine.get_chip_at(
-                chip.nearest_ethernet_x, chip.nearest_ethernet_y)
-            board_address = eth_chip.ip_address
 
         # Check if each of the tags is available
         for ip_tag in ip_tags:
@@ -659,11 +683,9 @@ class ResourceTracker(object):
         return port_available
 
     def _are_reverse_ip_tags_available(
-            self, chip, board_address, reverse_ip_tags):
+            self, board_address, reverse_ip_tags):
         """ Check if this chip can be used given the reverse ip tag resources
 
-        :param chip: the chip to check
-        :type chip: :py:class:`spinn_machine.chip.Chip`
         :param board_address: the board to allocate ip tags on
         :type board_address: str or None
         :param reverse_ip_tags: The reverse ip tag resource to be met
@@ -675,18 +697,6 @@ class ResourceTracker(object):
         # If there are no tags, declare they are available
         if reverse_ip_tags is None or len(reverse_ip_tags) == 0:
             return True
-
-        # If there is a fixed board address and the chip is not on the board
-        # the tags are not available
-        if (board_address is not None and not (chip.x, chip.y)
-                in self._ethernet_area_codes[board_address]):
-            return False
-
-        # If board_address is None, set it to the chip board address
-        if board_address is None:
-            eth_chip = self._machine.get_chip_at(
-                chip.nearest_ethernet_x, chip.nearest_ethernet_y)
-            board_address = eth_chip.ip_address
 
         for ip_tag in reverse_ip_tags:
             if not self._is_reverse_ip_tag_available(
@@ -739,9 +749,11 @@ class ResourceTracker(object):
             self._chips_available.remove(key)
         return processor_id
 
-    def _allocate_tag(self, board_address, tag):
+    def _allocate_tag(self, chip, board_address, tag):
         """ Allocate a tag given the constraints
 
+        :param chip: The chip containing the source of data for this tag
+        :type chip: :py:class:`spinn_machine.chip.Chip`
         :param board_address: the board address to allocate to
         :type board_address: str or None
         :param tag: the tag id to allocate on this board address
@@ -749,6 +761,21 @@ class ResourceTracker(object):
         :return: a tuple of (board_address and tag)
         :rtype: (str, int)
         """
+
+        # First try to find a tag on the board closest to the chip
+        if board_address is None:
+            eth_chip = self._machine.get_chip_at(
+                chip.nearest_ethernet_x, chip.nearest_ethernet_y)
+            if eth_chip is not None:
+
+                # Having found the board address, it can only be used if a
+                # tag is available
+                if (eth_chip.ip_address in self._boards_with_ip_tags and
+                        (tag is None or tag in self._boards_with_ip_tags[
+                            eth_chip.ip_address])):
+
+                    board_address = eth_chip.ip_address
+
         if board_address is None and tag is not None:
             for b_address in self._boards_with_ip_tags:
                 if (b_address not in self._tags_by_board or
@@ -788,18 +815,13 @@ class ResourceTracker(object):
         if ip_tags is None or len(ip_tags) == 0:
             return None
 
-        if board_address is None:
-            eth_chip = self._machine.get_chip_at(
-                chip.nearest_ethernet_x, chip.nearest_ethernet_y)
-            board_address = eth_chip.ip_address
-
         allocations = list()
         for ip_tag in ip_tags:
 
             # Find a tag that matches the one required
             (b_address, a_tag, a_port) = self._get_matching_ip_tag(
-                board_address, ip_tag.tag, ip_tag.ip_address, ip_tag.port,
-                ip_tag.strip_sdp, ip_tag.traffic_identifier)
+                chip, board_address, ip_tag.tag, ip_tag.ip_address,
+                ip_tag.port, ip_tag.strip_sdp, ip_tag.traffic_identifier)
 
             if b_address is not None:
 
@@ -819,7 +841,7 @@ class ResourceTracker(object):
 
                 # Allocate an ip tag
                 (board_address, tag) = self._allocate_tag(
-                    board_address, ip_tag.tag)
+                    chip, board_address, ip_tag.tag)
                 tag_key = (board_address, tag)
                 existing_tags = self._ip_tags_address_traffic[
                     (ip_tag.ip_address, ip_tag.traffic_identifier)]
@@ -833,7 +855,10 @@ class ResourceTracker(object):
                 # in case an deallocation is requested
                 self._n_ip_tag_allocations[tag_key] = 1
 
-                allocations.append((board_address, tag))
+                # Get the chip with the Ethernet
+                (e_chip_x, e_chip_y) = self._ethernet_chips[board_address]
+
+                allocations.append((board_address, tag, e_chip_x, e_chip_y))
         if len(allocations) == 0:
             return None
         return allocations
@@ -854,16 +879,11 @@ class ResourceTracker(object):
         if reverse_ip_tags is None or len(reverse_ip_tags) == 0:
             return None
 
-        if board_address is None:
-            eth_chip = self._machine.get_chip_at(
-                chip.nearest_ethernet_x, chip.nearest_ethernet_y)
-            board_address = eth_chip.ip_address
-
         allocations = list()
         for reverse_ip_tag in reverse_ip_tags:
 
             (_, tag) = self._allocate_tag(
-                board_address, reverse_ip_tag.tag)
+                chip, board_address, reverse_ip_tag.tag)
             allocations.append((board_address, tag))
             if reverse_ip_tag.port is not None:
                 self._reverse_ip_tag_listen_port.add(
@@ -1024,9 +1044,9 @@ class ResourceTracker(object):
                     if (not self._is_core_available(
                             chip, key, processor_id) or
                             not self._are_ip_tags_available(
-                                chip, board_address, ip_tags) or
+                                board_address, ip_tags) or
                             not self._are_reverse_ip_tags_available(
-                                chip, board_address, reverse_ip_tags)):
+                                board_address, reverse_ip_tags)):
                         is_available = False
                         break
 
@@ -1097,9 +1117,8 @@ class ResourceTracker(object):
 
             if (self._is_core_available(chip, key, processor_id) and
                     self._is_sdram_available(chip, key, resources) and
-                    self._are_ip_tags_available(chip, board_address,
-                                                ip_tags) and
-                    self._are_reverse_ip_tags_available(chip, board_address,
+                    self._are_ip_tags_available(board_address, ip_tags) and
+                    self._are_reverse_ip_tags_available(board_address,
                                                         reverse_ip_tags)):
                 processor_id = self._allocate_core(chip, key, processor_id)
                 self._allocate_sdram(chip, key, resources)
@@ -1213,9 +1232,9 @@ class ResourceTracker(object):
             chip = self._machine.get_chip_at(chip_x, chip_y)
             sdram_available = self._sdram_available(chip, key)
             ip_tags_available = self._are_ip_tags_available(
-                chip, board_address, ip_tags)
+                board_address, ip_tags)
             reverse_ip_tags_available = self._are_reverse_ip_tags_available(
-                chip, board_address, reverse_ip_tags)
+                board_address, reverse_ip_tags)
 
             if (sdram_available > max_sdram_available and
                     ip_tags_available and reverse_ip_tags_available):
@@ -1264,7 +1283,7 @@ class ResourceTracker(object):
 
         # Deallocate the ip tags
         if ip_tags is not None:
-            for (board_address, tag) in ip_tags:
+            for (board_address, tag, _, _) in ip_tags:
                 self._boards_with_ip_tags.add(board_address)
                 tag_key = (board_address, tag)
                 self._n_ip_tag_allocations[tag_key] -= 1

--- a/pacman/utilities/utility_objs/resource_tracker.py
+++ b/pacman/utilities/utility_objs/resource_tracker.py
@@ -885,7 +885,7 @@ class ResourceTracker(object):
         allocations = list()
         for reverse_ip_tag in reverse_ip_tags:
 
-            (_, tag) = self._allocate_tag(
+            (board_address, tag) = self._allocate_tag(
                 chip, board_address, reverse_ip_tag.tag)
             allocations.append((board_address, tag))
             if reverse_ip_tag.port is not None:

--- a/pacman/utilities/utility_objs/resource_tracker.py
+++ b/pacman/utilities/utility_objs/resource_tracker.py
@@ -825,9 +825,12 @@ class ResourceTracker(object):
 
             if b_address is not None:
 
+                # Get the chip with the Ethernet
+                (e_chip_x, e_chip_y) = self._ethernet_chips[b_address]
+
                 # If there is already an allocation that matches the current
                 # tag, return this as the allocated tag
-                allocations.append((b_address, a_tag))
+                allocations.append((b_address, a_tag, e_chip_x, e_chip_y))
 
                 # Add to the number of things allocated to the tag
                 self._n_ip_tag_allocations[(b_address, a_tag)] += 1
@@ -1105,7 +1108,7 @@ class ResourceTracker(object):
                     :py:class:`pacman.model.resources.reverse_iptag_resource.ReverseIPtagResource`
         :return: The x and y coordinates of the used chip, the processor_id,\
                  and the ip tag and reverse ip tag allocation tuples
-        :rtype: (int, int, int, list((int, int)), list((int, int)))
+        :rtype: (int, int, int, list((int, int, int, int)), list((int, int)))
         """
         usable_chips = self._get_usable_chips(chips, board_address,
                                               ip_tags, reverse_ip_tags)

--- a/unittests/model_tests/tag_tests/test_tag_infos_model.py
+++ b/unittests/model_tests/tag_tests/test_tag_infos_model.py
@@ -1,7 +1,7 @@
 """
 TestTagsModel
 """
-
+from __future__ import absolute_import
 # pacman imports
 from pacman.model.graphs.machine.impl.simple_machine_vertex \
     import SimpleMachineVertex

--- a/unittests/model_tests/tag_tests/test_tag_infos_model.py
+++ b/unittests/model_tests/tag_tests/test_tag_infos_model.py
@@ -34,8 +34,8 @@ class TestTagsModel(unittest.TestCase):
         """
         tag_info = Tags()
         iptag = IPTag("", 0, 0, 1, "122.2.2.2", 1, False)
-        parttiioned_vertex = SimpleMachineVertex(None, "")
-        tag_info.add_ip_tag(iptag, parttiioned_vertex)
+        machine_vertex = SimpleMachineVertex(None, "")
+        tag_info.add_ip_tag(iptag, machine_vertex)
 
     def test_adding_a_reverse_iptag(self):
         """
@@ -44,8 +44,8 @@ class TestTagsModel(unittest.TestCase):
         """
         tag_info = Tags()
         reverse_iptag = ReverseIPTag("", 1, 23, 0, 0, 1, 1)
-        parttiioned_vertex = SimpleMachineVertex(None, "")
-        tag_info.add_reverse_ip_tag(reverse_iptag, parttiioned_vertex)
+        machine_vertex = SimpleMachineVertex(None, "")
+        tag_info.add_reverse_ip_tag(reverse_iptag, machine_vertex)
 
     def test_add_iptag_then_locate_tag(self):
         """
@@ -54,10 +54,10 @@ class TestTagsModel(unittest.TestCase):
         """
         tag_info = Tags()
         iptag = IPTag("", 0, 0, 1, "122.2.2.2", 1, False)
-        parttiioned_vertex = SimpleMachineVertex(None, "")
-        tag_info.add_ip_tag(iptag, parttiioned_vertex)
+        machine_vertex = SimpleMachineVertex(None, "")
+        tag_info.add_ip_tag(iptag, machine_vertex)
 
-        gotton_tag = tag_info.get_ip_tags_for_vertex(parttiioned_vertex)
+        gotton_tag = tag_info.get_ip_tags_for_vertex(machine_vertex)
         self.assertEqual(gotton_tag[0], iptag)
 
     def test_add_iptag_then_fail_to_locate(self):
@@ -67,11 +67,11 @@ class TestTagsModel(unittest.TestCase):
         """
         tag_info = Tags()
         iptag = IPTag("", 0, 0, 1, "122.2.2.2", 1, False)
-        parttiioned_vertex = SimpleMachineVertex(None, "")
-        parttiioned_vertex_2 = SimpleMachineVertex(None, "")
-        tag_info.add_ip_tag(iptag, parttiioned_vertex)
+        machine_vertex = SimpleMachineVertex(None, "")
+        machine_vertex_2 = SimpleMachineVertex(None, "")
+        tag_info.add_ip_tag(iptag, machine_vertex)
 
-        gotton_tag = tag_info.get_ip_tags_for_vertex(parttiioned_vertex_2)
+        gotton_tag = tag_info.get_ip_tags_for_vertex(machine_vertex_2)
         self.assertEqual(gotton_tag, None)
 
     def test_add_reverse_iptag_then_locate_tag(self):
@@ -82,10 +82,10 @@ class TestTagsModel(unittest.TestCase):
         """
         tag_info = Tags()
         reverse_iptag = ReverseIPTag("", 1, 23, 0, 0, 1, 1)
-        parttiioned_vertex = SimpleMachineVertex(None, "")
-        tag_info.add_reverse_ip_tag(reverse_iptag, parttiioned_vertex)
+        machine_vertex = SimpleMachineVertex(None, "")
+        tag_info.add_reverse_ip_tag(reverse_iptag, machine_vertex)
         gotton_tag = tag_info.get_reverse_ip_tags_for_vertex(
-            parttiioned_vertex)
+            machine_vertex)
         self.assertEqual(gotton_tag[0], reverse_iptag)
 
     def test_add_reverse_iptag_then_not_locate_tag(self):
@@ -96,11 +96,11 @@ class TestTagsModel(unittest.TestCase):
         """
         tag_info = Tags()
         reverse_iptag = ReverseIPTag("", 1, 23, 0, 0, 1, 1)
-        parttiioned_vertex = SimpleMachineVertex(None, "")
-        parttiioned_vertex2 = SimpleMachineVertex(None, "")
-        tag_info.add_reverse_ip_tag(reverse_iptag, parttiioned_vertex2)
+        machine_vertex = SimpleMachineVertex(None, "")
+        machine_vertex2 = SimpleMachineVertex(None, "")
+        tag_info.add_reverse_ip_tag(reverse_iptag, machine_vertex2)
         gotton_tag = tag_info.get_reverse_ip_tags_for_vertex(
-            parttiioned_vertex)
+            machine_vertex)
         self.assertEqual(gotton_tag, None)
 
 if __name__ == '__main__':

--- a/unittests/model_tests/tag_tests/test_tag_infos_model.py
+++ b/unittests/model_tests/tag_tests/test_tag_infos_model.py
@@ -32,7 +32,7 @@ class TestTagsModel(unittest.TestCase):
         :return:
         """
         tag_info = Tags()
-        iptag = IPTag("", 1, "122.2.2.2", 1, False)
+        iptag = IPTag("", 0, 0, 1, "122.2.2.2", 1, False)
         parttiioned_vertex = SimpleMachineVertex(None, "")
         tag_info.add_ip_tag(iptag, parttiioned_vertex)
 
@@ -52,7 +52,7 @@ class TestTagsModel(unittest.TestCase):
         :return:
         """
         tag_info = Tags()
-        iptag = IPTag("", 1, "122.2.2.2", 1, False)
+        iptag = IPTag("", 0, 0, 1, "122.2.2.2", 1, False)
         parttiioned_vertex = SimpleMachineVertex(None, "")
         tag_info.add_ip_tag(iptag, parttiioned_vertex)
 
@@ -65,7 +65,7 @@ class TestTagsModel(unittest.TestCase):
         :return:
         """
         tag_info = Tags()
-        iptag = IPTag("", 1, "122.2.2.2", 1, False)
+        iptag = IPTag("", 0, 0, 1, "122.2.2.2", 1, False)
         parttiioned_vertex = SimpleMachineVertex(None, "")
         parttiioned_vertex_2 = SimpleMachineVertex(None, "")
         tag_info.add_ip_tag(iptag, parttiioned_vertex)

--- a/unittests/model_tests/tag_tests/test_tag_infos_model.py
+++ b/unittests/model_tests/tag_tests/test_tag_infos_model.py
@@ -3,14 +3,15 @@ TestTagsModel
 """
 
 # pacman imports
-from pacman.model.graphs.machine.impl.simple_machine_vertex import SimpleMachineVertex
+from pacman.model.graphs.machine.impl.simple_machine_vertex \
+    import SimpleMachineVertex
 from pacman.model.tags.tags import Tags
 
 # spinnmachine imports
 from spinn_machine.tags.iptag import IPTag
 from spinn_machine.tags.reverse_iptag import ReverseIPTag
 
-# gfeneral imports
+# general imports
 import unittest
 
 
@@ -21,14 +22,14 @@ class TestTagsModel(unittest.TestCase):
 
     def test_new_tag_info(self):
         """
-        test that creating a empty tag object wroks
+        test that creating a empty tag object works
         :return:
         """
-        tag_info = Tags()
+        Tags()
 
     def test_adding_a_iptag_to_tag_info(self):
         """
-        check that adding a tag after init works
+        check that adding a tag after initialisation works
         :return:
         """
         tag_info = Tags()
@@ -75,7 +76,7 @@ class TestTagsModel(unittest.TestCase):
 
     def test_add_reverse_iptag_then_locate_tag(self):
         """
-        check that asking for a reverse iptag for a speific machine vertex
+        check that asking for a reverse iptag for a specific machine vertex
         works
         :return:
         """
@@ -83,7 +84,8 @@ class TestTagsModel(unittest.TestCase):
         reverse_iptag = ReverseIPTag("", 1, 23, 0, 0, 1, 1)
         parttiioned_vertex = SimpleMachineVertex(None, "")
         tag_info.add_reverse_ip_tag(reverse_iptag, parttiioned_vertex)
-        gotton_tag = tag_info.get_reverse_ip_tags_for_vertex(parttiioned_vertex)
+        gotton_tag = tag_info.get_reverse_ip_tags_for_vertex(
+            parttiioned_vertex)
         self.assertEqual(gotton_tag[0], reverse_iptag)
 
     def test_add_reverse_iptag_then_not_locate_tag(self):
@@ -97,7 +99,8 @@ class TestTagsModel(unittest.TestCase):
         parttiioned_vertex = SimpleMachineVertex(None, "")
         parttiioned_vertex2 = SimpleMachineVertex(None, "")
         tag_info.add_reverse_ip_tag(reverse_iptag, parttiioned_vertex2)
-        gotton_tag = tag_info.get_reverse_ip_tags_for_vertex(parttiioned_vertex)
+        gotton_tag = tag_info.get_reverse_ip_tags_for_vertex(
+            parttiioned_vertex)
         self.assertEqual(gotton_tag, None)
 
 if __name__ == '__main__':


### PR DESCRIPTION
Changes the allocation of IP tags and Reverse IP tags:
    - Allow the allocation of a tag on any board in a set of boards
    - Prefer the allocation of a tag on the board where the item is placed
    - Updates to reflect changes in the IPTag interface

- [x] Wait for merge of SpiNNakerManchester/SpiNNMachine#27 