### PR TITLE
Fixed atoms per core

### DIFF
--- a/pacman/model/constraints/partitioner_constraints/__init__.py
+++ b/pacman/model/constraints/partitioner_constraints/__init__.py
@@ -1,7 +1,9 @@
 from .abstract_partitioner_constraint import AbstractPartitionerConstraint
+from .fixed_vertex_atoms_constraint import FixedVertexAtomsConstraint
 from .max_vertex_atoms_constraint import MaxVertexAtomsConstraint
 from .same_atoms_as_vertex_constraint import SameAtomsAsVertexConstraint
 
 __all__ = ["AbstractPartitionerConstraint",
+           "FixedVertexAtomsConstraint",
            "MaxVertexAtomsConstraint",
            "SameAtomsAsVertexConstraint"]

--- a/pacman/model/constraints/partitioner_constraints/fixed_vertex_atoms_constraint.py
+++ b/pacman/model/constraints/partitioner_constraints/fixed_vertex_atoms_constraint.py
@@ -1,0 +1,40 @@
+# pacman import
+from .abstract_partitioner_constraint import AbstractPartitionerConstraint
+
+
+class FixedVertexAtomsConstraint(AbstractPartitionerConstraint):
+    """ A constraint which specifies the exact number of atoms on each\
+        division of a vertex
+    """
+
+    __slots__ = [
+        # The exact number of atoms to split the application vertex into
+        "_size"
+    ]
+
+    def __init__(self, size):
+        """
+
+        :param size: The exact number of atoms to split the vertex into
+        :type size: int
+        """
+        self._size = size
+
+    @property
+    def size(self):
+        """ The exact number of atoms to split the vertex into
+
+        :rtype: int
+        """
+        return self._size
+
+    def __repr__(self):
+        return "FixedVertexAtomsConstraint(size={})".format(self._size)
+
+    def __eq__(self, other):
+        if not isinstance(other, FixedVertexAtomsConstraint):
+            return False
+        return self._size == other.size
+
+    def __hash__(self):
+        return hash((self._size,))

--- a/pacman/operations/partition_algorithms/basic_partitioner.py
+++ b/pacman/operations/partition_algorithms/basic_partitioner.py
@@ -2,7 +2,8 @@ import logging
 
 from pacman.exceptions import PacmanPartitionException
 from pacman.model.constraints.partitioner_constraints \
-    import AbstractPartitionerConstraint, MaxVertexAtomsConstraint
+    import AbstractPartitionerConstraint, MaxVertexAtomsConstraint, \
+    FixedVertexAtomsConstraint
 from pacman.model.graphs.common import GraphMapper, Slice
 from pacman.model.graphs.machine import MachineGraph
 from pacman.utilities import utility_calls
@@ -47,7 +48,8 @@ class BasicPartitioner(object):
         ResourceTracker.check_constraints(graph.vertices)
         utility_calls.check_algorithm_can_support_constraints(
             constrained_vertices=graph.vertices,
-            supported_constraints=[MaxVertexAtomsConstraint],
+            supported_constraints=[
+                MaxVertexAtomsConstraint, FixedVertexAtomsConstraint],
             abstract_constraint_type=AbstractPartitionerConstraint)
 
         # start progress bar
@@ -122,8 +124,25 @@ class BasicPartitioner(object):
         atoms_per_cpu = self._get_ratio(
             limits.cpu_cycles.get_value(), requirements.cpu_cycles.get_value())
 
+        n_atoms = None
+        for fa_constraint in utility_calls.locate_constraints_of_type(
+                vertex.constraints, FixedVertexAtomsConstraint):
+            if n_atoms is not None and n_atoms != fa_constraint.size:
+                raise PacmanPartitionException(
+                    "Vertex has multiple contradictory fixed atom constraints"
+                    " - cannot be both {} and {}".format(
+                        n_atoms, fa_constraint.size))
+            n_atoms = fa_constraint.size
+
         max_atom_values = [atoms_per_sdram, atoms_per_dtcm, atoms_per_cpu]
         for max_atom_constraint in utility_calls.locate_constraints_of_type(
                 vertex.constraints, MaxVertexAtomsConstraint):
             max_atom_values.append(float(max_atom_constraint.size))
