### PR TITLE
Min atoms per core

### DIFF
--- a/pacman/model/constraints/partitioner_constraints/__init__.py
+++ b/pacman/model/constraints/partitioner_constraints/__init__.py
@@ -1,7 +1,9 @@
 from .abstract_partitioner_constraint import AbstractPartitionerConstraint
 from .max_vertex_atoms_constraint import MaxVertexAtomsConstraint
+from .min_vertex_atoms_constraint import MinVertexAtomsConstraint
 from .same_atoms_as_vertex_constraint import SameAtomsAsVertexConstraint
 
 __all__ = ["AbstractPartitionerConstraint",
            "MaxVertexAtomsConstraint",
+           "MinVertexAtomsConstraint",
            "SameAtomsAsVertexConstraint"]

--- a/pacman/model/constraints/partitioner_constraints/min_vertex_atoms_constraint.py
+++ b/pacman/model/constraints/partitioner_constraints/min_vertex_atoms_constraint.py
@@ -1,0 +1,40 @@
+# pacman import
+from .abstract_partitioner_constraint import AbstractPartitionerConstraint
+
+
+class MinVertexAtomsConstraint(AbstractPartitionerConstraint):
+    """ A constraint which limits the number of atoms on each division of a\
+        vertex
+    """
+
+    __slots__ = [
+        # The minimum number of atoms to split the application vertex into
+        "_size"
+    ]
+
+    def __init__(self, size):
+        """
+
+        :param size: The minimum number of atoms to split the vertex into
+        :type size: int
+        """
+        self._size = size
+
+    @property
+    def size(self):
+        """ The minimum number of atoms to split the vertex into
+
+        :rtype: int
+        """
+        return self._size
+
+    def __repr__(self):
+        return "MinVertexAtomsConstraint(size={})".format(self._size)
+
+    def __eq__(self, other):
+        if not isinstance(other, MinVertexAtomsConstraint):
+            return False
+        return self._size == other.size
+
+    def __hash__(self):
+        return hash((self._size,))

--- a/pacman/operations/partition_algorithms/basic_partitioner.py
+++ b/pacman/operations/partition_algorithms/basic_partitioner.py
@@ -2,8 +2,7 @@ import logging
 
 from pacman.exceptions import PacmanPartitionException
 from pacman.model.constraints.partitioner_constraints \
-    import AbstractPartitionerConstraint, MaxVertexAtomsConstraint, \
-    MinVertexAtomsConstraint
+    import AbstractPartitionerConstraint, MaxVertexAtomsConstraint
 from pacman.model.graphs.common import GraphMapper, Slice
 from pacman.model.graphs.machine import MachineGraph
 from pacman.utilities import utility_calls
@@ -48,8 +47,7 @@ class BasicPartitioner(object):
         ResourceTracker.check_constraints(graph.vertices)
         utility_calls.check_algorithm_can_support_constraints(
             constrained_vertices=graph.vertices,
-            supported_constraints=[
-                MaxVertexAtomsConstraint, MinVertexAtomsConstraint],
+            supported_constraints=[MaxVertexAtomsConstraint],
             abstract_constraint_type=AbstractPartitionerConstraint)
 
         # start progress bar
