### PR TITLE
supports fixed route router

### DIFF
--- a/pacman/model/graphs/common/graph_mapper.py
+++ b/pacman/model/graphs/common/graph_mapper.py
@@ -1,5 +1,6 @@
 from pacman.exceptions import PacmanValueError
 from collections import defaultdict
+from spinn_utilities.ordered_set import OrderedSet
 
 
 class GraphMapper(object):
@@ -35,8 +36,8 @@ class GraphMapper(object):
         self._application_vertex_by_machine_vertex = dict()
         self._application_edge_by_machine_edge = dict()
 
-        self._machine_vertices_by_application_vertex = defaultdict(set)
-        self._machine_edges_by_application_edge = defaultdict(set)
+        self._machine_vertices_by_application_vertex = defaultdict(OrderedSet)
+        self._machine_edges_by_application_edge = defaultdict(OrderedSet)
 
         self._index_by_machine_vertex = dict()
         self._slice_by_machine_vertex = dict()

--- a/pacman/operations/algorithms_metadata.xml
+++ b/pacman/operations/algorithms_metadata.xml
@@ -3,7 +3,7 @@
 		xsi:schemaLocation="https://github.com/SpiNNakerManchester/PACMAN
 			https://raw.githubusercontent.com/SpiNNakerManchester/PACMAN/master/pacman/operations/algorithms_metadata_schema.xsd">
     <algorithm name="FixedRouteRouter">
-        <python_module>pacman.operations.fixed_route_router</python_module>
+        <python_module>pacman.operations.fixed_route_router.fixed_route_router</python_module>
         <python_class>FixedRouteRouter</python_class>
         <input_definitions>
             <parameter>
@@ -25,7 +25,7 @@
             <param_name>destination_class</param_name>
         </required_inputs>
         <outputs>
-            <param_type>MemoryFixedRouteRouters</param_type>
+            <param_type>MemoryFixedRoutes</param_type>
         </outputs>
     </algorithm>
     <algorithm name="BasicPartitioner">

--- a/pacman/operations/placer_algorithms/one_to_one_placer.py
+++ b/pacman/operations/placer_algorithms/one_to_one_placer.py
@@ -1,4 +1,5 @@
 from spinn_utilities.progress_bar import ProgressBar
+from spinn_utilities.ordered_set import OrderedSet
 
 # pacman imports
 from pacman import exceptions
@@ -144,7 +145,7 @@ class OneToOnePlacer(RadialPlacer):
 
                 # create list for each vertex thats connected haven't already
                 #  been seen before
-                new_list = set()
+                new_list = OrderedSet()
                 for found_vertex in connected_vertices:
                     if found_vertex not in found_list:
                         new_list.add(found_vertex)


### PR DESCRIPTION
allows the extra monitor core to use the fixed routes. Is tied to the following pull requests:

 FEC, https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/pull/220
SPinnMan, https://github.com/SpiNNakerManchester/SpiNNMan/pull/98
SpinnMachine, https://github.com/SpiNNakerManchester/SpiNNMachine/pull/52
GFE https://github.com/SpiNNakerManchester/SpiNNakerGraphFrontEnd/pull/68

need to all be merged at same time.