### PR TITLE
SDRAM edges

### DIFF
--- a/pacman/model/graphs/common/edge_traffic_type.py
+++ b/pacman/model/graphs/common/edge_traffic_type.py
@@ -7,3 +7,4 @@ class EdgeTrafficType(Enum):
 
     MULTICAST = 1
     FIXED_ROUTE = 2
+    SDRAM = 3

--- a/pacman/operations/placer_algorithms/one_to_one_placer.py
+++ b/pacman/operations/placer_algorithms/one_to_one_placer.py
@@ -7,8 +7,8 @@ from pacman.exceptions import \
 from pacman.model.placements import Placement, Placements
 from pacman.operations.placer_algorithms import RadialPlacer
 from pacman.utilities.utility_objs import ResourceTracker
-from pacman.utilities.algorithm_utilities \
-    import placer_algorithm_utilities as placer_utils
+from pacman.utilities.algorithm_utilities.placer_algorithm_utilities \
+    import get_same_chip_vertex_groups, sort_vertices_by_known_constraints
 from pacman.model.constraints.placer_constraints\
     import SameChipAsConstraint
 from pacman.utilities.utility_calls import is_single
@@ -37,8 +37,7 @@ class OneToOnePlacer(RadialPlacer):
             additional_placement_constraints={SameChipAsConstraint})
 
         # Get which vertices must be placed on the same chip as another vertex
-        same_chip_vertex_groups = placer_utils.get_same_chip_vertex_groups(
-            machine_graph.vertices)
+        same_chip_vertex_groups = get_same_chip_vertex_groups(machine_graph)
         sorted_vertices = self._sort_vertices_for_one_to_one_connection(
             machine_graph, same_chip_vertex_groups)
 
@@ -120,8 +119,7 @@ class OneToOnePlacer(RadialPlacer):
         found_list = set()
 
         # order vertices based on constraint priority
-        vertices = placer_utils.sort_vertices_by_known_constraints(
-            machine_graph.vertices)
+        vertices = sort_vertices_by_known_constraints(machine_graph.vertices)
 
         for vertex in vertices:
             if vertex not in found_list:

--- a/pacman/operations/placer_algorithms/radial_placer.py
+++ b/pacman/operations/placer_algorithms/radial_placer.py
@@ -1,8 +1,8 @@
 # pacman imports
 from pacman.model.constraints.placer_constraints \
     import RadialPlacementFromChipConstraint, SameChipAsConstraint
-from pacman.utilities.algorithm_utilities \
-    import placer_algorithm_utilities as placer_utils
+from pacman.utilities.algorithm_utilities.placer_algorithm_utilities \
+    import sort_vertices_by_known_constraints, get_same_chip_vertex_groups
 from pacman.model.placements import Placement, Placements
 from pacman.utilities.utility_calls import locate_constraints_of_type
 from pacman.utilities.utility_objs import ResourceTracker
@@ -28,16 +28,14 @@ class RadialPlacer(object):
         self._check_constraints(machine_graph.vertices)
 
         placements = Placements()
-        vertices = placer_utils.sort_vertices_by_known_constraints(
-            machine_graph.vertices)
+        vertices = sort_vertices_by_known_constraints(machine_graph.vertices)
 
         # Iterate over vertices and generate placements
         progress = ProgressBar(
             machine_graph.n_vertices, "Placing graph vertices")
         resource_tracker = ResourceTracker(
             machine, self._generate_radial_chips(machine))
-        vertices_on_same_chip = placer_utils.get_same_chip_vertex_groups(
-            machine_graph.vertices)
+        vertices_on_same_chip = get_same_chip_vertex_groups(machine_graph)
         all_vertices_placed = set()
         for vertex in progress.over(vertices):
             if vertex not in all_vertices_placed:

--- a/pacman/operations/rigged_algorithms/hilbert_placer.py
+++ b/pacman/operations/rigged_algorithms/hilbert_placer.py
@@ -48,8 +48,7 @@ class HilbertPlacer(object):
             machine, self._generate_hilbert_chips(machine))
 
         # get vertices which must be placed on the same chip
