### PR TITLE
fix spalloc external devices

### DIFF
--- a/pacman/operations/algorithms_metadata.xml
+++ b/pacman/operations/algorithms_metadata.xml
@@ -67,8 +67,8 @@
             </parameter>
             <parameter>
                 <param_name>machine</param_name>
-                <param_type>MemoryExtendedVirtualMachine</param_type>
-                <param_type>MemoryExtendedMachine</param_type>
+                <param_type>MemoryVirtualMachine</param_type>
+                <param_type>MemoryMachine</param_type>
             </parameter>
             <parameter>
                 <param_name>preallocated_resources</param_name>


### PR DESCRIPTION
Allows the use of spalloc with external devices, by ignoring virtual vertices until after partitioning; at this point we know how many (physical) chips we need, and so can get a real machine, and add the device chips.