### PR TITLE
Fix fixed route down chips

### DIFF
--- a/pacman/operations/fixed_route_router/fixed_route_router.py
+++ b/pacman/operations/fixed_route_router/fixed_route_router.py
@@ -6,6 +6,7 @@ from spinn_machine.fixed_route_entry import FixedRouteEntry
 from pacman import exceptions
 from spinn_utilities.progress_bar import ProgressBar
 from spinn_machine.virtual_machine import VirtualMachine
+from spinn_machine.machine import Machine
 
 
 class FixedRouteRouter(object):
@@ -210,7 +211,7 @@ class FixedRouteRouter(object):
         :rtype: None
         """
 
-        joins, paths = self._get_joins_paths(board_version, machine)
+        joins, paths = self._get_joins_paths(board_version)
 
         for path_id in paths.keys():
 
@@ -246,9 +247,9 @@ class FixedRouteRouter(object):
                 "fixed route entry", str(key))
         fixed_route_tables[key] = fixed_route_entry
 
-    def _get_joins_paths(self, board_version, machine):
+    def _get_joins_paths(self, board_version):
         # process each path separately
-        if board_version in machine.BOARD_VERSION_FOR_48_CHIPS:
+        if board_version in Machine.BOARD_VERSION_FOR_48_CHIPS:
             return self.joins_48, self.router_path_chips_48
         else:
             return self.joins_4, self.router_path_chips_4
@@ -308,7 +309,7 @@ class FixedRouteRouter(object):
             return False
 
         # figure correct links
-        joins, _ = self._get_joins_paths(board_version, machine)
+        joins, _ = self._get_joins_paths(board_version)
         for ethernet_connected_chip in machine.ethernet_connected_chips:
             ethernet_chip_x = ethernet_connected_chip.x
             ethernet_chip_y = ethernet_connected_chip.y

--- a/pacman/operations/fixed_route_router/fixed_route_router.py
+++ b/pacman/operations/fixed_route_router/fixed_route_router.py
@@ -136,7 +136,11 @@ class FixedRouteRouter(object):
             vertex = RoutingMachineVertex()
             graph.add_vertex(vertex)
             rel_x = chip_x - eth_x
+            if rel_x < 0:
+                rel_x += machine.max_chip_x + 1
             rel_y = chip_y - eth_y
+            if rel_y < 0:
+                rel_y += machine.max_chip_y + 1
             fake_placements.add_placement(Placement(
                 x=rel_x, y=rel_y, p=self.RANDOM_CORE_ID, vertex=vertex))
             down_links.update({
@@ -150,7 +154,9 @@ class FixedRouteRouter(object):
                 (machine.max_chip_x > 7 or machine.max_chip_y > 7)):
             down_chips = {
                 (x, y) for x, y in zip(range(8), range(8))
-                if not machine.is_chip_at(x + eth_x, y + eth_y)}
+                if not machine.is_chip_at(
+                    (x + eth_x) % (machine.max_chip_x + 1),
+                    (y + eth_y) % (machine.max_chip_y + 1))}
 
             # build a fake machine which is just one board but with the missing
             # bits of the real board
@@ -189,7 +195,9 @@ class FixedRouteRouter(object):
             fixed_route_entry = FixedRouteEntry(
                 link_ids=mc_entry.out_going_links,
                 processor_ids=mc_entry.out_going_processors)
-            key = (chip_x + eth_x, chip_y + eth_y)
+            x = (chip_x + eth_x) % (machine.max_chip_x + 1)
+            y = (chip_y + eth_y) % (machine.max_chip_y + 1)
+            key = (x, y)
             if key in fixed_route_tables:
                 raise exceptions.PacmanAlreadyExistsException(
                     "fixed route entry", str(key))

--- a/unittests/test_fixed_route_router.py
+++ b/unittests/test_fixed_route_router.py
@@ -1,0 +1,109 @@
+from spinn_machine import VirtualMachine
+from pacman.model.placements import Placements, Placement
+import pytest
+from pacman.operations.fixed_route_router.fixed_route_router \
+    import FixedRouteRouter
+
+
+class DestinationVertex():
+    pass
+
+
+def _get_destinations(machine, fixed_route_tables, source_x, source_y):
+    to_search = list([(source_x, source_y)])
+    visited = set()
+    destinations = set()
+    while to_search:
+        x, y = to_search.pop()
+        assert (x, y) not in visited
+        entry = fixed_route_tables[x, y]
+        for link in entry.link_ids:
+            assert machine.is_link_at(x, y, link)
+            chip = machine.get_chip_at(x, y)
+            link_obj = chip.router.get_link(link)
+            to_search.append((link_obj.destination_x, link_obj.destination_y))
+        for processor_id in entry.processor_ids:
+            destinations.add((x, y, processor_id))
+        visited.add((x, y))
+    return destinations
+
+
+@pytest.mark.parametrize(
+    "width,height,with_wrap_arounds,version,board_version",
+    [(2, 2, True, None, 3),
+     (2, 2, False, None, 3),
+     (None, None, None, 3, 3),
+     (8, 8, None, None, 5),
+     (None, None, None, 5, 5),
+     (12, 12, True, None, 5),
+     (16, 16, False, None, 5)])
+def test_all_working(width, height, with_wrap_arounds, version, board_version):
+    machine = VirtualMachine(
+        width=width, height=height, with_wrap_arounds=with_wrap_arounds,
+        version=version)
+    placements = Placements()
+
+    ethernet_chips = machine.ethernet_connected_chips
+    for ethernet_chip in ethernet_chips:
+        destination_vertex = DestinationVertex()
+        placements.add_placement(Placement(
+            destination_vertex, ethernet_chip.x, ethernet_chip.y, 1))
+
+    router = FixedRouteRouter()
+
+    for ethernet_chip in ethernet_chips:
+        assert(router._detect_failed_chips_on_board(
+            machine, ethernet_chip, board_version))
+
+    fixed_route_tables = router.__call__(
+        machine, placements, board_version, DestinationVertex)
+
+    for x, y in machine.chip_coordinates:
+        assert (x, y) in fixed_route_tables
+        chip = machine.get_chip_at(x, y)
+        destinations = _get_destinations(machine, fixed_route_tables, x, y)
+        assert len(destinations) == 1
+        assert (
+            (chip.nearest_ethernet_x, chip.nearest_ethernet_y, 1)
+            in destinations)
+
+
+@pytest.mark.parametrize(
+    "width,height,with_wrap_arounds,version,board_version,down_links",
+    [(2, 2, True, None, 3),
+     (2, 2, False, None, 3),
+     (None, None, None, 3, 3),
+     (8, 8, None, None, 5),
+     (None, None, None, 5, 5),
+     (12, 12, True, None, 5),
+     (16, 16, False, None, 5)])
+def test_missing_links(
+        width, height, with_wrap_arounds, version, board_version, down_links):
+    machine = VirtualMachine(
+        width=width, height=height, with_wrap_arounds=with_wrap_arounds,
+        version=version, down_links=down_links)
+    placements = Placements()
+
+    ethernet_chips = machine.ethernet_connected_chips
+    for ethernet_chip in ethernet_chips:
+        destination_vertex = DestinationVertex()
+        placements.add_placement(Placement(
+            destination_vertex, ethernet_chip.x, ethernet_chip.y, 1))
+
+    router = FixedRouteRouter()
+
+    for ethernet_chip in ethernet_chips:
+        assert(not router._detect_failed_chips_on_board(
+            machine, ethernet_chip, board_version))
+
+    fixed_route_tables = router.__call__(
+        machine, placements, board_version, DestinationVertex)
+
+    for x, y in machine.chip_coordinates:
+        assert (x, y) in fixed_route_tables
+        chip = machine.get_chip_at(x, y)
+        destinations = _get_destinations(machine, fixed_route_tables, x, y)
+        assert len(destinations) == 1
+        assert (
+            (chip.nearest_ethernet_x, chip.nearest_ethernet_y, 1)
+            in destinations)

--- a/unittests/test_fixed_route_router.py
+++ b/unittests/test_fixed_route_router.py
@@ -92,6 +92,7 @@ def test_all_working(
             (chip.nearest_ethernet_x, chip.nearest_ethernet_y, 1)
             in destinations)
 
+
 if __name__ == '__main__':
     iterations = [
         (False, False),

--- a/unittests/test_fixed_route_router.py
+++ b/unittests/test_fixed_route_router.py
@@ -5,7 +5,7 @@ from pacman.operations.fixed_route_router.fixed_route_router \
     import FixedRouteRouter
 
 
-class DestinationVertex():
+class DestinationVertex(object):
     pass
 
 
@@ -91,3 +91,17 @@ def test_all_working(
         assert (
             (chip.nearest_ethernet_x, chip.nearest_ethernet_y, 1)
             in destinations)
+
+if __name__ == '__main__':
+    iterations = [
+        (False, False),
+        (True, False),
+        (False, True)]
+    for (x, y) in iterations:
+        test_all_working(2, 2, True, None, 3, x, y)
+        test_all_working(2, 2, False, None, 3, x, y)
+        test_all_working(None, None, None, 3, 3, x, y)
+        test_all_working(8, 8, None, None, 5, x, y)
+        test_all_working(None, None, None, 5, 5, x, y)
+        test_all_working(12, 12, True, None, 5, x, y)
+        test_all_working(16, 16, False, None, 5, x, y)


### PR DESCRIPTION
This adds some tests and fixes some bugs in the fixed route router.  The main changes are:
 - Fix an issue that meant that almost all boards were using the dynamic routing (since 0, 0, 4 doesn't exist on boards without wrap arounds).
 - Force dynamic routing to stick to the board with the Ethernet chip that is being routed to.