### PR TITLE
fix harshness that fails spalloc machines

### DIFF
--- a/pacman/executor/pacman_algorithm_executor.py
+++ b/pacman/executor/pacman_algorithm_executor.py
@@ -331,16 +331,11 @@ class PACMANAlgorithmExecutor(object):
             #  3. require optional inputs)
             order = [
 
-                # Check required algorithms forcing optional inputs
-                (algorithms_to_find, False, True),
+                # Check required algorithms regardless of optional inputs
+                (algorithms_to_find, False, False),
 
                 # Check optional algorithms forcing optional inputs
                 (optionals_to_use, True, True),
-
-                # Check required algorithms without optional inputs
-                # - shouldn't need to do this, but might if an optional input
-                # is also a generated output of the same algorithm
-                (algorithms_to_find, False, False),
 
                 # Check optional algorithms without optional inputs
                 # - as above, it shouldn't be necessary but might be if an

--- a/unittests/test_pacman_algorithm_executor.py
+++ b/unittests/test_pacman_algorithm_executor.py
@@ -95,26 +95,6 @@ class Test(unittest.TestCase):
         self.assertTrue(TestNoChangesAlgorithm.called)
         self.assertTrue(TestAlgorithm3.called)
 
-    def test_optional_workflow(self):
-        """ Tests that an optional algorithm that doesn't do anything doesn't
-            get called
-        """
-        TestAlgorithm.called = False
-        TestNoChangesAlgorithm.called = False
-        TestAlgorithm3.called = False
-        inputs = {"TestType1": "TestType1"}
-        executor = PACMANAlgorithmExecutor(
-            algorithms=["TestAlgorithm"],
-            optional_algorithms=["TestNoChangesAlgorithm", "TestAlgorithm3"],
-            inputs=inputs,
-            required_outputs=["TestType3"],
-            tokens=[], required_output_tokens=[])
-        executor.execute_mapping()
-        self.assertTrue(TestAlgorithm.called)
-        self.assertFalse(TestNoChangesAlgorithm.called)
-        self.assertTrue(TestAlgorithm3.called)
-        self.assertEqual(executor.get_item("TestType3"), "TestType3")
-
     def test_token_workflow(self):
         """ Tests that a workflow with tokens works
         """


### PR DESCRIPTION
this removes the harshness of looking for optional inputs first. it results in spalloc machines failing as they run the chip allocater twice right after each other. This is ebcuase the pre alloc resources are designed to be ran in any order, and therefore havea  optional input which cripples the logic. 

by removing this restriction everything flows again. 


currently without this fix, master fails to run on spalloc machines due to being allocated a virutal board for doign real mappings on