-        return min(max_atom_values)
+        max_atoms = min(max_atom_values)
+
+        if n_atoms is not None and max_atoms < n_atoms:
+            raise PacmanPartitionException(
+                "Max size of {} is incompatible with fixed size of {}".format(
+                    max_atoms, n_atoms))
+
+        return n_atoms if n_atoms is not None else max_atoms

--- a/pacman/operations/partition_algorithms/partition_and_place_partitioner.py
+++ b/pacman/operations/partition_algorithms/partition_and_place_partitioner.py
@@ -4,7 +4,8 @@ from six import raise_from
 from pacman.model.abstract_classes import AbstractHasGlobalMaxAtoms
 from pacman.exceptions import PacmanPartitionException, PacmanValueError
 from pacman.model.constraints.partitioner_constraints \
-    import AbstractPartitionerConstraint, MaxVertexAtomsConstraint
+    import AbstractPartitionerConstraint, MaxVertexAtomsConstraint, \
+    FixedVertexAtomsConstraint
 from pacman.model.constraints.partitioner_constraints \
     import SameAtomsAsVertexConstraint
 from pacman.model.graphs.common import GraphMapper, Slice
@@ -51,7 +52,8 @@ class PartitionAndPlacePartitioner(object):
             constrained_vertices=graph.vertices,
             abstract_constraint_type=AbstractPartitionerConstraint,
             supported_constraints=[MaxVertexAtomsConstraint,
-                                   SameAtomsAsVertexConstraint])
+                                   SameAtomsAsVertexConstraint,
+                                   FixedVertexAtomsConstraint])
 
         # Load the vertices and create the machine_graph to fill
         machine_graph = MachineGraph(
@@ -120,28 +122,48 @@ class PartitionAndPlacePartitioner(object):
 
         partition_together_vertices = list(vertex_groups[vertex])
 
-        # locate max atoms per core
+        # locate max atoms per core and fixed atoms per core
         possible_max_atoms = list()
-        if isinstance(vertex, AbstractHasGlobalMaxAtoms):
-            possible_max_atoms.append(vertex.get_max_atoms_per_core())
-
+        n_atoms = None
         for other_vertex in partition_together_vertices:
+            if isinstance(other_vertex, AbstractHasGlobalMaxAtoms):
+                possible_max_atoms.append(
+                    other_vertex.get_max_atoms_per_core())
             max_atom_constraints = utils.locate_constraints_of_type(
-                other_vertex.constraints,
-                MaxVertexAtomsConstraint)
+                other_vertex.constraints, MaxVertexAtomsConstraint)
             for constraint in max_atom_constraints:
                 possible_max_atoms.append(constraint.size)
+            n_atom_constraints = utils.locate_constraints_of_type(
+                other_vertex.constraints, FixedVertexAtomsConstraint)
+            for constraint in n_atom_constraints:
+                if n_atoms is not None and constraint.size != n_atoms:
+                    raise PacmanPartitionException(
+                        "Vertex has multiple contradictory fixed atom "
+                        "constraints - cannot be both {} and {}".format(
+                            n_atoms, constraint.size))
+                n_atoms = constraint.size
 
         max_atoms_per_core = int(min(possible_max_atoms))
+        if n_atoms is not None and max_atoms_per_core < n_atoms:
+            raise PacmanPartitionException(
+                "Max size of {} is incompatible with fixed size of {}".format(
+                    max_atoms_per_core, n_atoms))
+        if n_atoms is not None:
+            max_atoms_per_core = n_atoms
+            if vertex.n_atoms % n_atoms != 0:
+                raise PacmanPartitionException(
+                    "Vertex of {} atoms cannot be divided into units of {}"
+                    .format(vertex.n_atoms, n_atoms))
 
         # partition by atoms
         self._partition_by_atoms(
             partition_together_vertices, vertex.n_atoms, max_atoms_per_core,
-            machine_graph, graph, graph_mapper, resource_tracker, progress)
+            machine_graph, graph, graph_mapper, resource_tracker, progress,
+            n_atoms is not None)
 
     def _partition_by_atoms(
             self, vertices, n_atoms, max_atoms_per_core, machine_graph, graph,
-            graph_mapper, resource_tracker, progress):
+            graph_mapper, resource_tracker, progress, fixed_n_atoms=False):
         """ Try to partition vertices on how many atoms it can fit on\
             each vertex
 
@@ -168,6 +190,10 @@ class PartitionAndPlacePartitioner(object):
         :param resource_tracker: A tracker of assigned resources
         :type resource_tracker:\
             :py:class:`pacman.utilities.ResourceTracker`
+        :param fixed_n_atoms:\
+            True if max_atoms_per_core is actually the fixed number of atoms\
+            per core and cannot be reduced
+        :type fixed_n_atoms: bool
         """
         n_atoms_placed = 0
         while n_atoms_placed < n_atoms:
