### PR TITLE
Fix missing ethernet ip address

### DIFF
--- a/pacman/utilities/utility_objs/resource_tracker.py
+++ b/pacman/utilities/utility_objs/resource_tracker.py
@@ -179,14 +179,18 @@ class ResourceTracker(object):
                         chip.nearest_ethernet_x, chip.nearest_ethernet_y)
                     if ethernet_connected_chip is not None:
                         ethernet_area_code = ethernet_connected_chip.ip_address
-                        if ethernet_area_code not in self._ethernet_area_codes:
-                            self._ethernet_area_codes[
-                                ethernet_area_code] = OrderedSet()
-                            self._boards_with_ip_tags.add(ethernet_area_code)
-                            self._ethernet_chips[ethernet_area_code] = (
-                                chip.nearest_ethernet_x,
-                                chip.nearest_ethernet_y)
-                        self._ethernet_area_codes[ethernet_area_code].add(key)
+                        if ethernet_area_code is not None:
+                            if (ethernet_area_code not in
+                                    self._ethernet_area_codes):
+                                self._ethernet_area_codes[
+                                    ethernet_area_code] = OrderedSet()
+                                self._boards_with_ip_tags.add(
+                                    ethernet_area_code)
+                                self._ethernet_chips[ethernet_area_code] = (
+                                    chip.nearest_ethernet_x,
+                                    chip.nearest_ethernet_y)
+                            self._ethernet_area_codes[ethernet_area_code].add(
+                                key)
 
     @staticmethod
     def check_constraints(

--- a/pacman/utilities/utility_objs/resource_tracker.py
+++ b/pacman/utilities/utility_objs/resource_tracker.py
@@ -1025,7 +1025,9 @@ class ResourceTracker(object):
             total_sdram += resources.sdram.get_value()
 
         # Find the first usable chip which fits all the group resources
+        tried_chips = list()
         for (chip_x, chip_y) in usable_chips:
+            tried_chips.append((chip_x, chip_y))
             chip = self._machine.get_chip_at(chip_x, chip_y)
             key = (chip_x, chip_y)
 
@@ -1069,7 +1071,7 @@ class ResourceTracker(object):
 
         # If no chip is available, raise an exception
         n_cores, n_chips, max_sdram, n_tags = self._available_resources(
-            usable_chips)
+            tried_chips)
         raise exceptions.PacmanValueError(
             "No resources available to allocate the given group resources"
             " within the given constraints:\n"
@@ -1110,7 +1112,9 @@ class ResourceTracker(object):
                                               ip_tags, reverse_ip_tags)
 
         # Find the first usable chip which fits the resources
+        tried_chips = list()
         for (chip_x, chip_y) in usable_chips:
+            tried_chips.append((chip_x, chip_y))
             chip = self._machine.get_chip_at(chip_x, chip_y)
             key = (chip_x, chip_y)
 
@@ -1130,7 +1134,7 @@ class ResourceTracker(object):
 
         # If no chip is available, raise an exception
         n_cores, n_chips, max_sdram, n_tags = \
-            self._available_resources(usable_chips)
+            self._available_resources(tried_chips)
         all_chips = self._get_usable_chips(None, None, None, None)
         all_n_cores, all_n_chips, all_max_sdram, all_n_tags = \
             self._available_resources(all_chips)

--- a/pacman/utilities/utility_objs/resource_tracker.py
+++ b/pacman/utilities/utility_objs/resource_tracker.py
@@ -348,8 +348,7 @@ class ResourceTracker(object):
             return chips_to_use
         elif board_address is not None:
             return self._ethernet_area_codes[board_address]
-        elif ((ip_tags is not None and len(ip_tags) > 0) or
-                (reverse_ip_tags is not None and len(reverse_ip_tags) > 0)):
+        elif (reverse_ip_tags is not None and len(reverse_ip_tags) > 0):
             return self._get_usable_ip_tag_chips()
         return self._chips_available
 


### PR DESCRIPTION
Fix a couple of bugs including:
 - Ethernet chips that are not connected cause issues
 - Fix the error message when constrained chips don't have enough resources
 - Allow allocation to all chips when ip tags are in use as these could be ok with tag sharing