### PR TITLE
Default uninitialised weights to infinity, not None

### DIFF
--- a/pacman/operations/router_algorithms/basic_dijkstra_routing.py
+++ b/pacman/operations/router_algorithms/basic_dijkstra_routing.py
@@ -12,6 +12,7 @@ import logging
 import sys
 
 logger = logging.getLogger(__name__)
+infinity = float("inf")
 
 
 class _NodeInfo(object):
@@ -142,7 +143,7 @@ class BasicDijkstraRouting(object):
             for source_id in range(6):
                 n = chip.router.get_link(source_id)
                 node.neighbours.append(n)
-                node.weights.append(None)
+                node.weights.append(infinity)
                 node.bws.append(None if n is None else self._max_bw)
             nodes_info[chip.x, chip.y] = node
         return nodes_info


### PR DESCRIPTION
This is the possible fix to the problems with Dijkstra routing, making the weights default to infinity instead of None so that they are at least type-usable with math operations.