@@ -179,7 +205,7 @@ class PartitionAndPlacePartitioner(object):
             # Scale down the number of atoms to fit the available resources
             used_placements, hi_atom = self._scale_down_resources(
                 lo_atom, hi_atom, vertices, resource_tracker,
-                max_atoms_per_core, graph)
+                max_atoms_per_core, graph, fixed_n_atoms)
 
             # Update where we are
             n_atoms_placed = hi_atom + 1
@@ -245,7 +271,7 @@ class PartitionAndPlacePartitioner(object):
     # noinspection PyUnusedLocal
     def _scale_down_resources(
             self, lo_atom, hi_atom, vertices, resource_tracker,
-            max_atoms_per_core, graph):
+            max_atoms_per_core, graph, fixed_n_atoms=False):
         """ Reduce the number of atoms on a core so that it fits within the
             resources available.
 
@@ -267,6 +293,10 @@ class PartitionAndPlacePartitioner(object):
             :py:class:`pacman.model.graphs.application.ApplicationGraph`
         :param resource_tracker: Tracker of used resources
         :type resource_tracker: spinn_machine.Machine object
+        :param fixed_n_atoms:\
+            True if max_atoms_per_core is actually the fixed number of atoms\
+            per core
+        :type fixed_n_atoms: bool
         :return: the list of placements made by this method and the new amount\
             of atoms partitioned
         :rtype: tuple of (iterable of tuples, int)
@@ -289,6 +319,16 @@ class PartitionAndPlacePartitioner(object):
 
             # Work out the ratio of used to available resources
             ratio = self._find_max_ratio(used_resources, resources)
+
+            if fixed_n_atoms and ratio > 1.0:
+                raise PacmanPartitionException(
+                    "No more of vertex '{}' would fit on the board:\n"
+                    "    Allocated so far: {} atoms\n"
+                    "    Request for SDRAM: {}\n"
+                    "    Largest SDRAM space: {}".format(
+                        vertex, lo_atom - 1,
+                        used_resources.sdram.get_value(),
+                        resources.sdram.get_value()))
 
             while ratio > 1.0 and hi_atom >= lo_atom:
                 # Scale the resources by the ratio

--- a/unittests/model_tests/test_partition.py
+++ b/unittests/model_tests/test_partition.py
@@ -1,7 +1,8 @@
 import unittest
 from pacman.model.graphs.machine import SimpleMachineVertex
 from pacman.model.constraints.partitioner_constraints import \
-    MaxVertexAtomsConstraint, SameAtomsAsVertexConstraint
+    MaxVertexAtomsConstraint, SameAtomsAsVertexConstraint,\
+    FixedVertexAtomsConstraint
 
 
 class TestPartitionConstraints(unittest.TestCase):
@@ -14,6 +15,19 @@ class TestPartitionConstraints(unittest.TestCase):
         self.assertEqual(c1, MaxVertexAtomsConstraint(5))
         self.assertEqual(str(c1), 'MaxVertexAtomsConstraint(size=5)')
         c2 = MaxVertexAtomsConstraint(7)
+        self.assertNotEqual(c1, c2)
+        self.assertNotEqual(c1, "1.2.3.4")
+        d = {}
+        d[c1] = 1
+        d[c2] = 2
+        self.assertEqual(len(d), 2)
+
+    def test_fixed_vertex_atoms_constraint(self):
+        c1 = FixedVertexAtomsConstraint(5)
+        self.assertEqual(c1.size, 5)
+        self.assertEqual(c1, FixedVertexAtomsConstraint(5))
+        self.assertEqual(str(c1), 'FixedVertexAtomsConstraint(size=5)')
+        c2 = FixedVertexAtomsConstraint(7)
         self.assertNotEqual(c1, c2)
         self.assertNotEqual(c1, "1.2.3.4")
         d = {}

--- a/unittests/operations_tests/partition_algorithms_tests/test_basic_partitioner.py
+++ b/unittests/operations_tests/partition_algorithms_tests/test_basic_partitioner.py
@@ -6,9 +6,10 @@ test for partitioning
 from pacman.model.graphs.application import ApplicationEdge, ApplicationGraph
 
 from pacman.exceptions import PacmanInvalidParameterException,\
-    PacmanPartitionException
+    PacmanPartitionException, PacmanValueError
 from pacman.model.constraints.partitioner_constraints\
-    import MaxVertexAtomsConstraint
+    import MaxVertexAtomsConstraint, FixedVertexAtomsConstraint
+from spinn_machine.virtual_machine import VirtualMachine
 from pacman.operations.partition_algorithms.basic_partitioner \
     import BasicPartitioner
 
@@ -313,6 +314,63 @@ class TestBasicPartitioner(unittest.TestCase):
         self.graph = ApplicationGraph("foo")
         graph, _, _ = self.bp(self.graph, self.machine)
         self.assertEqual(len(list(graph.vertices)), 0)
+
+    def test_partition_with_fixed_atom_constraints(self):
+        """
+        test a partitioning with a graph with fixed atom constraint
+        """
+
+        # Create a 2x2 machine with 10 cores per chip (so 40 cores),
+        # but 1MB off 2MB per chip (so 19MB per chip)
+        n_cores_per_chip = 10
+        sdram_per_chip = (n_cores_per_chip * 2) - 1
+        machine = VirtualMachine(
+            width=2, height=2, with_monitors=False,
+            n_cpus_per_chip=n_cores_per_chip,
+            sdram_per_chip=sdram_per_chip)
+
+        # Create a vertex where each atom requires 1MB (default) of SDRAM
+        # but which can't be subdivided lower than 2 atoms per core.
+        # The vertex has 1 atom per MB of SDRAM, and so would fit but will
+        # be disallowed by the fixed atoms per core constraint
+        vertex = SimpleTestVertex(
+            sdram_per_chip * machine.n_chips,
+            max_atoms_per_core=2, constraints=[FixedVertexAtomsConstraint(2)])
+        app_graph = ApplicationGraph("Test")
+        app_graph.add_vertex(vertex)
+
+        # Do the partitioning - this should result in an error
+        with self.assertRaises(PacmanValueError):
+            partitioner = BasicPartitioner()
+            partitioner(app_graph, machine)
+
+    def test_partition_with_fixed_atom_constraints_at_limit(self):
+        """
+        test a partitioning with a graph with fixed atom constraint which\
+        should fit but is close to the limit
+        """
+
+        # Create a 2x2 machine with 1 core per chip (so 4 cores),
+        # and 8MB SDRAM per chip
+        n_cores_per_chip = 1
+        sdram_per_chip = 8
+        machine = VirtualMachine(
+            width=2, height=2, with_monitors=False,
+            n_cpus_per_chip=n_cores_per_chip,
+            sdram_per_chip=sdram_per_chip)
+
+        # Create a vertex which will need to be split perfectly into 4 cores
+        # to work and which max atoms per core must be ignored
+        vertex = SimpleTestVertex(
+            sdram_per_chip * 2, max_atoms_per_core=sdram_per_chip,
+            constraints=[FixedVertexAtomsConstraint(sdram_per_chip // 2)])
+        app_graph = ApplicationGraph("Test")
+        app_graph.add_vertex(vertex)
+
+        # Do the partitioning - this should just work
+        partitioner = BasicPartitioner()
+        machine_graph, _, _ = partitioner(app_graph, machine)
+        self.assert_(len(machine_graph.vertices) == 4)
 
 
 if __name__ == '__main__':

--- a/unittests/operations_tests/partition_algorithms_tests/test_partition_and_place_partitioner.py
+++ b/unittests/operations_tests/partition_algorithms_tests/test_partition_and_place_partitioner.py
@@ -1,6 +1,7 @@
 """
 test for partitioning
 """
+from __future__ import division
 
 # pacman imports
 from pacman.model.graphs.application import ApplicationEdge, ApplicationGraph
@@ -8,7 +9,7 @@ from pacman.model.graphs.application import ApplicationEdge, ApplicationGraph
 from pacman.exceptions import PacmanPartitionException, \
     PacmanInvalidParameterException, PacmanValueError
 from pacman.model.constraints.partitioner_constraints\
-    import MaxVertexAtomsConstraint
+    import MaxVertexAtomsConstraint, FixedVertexAtomsConstraint
 from pacman.model.constraints.partitioner_constraints\
     import SameAtomsAsVertexConstraint
 from pacman.model.resources.pre_allocated_resource_container import \
@@ -446,6 +447,63 @@ class TestBasicPartitioner(unittest.TestCase):
     @unittest.skip("Test not implemented yet")
     def test_partition_with_supported_constraints_not_enough_space(self):
         self.assertEqual(True, False, "Test not implemented yet")
+
+    def test_partition_with_fixed_atom_constraints(self):
+        """
+        test a partitioning with a graph with fixed atom constraint
+        """
+
+        # Create a 2x2 machine with 10 cores per chip (so 40 cores),
+        # but 1MB off 2MB per chip (so 19MB per chip)
+        n_cores_per_chip = 10
+        sdram_per_chip = (n_cores_per_chip * 2) - 1
+        machine = VirtualMachine(
+            width=2, height=2, with_monitors=False,
+            n_cpus_per_chip=n_cores_per_chip,
+            sdram_per_chip=sdram_per_chip)
+
+        # Create a vertex where each atom requires 1MB (default) of SDRAM
+        # but which can't be subdivided lower than 2 atoms per core.
+        # The vertex has 1 atom per MB of SDRAM, and so would fit but will
+        # be disallowed by the fixed atoms per core constraint
+        vertex = SimpleTestVertex(
+            sdram_per_chip * machine.n_chips,
+            max_atoms_per_core=2, constraints=[FixedVertexAtomsConstraint(2)])
+        app_graph = ApplicationGraph("Test")
+        app_graph.add_vertex(vertex)
+
+        # Do the partitioning - this should result in an error
+        with self.assertRaises(PacmanPartitionException):
+            partitioner = PartitionAndPlacePartitioner()
+            partitioner(app_graph, machine)
+
+    def test_partition_with_fixed_atom_constraints_at_limit(self):
+        """
+        test a partitioning with a graph with fixed atom constraint which\
+        should fit but is close to the limit
+        """
+
+        # Create a 2x2 machine with 1 core per chip (so 4 cores),
+        # and 8MB SDRAM per chip
+        n_cores_per_chip = 1
+        sdram_per_chip = 8
+        machine = VirtualMachine(
+            width=2, height=2, with_monitors=False,
+            n_cpus_per_chip=n_cores_per_chip,
+            sdram_per_chip=sdram_per_chip)
+
+        # Create a vertex which will need to be split perfectly into 4 cores
+        # to work and which max atoms per core must be ignored
+        vertex = SimpleTestVertex(
+            sdram_per_chip * 2, max_atoms_per_core=sdram_per_chip,
+            constraints=[FixedVertexAtomsConstraint(sdram_per_chip // 2)])
+        app_graph = ApplicationGraph("Test")
+        app_graph.add_vertex(vertex)
+
+        # Do the partitioning - this should just work
+        partitioner = PartitionAndPlacePartitioner()
+        machine_graph, _, _ = partitioner(app_graph, machine)
+        self.assert_(len(machine_graph.vertices) == 4)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Added a FixedAtomsPerCore constraint.  This enforces the splitting of an ApplicationVertex into fixed sized chunks.  Max atoms per core is ignored except to check that it is valid.

This works well on vertices where the concept of an atom has more meaning than just the subdivisability of the vertex in partitioning.