-        vertices_on_same_chip = \
-            get_same_chip_vertex_groups(machine_graph.vertices)
+        vertices_on_same_chip = get_same_chip_vertex_groups(machine_graph)
 
         # iterate over vertices and generate placements
         all_vertices_placed = set()

--- a/pacman/operations/rigged_algorithms/random_placer.py
+++ b/pacman/operations/rigged_algorithms/random_placer.py
@@ -32,8 +32,7 @@ class RandomPlacer(object):
                                "Placing graph vertices")
         resource_tracker = ResourceTracker(
             machine, self._generate_random_chips(machine))
-        vertices_on_same_chip = get_same_chip_vertex_groups(
-            machine_graph.vertices)
+        vertices_on_same_chip = get_same_chip_vertex_groups(machine_graph)
         vertices_placed = set()
         for vertex in progress.over(vertices):
             if vertex not in vertices_placed:

--- a/pacman/utilities/algorithm_utilities/placer_algorithm_utilities.py
+++ b/pacman/utilities/algorithm_utilities/placer_algorithm_utilities.py
@@ -1,5 +1,6 @@
 from pacman.model.constraints.placer_constraints\
     import ChipAndCoreConstraint, SameChipAsConstraint
+from pacman.model.graphs.common.edge_traffic_type import EdgeTrafficType
 from pacman.model.constraints.placer_constraints \
     import BoardConstraint, RadialPlacementFromChipConstraint
 from pacman.utilities import VertexSorter, ConstraintOrder
@@ -18,15 +19,15 @@ def sort_vertices_by_known_constraints(vertices):
     return sorter.sort(vertices)
 
 