@@ -73,11 +71,7 @@ class BasicPartitioner(object):
         """
         # Compute how many atoms of this vertex we can put on one core
         atoms_per_core = self._compute_atoms_per_core(vertex, res_tracker)
-        min_atom_values = [1.0]
-        for min_atom_constraint in utility_calls.locate_constraints_of_type(
-                vertex.constraints, MinVertexAtomsConstraint):
-            min_atom_values.append(float(min_atom_constraint.size))
-        if atoms_per_core < max(min_atom_values):
+        if atoms_per_core < 1.0:
             raise PacmanPartitionException(
                 "Not enough resources available to create vertex")
 

--- a/pacman/operations/partition_algorithms/partition_and_place_partitioner.py
+++ b/pacman/operations/partition_algorithms/partition_and_place_partitioner.py
@@ -4,7 +4,8 @@ from six import raise_from
 from pacman.model.abstract_classes import AbstractHasGlobalMaxAtoms
 from pacman.exceptions import PacmanPartitionException, PacmanValueError
 from pacman.model.constraints.partitioner_constraints \
-    import AbstractPartitionerConstraint, MaxVertexAtomsConstraint
+    import AbstractPartitionerConstraint, MaxVertexAtomsConstraint, \
+    MinVertexAtomsConstraint
 from pacman.model.constraints.partitioner_constraints \
     import SameAtomsAsVertexConstraint
 from pacman.model.graphs.common import GraphMapper, Slice
@@ -50,8 +51,9 @@ class PartitionAndPlacePartitioner(object):
         utils.check_algorithm_can_support_constraints(
             constrained_vertices=graph.vertices,
             abstract_constraint_type=AbstractPartitionerConstraint,
-            supported_constraints=[MaxVertexAtomsConstraint,
-                                   SameAtomsAsVertexConstraint])
+            supported_constraints=[
+                MaxVertexAtomsConstraint, MinVertexAtomsConstraint,
+                SameAtomsAsVertexConstraint])
 
         # Load the vertices and create the machine_graph to fill
         machine_graph = MachineGraph(
@@ -122,6 +124,7 @@ class PartitionAndPlacePartitioner(object):
 
         # locate max atoms per core
         possible_max_atoms = list()
+        possible_min_atoms = list([1])
         if isinstance(vertex, AbstractHasGlobalMaxAtoms):
             possible_max_atoms.append(vertex.get_max_atoms_per_core())
 
@@ -131,17 +134,23 @@ class PartitionAndPlacePartitioner(object):
                 MaxVertexAtomsConstraint)
             for constraint in max_atom_constraints:
                 possible_max_atoms.append(constraint.size)
+            min_atom_constraints = utils.locate_constraints_of_type(
+                MinVertexAtomsConstraint)
+            for constraint in min_atom_constraints:
+                possible_min_atoms.append(constraint.size)
 
         max_atoms_per_core = int(min(possible_max_atoms))
+        min_atoms_per_core = int(min(possible_min_atoms))
 
         # partition by atoms
         self._partition_by_atoms(
             partition_together_vertices, vertex.n_atoms, max_atoms_per_core,
-            machine_graph, graph, graph_mapper, resource_tracker, progress)
+            min_atoms_per_core, machine_graph, graph, graph_mapper,
+            resource_tracker, progress)
 
     def _partition_by_atoms(
-            self, vertices, n_atoms, max_atoms_per_core, machine_graph, graph,
-            graph_mapper, resource_tracker, progress):
+            self, vertices, n_atoms, max_atoms_per_core, min_atoms_per_core,
+            machine_graph, graph, graph_mapper, resource_tracker, progress):
         """ Try to partition vertices on how many atoms it can fit on\
             each vertex
 
@@ -156,6 +165,10 @@ class PartitionAndPlacePartitioner(object):
             the max atoms from all the vertexes considered that have max_atom\
             constraints
         :type max_atoms_per_core: int
+        :param min_atoms_per_core:\
+            the min atoms from all the vertexes considered that have min_atom\
+            constraints
+        :type min_atoms_per_core: int
         :param machine_graph: the machine graph
         :type machine_graph:\
             :py:class:`pacman.model.graphs.machine.MachineGraph`
@@ -179,7 +192,7 @@ class PartitionAndPlacePartitioner(object):
             # Scale down the number of atoms to fit the available resources
             used_placements, hi_atom = self._scale_down_resources(
                 lo_atom, hi_atom, vertices, resource_tracker,
-                max_atoms_per_core, graph)
+                max_atoms_per_core, min_atoms_per_core, graph)
 
             # Update where we are
             n_atoms_placed = hi_atom + 1
@@ -245,7 +258,7 @@ class PartitionAndPlacePartitioner(object):
     # noinspection PyUnusedLocal
     def _scale_down_resources(
             self, lo_atom, hi_atom, vertices, resource_tracker,
-            max_atoms_per_core, graph):
+            max_atoms_per_core, min_atoms_per_core, graph):
         """ Reduce the number of atoms on a core so that it fits within the
             resources available.
 
@@ -262,6 +275,10 @@ class PartitionAndPlacePartitioner(object):
             the max atoms from all the vertexes considered that have max_atom\
             constraints
         :type max_atoms_per_core: int
+        :param min_atoms_per_core:\
+            the min atoms from all the vertexes considered that have min_atom\
+            constraints
+        :type min_atoms_per_core: int
         :param graph: the application graph object
         :type graph:\
             :py:class:`pacman.model.graphs.application.ApplicationGraph`
@@ -290,7 +307,8 @@ class PartitionAndPlacePartitioner(object):
             # Work out the ratio of used to available resources
             ratio = self._find_max_ratio(used_resources, resources)
 
-            while ratio > 1.0 and hi_atom >= lo_atom:
+            while ratio > 1.0 and (
+                    (hi_atom - lo_atom) + 1 >= min_atoms_per_core):
                 # Scale the resources by the ratio
                 old_n_atoms = (hi_atom - lo_atom) + 1
                 new_n_atoms = int(float(old_n_atoms) / (ratio * 1.1))
@@ -301,14 +319,14 @@ class PartitionAndPlacePartitioner(object):
 
                 # Find the new resource usage
                 hi_atom = lo_atom + new_n_atoms - 1
-                if hi_atom >= lo_atom:
+                if (hi_atom - lo_atom) + 1 >= min_atoms_per_core:
                     vertex_slice = Slice(lo_atom, hi_atom)
                     used_resources = \
                         vertex.get_resources_used_by_atoms(vertex_slice)
                     ratio = self._find_max_ratio(used_resources, resources)
 
             # If we couldn't partition, raise an exception
-            if hi_atom < lo_atom:
+            if (hi_atom - lo_atom) + 1 < min_atoms_per_core:
                 raise PacmanPartitionException(
                     "No more of vertex '{}' would fit on the board:\n"
                     "    Allocated so far: {} atoms\n"

--- a/unittests/model_tests/test_partition.py
+++ b/unittests/model_tests/test_partition.py
@@ -1,7 +1,8 @@
 import unittest
 from pacman.model.graphs.machine import SimpleMachineVertex
 from pacman.model.constraints.partitioner_constraints import \
-    MaxVertexAtomsConstraint, SameAtomsAsVertexConstraint
+    MaxVertexAtomsConstraint, SameAtomsAsVertexConstraint, \
+    MinVertexAtomsConstraint
 
 
 class TestPartitionConstraints(unittest.TestCase):
@@ -14,6 +15,19 @@ class TestPartitionConstraints(unittest.TestCase):
         self.assertEqual(c1, MaxVertexAtomsConstraint(5))
         self.assertEqual(str(c1), 'MaxVertexAtomsConstraint(size=5)')
         c2 = MaxVertexAtomsConstraint(7)
+        self.assertNotEqual(c1, c2)
+        self.assertNotEqual(c1, "1.2.3.4")
+        d = {}
+        d[c1] = 1
+        d[c2] = 2
+        self.assertEqual(len(d), 2)
+
+    def test_min_vertex_atoms_constraint(self):
+        c1 = MinVertexAtomsConstraint(5)
+        self.assertEqual(c1.size, 5)
+        self.assertEqual(c1, MinVertexAtomsConstraint(5))
+        self.assertEqual(str(c1), 'MinVertexAtomsConstraint(size=5)')
+        c2 = MinVertexAtomsConstraint(7)
         self.assertNotEqual(c1, c2)
         self.assertNotEqual(c1, "1.2.3.4")
         d = {}

--- a/unittests/operations_tests/partition_algorithms_tests/test_partition_and_place_partitioner.py
+++ b/unittests/operations_tests/partition_algorithms_tests/test_partition_and_place_partitioner.py
@@ -483,9 +483,9 @@ class TestBasicPartitioner(unittest.TestCase):
         """
 
         # Create a 2x2 machine with 1 core per chip (so 4 cores),
-        # and 5MB SDRAM per chip
+        # and 6MB SDRAM per chip
         n_cores_per_chip = 1