-def get_same_chip_vertex_groups(vertices):
-    """ Get a dictionary of vertex to vertex that must be placed on the same\
-        chip
+def get_same_chip_vertex_groups(graph):
+    """ Get a dictionary of vertex to list of vertices that must be placed on\
+       the same chip
     """
 
     # Dict of vertex to list of vertices on same chip (repeated lists expected)
     same_chip_vertices = dict()
 
-    for vertex in vertices:
+    for vertex in graph.vertices:
         # Find all vertices that have a same chip constraint associated with
         #  this vertex
         same_chip_as_vertices = list()
@@ -34,9 +35,14 @@ def get_same_chip_vertex_groups(vertices):
             if isinstance(constraint, SameChipAsConstraint):
                 same_chip_as_vertices.append(constraint.vertex)
 
+        for edge in filter(
+                lambda edge: edge.traffic_type == EdgeTrafficType.SDRAM,
+                graph.get_edges_starting_at_vertex(vertex)):
+            same_chip_as_vertices.append(edge.post_vertex)
+
         if same_chip_as_vertices:
-            # Go through all the verts that want to be on the same chip as
-            # the top level vert
+            # Go through all the vertices that want to be on the same chip as
+            # the top level vertex
             for same_as_chip_vertex in same_chip_as_vertices:
                 # Neither vertex has been seen
                 if (same_as_chip_vertex not in same_chip_vertices and

--- a/pacman/utilities/rig_converters.py
+++ b/pacman/utilities/rig_converters.py
@@ -205,7 +205,7 @@ def create_rig_graph_constraints(machine_graph, machine):
                     constraints.append(LocationConstraint(
                         vertex, (constraint.x, constraint.y)))
 
-    for group in get_same_chip_vertex_groups(machine_graph.vertices).values():
+    for group in get_same_chip_vertex_groups(machine_graph).itervalues():
         if len(group) > 1:
             constraints.append(SameChipConstraint(group))
     return constraints

--- a/pacman/utilities/rig_converters.py
+++ b/pacman/utilities/rig_converters.py
@@ -6,7 +6,7 @@ from rig.place_and_route.constraints import \
     LocationConstraint, ReserveResourceConstraint, RouteEndpointConstraint
 from rig.place_and_route.routing_tree import RoutingTree
 from rig.routing_table import Routes
-from six import iteritems
+from six import iteritems, itervalues
 
 from pacman.model.constraints.placer_constraints\
     import ChipAndCoreConstraint, RadialPlacementFromChipConstraint
@@ -205,7 +205,7 @@ def create_rig_graph_constraints(machine_graph, machine):
                     constraints.append(LocationConstraint(
                         vertex, (constraint.x, constraint.y)))
 
-    for group in get_same_chip_vertex_groups(machine_graph).itervalues():
+    for group in itervalues(get_same_chip_vertex_groups(machine_graph)):
         if len(group) > 1:
             constraints.append(SameChipConstraint(group))
     return constraints

--- a/unittests/operations_tests/placer_algorithms_tests/test_sdram_edge_placement.py
+++ b/unittests/operations_tests/placer_algorithms_tests/test_sdram_edge_placement.py
@@ -1,0 +1,56 @@
+from pacman.model.graphs.machine import MachineGraph, SimpleMachineVertex
+from spinn_machine import VirtualMachine
+from pacman.model.resources import ResourceContainer
+from pacman.model.graphs.machine.machine_edge import MachineEdge
+from pacman.model.graphs.common.edge_traffic_type import EdgeTrafficType
+from pacman.operations.rig_algorithms.rig_place import RigPlace
+from pacman.operations.placer_algorithms.one_to_one_placer \
+    import OneToOnePlacer
+from pacman.operations.placer_algorithms import RadialPlacer
+import random
+import unittest
+
+
+class TestSameChipConstraint(unittest.TestCase):
+
+    def _do_test(self, placer):
+        machine = VirtualMachine(width=8, height=8)
+        graph = MachineGraph("Test")
+
+        vertices = [
+            SimpleMachineVertex(ResourceContainer(), label="v{}".format(i))
+            for i in range(100)
+        ]
+        for vertex in vertices:
+            graph.add_vertex(vertex)
+
+        same_vertices = [
+            SimpleMachineVertex(ResourceContainer(), label="same{}".format(i))
+            for i in range(10)
+        ]
+        random.seed(12345)
+        sdram_edges = list()
+        for vertex in same_vertices:
+            graph.add_vertex(vertex)
+            for i in range(0, random.randint(1, 5)):
+                sdram_edge = MachineEdge(
+                    vertex, vertices[random.randint(0, 99)],
+                    traffic_type=EdgeTrafficType.SDRAM)
+                sdram_edges.append(sdram_edge)
+                graph.add_edge(sdram_edge, "Test")
+
+        placements = placer(graph, machine)
+        for edge in sdram_edges:
+            pre_place = placements.get_placement_of_vertex(edge.pre_vertex)
+            post_place = placements.get_placement_of_vertex(edge.post_vertex)
+            self.assert_(pre_place.x == post_place.x)
+            self.assert_(pre_place.y == post_place.y)
+
+    def test_one_to_one(self):
+        self._do_test(OneToOnePlacer())
+
+    def test_radial(self):
+        self._do_test(RadialPlacer())
+
+    def test_rig(self):
+        self._do_test(RigPlace())


### PR DESCRIPTION
This adds support for SDRAM edges - edges which have an SDRAM traffic type, and thus indicate communication over SDRAM.  This is similar to the SameChipAsConstraint, but has the following advantage: during partitioning, SDRAM edges will be expanded up to full connectivity.  The application can then further filter edges which don't match the appropriate connectivity.

An example:
Start with application vertices:

A(2 atoms) -> SDRAM edge -> B(2 atoms) 

with max 1 atom per core for each, and SDRAM communications on a 1-1 basis.  Partitioner will create machine vertices and edges:

A1 -> SDRAM edge -> B1 (needed)
A1 -> SDRAM edge -> B2 (can be filtered)
A2 -> SDRAM edge -> B1 (can be filtered)
A2 -> SDRAM edge -> B2 (needed)

With a SameChipAsConstraint, there would be no such ability to filter.


Another example:
Start with application vertices:

A(2 atoms) -> SDRAM edge -> B(4 atoms)

which should be connected in the ratio of 1 atom of A to 2 atoms of B.  The partitioner will create:

A1 -> SDRAM edge -> B1,2 (needed)
A1 -> SDRAM edge -> B3,4 (can be filtered)
A2 -> SDRAM edge -> B1,2 (can be filtered)
A2 -> SDRAM edge -> B3,4 (needed)

Again a SameChipAsConstraint would offer no ability to filter the edges.  Similarly assuming that SameChipAsConstraint applies on an atom-by-atom basis would fail.  The SDRAM edge offers a more flexible solution,