-        sdram_per_chip = 5
+        sdram_per_chip = 6
         machine = VirtualMachine(
             width=2, height=2, with_monitors=False,
             n_cpus_per_chip=n_cores_per_chip,
@@ -494,8 +494,8 @@ class TestBasicPartitioner(unittest.TestCase):
         # Create a vertex which will need to be split perfectly into 4 cores
         # to work
         vertex = SimpleTestVertex(
-            machine.n_chips * sdram_per_chip,
-            max_atoms_per_core=((machine.n_chips * sdram_per_chip) / 2),
+            10,
+            max_atoms_per_core=8,
             constraints=[MinVertexAtomsConstraint(sdram_per_chip)])
         app_graph = ApplicationGraph("Test")
         app_graph.add_vertex(vertex)

--- a/unittests/operations_tests/partition_algorithms_tests/test_partition_and_place_partitioner.py
+++ b/unittests/operations_tests/partition_algorithms_tests/test_partition_and_place_partitioner.py
@@ -8,7 +8,7 @@ from pacman.model.graphs.application import ApplicationEdge, ApplicationGraph
 from pacman.exceptions import PacmanPartitionException, \
     PacmanInvalidParameterException, PacmanValueError
 from pacman.model.constraints.partitioner_constraints\
-    import MaxVertexAtomsConstraint
+    import MaxVertexAtomsConstraint, MinVertexAtomsConstraint
 from pacman.model.constraints.partitioner_constraints\
     import SameAtomsAsVertexConstraint
 from pacman.model.resources.pre_allocated_resource_container import \
@@ -322,7 +322,7 @@ class TestBasicPartitioner(unittest.TestCase):
     def test_operation_with_same_size_as_vertex_constraint(self):
         """
         test that the partition and place partitioner can handle same size as
-        constraints ona  vertex that is split into one core
+        constraints on a vertex that is split into one core
         """
         self.setup()
         constrained_vertex = SimpleTestVertex(5, "Constrained")
@@ -446,6 +446,35 @@ class TestBasicPartitioner(unittest.TestCase):
     @unittest.skip("Test not implemented yet")
     def test_partition_with_supported_constraints_not_enough_space(self):
         self.assertEqual(True, False, "Test not implemented yet")
+
+    def test_partition_with_min_atom_constraints(self):
+        """
+        test a partitioning with a graph with min atom constraint
+        """
+
+        # Create a 2x2 machine with 10 cores per chip (so 40 cores),
+        # but 1MB off 2MB per chip (so 19MB per chip)
+        n_cores_per_chip = 10
+        sdram_per_chip = (n_cores_per_chip * 2) - 1
+        machine = VirtualMachine(
+            width=2, height=2, with_monitors=False,
+            n_cpus_per_chip=n_cores_per_chip,
+            sdram_per_chip=sdram_per_chip)
+
+        # Create a vertex where each atom requires 1MB (default) of SDRAM
+        # but which can't be subdivided lower than 2 atoms per core.
+        # The vertex has 1 atom per MB of SDRAM, and so would fit but will
+        # be disallowed by the min atoms per core constraint
+        vertex = SimpleTestVertex(
+            sdram_per_chip * machine.n_chips,
+            max_atoms_per_core=2, constraints=[MinVertexAtomsConstraint(2)])
+        app_graph = ApplicationGraph("Test")
+        app_graph.add_vertex(vertex)
+
+        # Do the partitioning - this should result in an error
+        with self.assertRaises(PacmanPartitionException):
+            partitioner = PartitionAndPlacePartitioner()
+            partitioner(app_graph, machine)
 
 
 if __name__ == '__main__':

--- a/unittests/operations_tests/partition_algorithms_tests/test_partition_and_place_partitioner.py
+++ b/unittests/operations_tests/partition_algorithms_tests/test_partition_and_place_partitioner.py
@@ -476,6 +476,34 @@ class TestBasicPartitioner(unittest.TestCase):
             partitioner = PartitionAndPlacePartitioner()
             partitioner(app_graph, machine)
 
+    def test_partition_with_min_atom_constraints_close_to_limit(self):
+        """
+        test a partitioning with a graph with min atom constraint which\
+        should fit but is close to the limit
+        """
+
+        # Create a 2x2 machine with 1 core per chip (so 4 cores),
+        # and 5MB SDRAM per chip
+        n_cores_per_chip = 1
+        sdram_per_chip = 5
+        machine = VirtualMachine(
+            width=2, height=2, with_monitors=False,
+            n_cpus_per_chip=n_cores_per_chip,
+            sdram_per_chip=sdram_per_chip)
+
+        # Create a vertex which will need to be split perfectly into 4 cores
+        # to work
+        vertex = SimpleTestVertex(
+            machine.n_chips * sdram_per_chip,
+            max_atoms_per_core=((machine.n_chips * sdram_per_chip) / 2),
+            constraints=[MinVertexAtomsConstraint(sdram_per_chip)])
+        app_graph = ApplicationGraph("Test")
+        app_graph.add_vertex(vertex)
+
+        # Do the partitioning - this should just work
+        partitioner = PartitionAndPlacePartitioner()
+        partitioner(app_graph, machine)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Add a constraint for min atoms per core.  This is useful in a scenario where the number of atoms is useful for reason other than simple divide-ability.

Note that I tried adding this to the BasicPartitioner too, but the way it works makes this quite difficult to make it work correctly!