### PR TITLE
fixes screw up with resource tracker for virtual chips

### DIFF
--- a/pacman/model/graphs/impl/graph.py
+++ b/pacman/model/graphs/impl/graph.py
@@ -35,6 +35,8 @@ class Graph(ConstrainedObject, AbstractGraph):
         "_incoming_edges_by_partition_name",
         # The outgoing edge partitions by pre-vertex
         "_outgoing_edge_partitions_by_pre_vertex",
+        # the outgoing partitions by edge
+        "_outgoing_edge_partition_by_edge",
         # The label of the graph
         "_label"]
 
@@ -60,6 +62,7 @@ class Graph(ConstrainedObject, AbstractGraph):
         self._incoming_edges = defaultdict(OrderedSet)
         self._incoming_edges_by_partition_name = defaultdict(list)
         self._outgoing_edge_partitions_by_pre_vertex = defaultdict(OrderedSet)
+        self._outgoing_edge_partition_by_edge = OrderedDict()
         self._label = label
 
     @property
@@ -112,6 +115,12 @@ class Graph(ConstrainedObject, AbstractGraph):
         self._incoming_edges_by_partition_name[
             (edge.post_vertex, outgoing_edge_partition_name)].append(edge)
         self._incoming_edges[edge.post_vertex].add(edge)
+        self._outgoing_edge_partition_by_edge[edge] = partition
+
+    def get_outgoing_partition_for_edge(self, edge):
+        if edge in self._outgoing_edge_partition_by_edge:
+            return self._outgoing_edge_partition_by_edge[edge]
+        return None
 
     @overrides(AbstractGraph.add_outgoing_edge_partition)
     def add_outgoing_edge_partition(self, outgoing_edge_partition):

--- a/pacman/model/graphs/impl/graph.py
+++ b/pacman/model/graphs/impl/graph.py
@@ -35,8 +35,6 @@ class Graph(ConstrainedObject, AbstractGraph):
         "_incoming_edges_by_partition_name",
         # The outgoing edge partitions by pre-vertex
         "_outgoing_edge_partitions_by_pre_vertex",
-        # the outgoing partitions by edge
-        "_outgoing_edge_partition_by_edge",
         # The label of the graph
         "_label"]
 
@@ -62,7 +60,6 @@ class Graph(ConstrainedObject, AbstractGraph):
         self._incoming_edges = defaultdict(OrderedSet)
         self._incoming_edges_by_partition_name = defaultdict(list)
         self._outgoing_edge_partitions_by_pre_vertex = defaultdict(OrderedSet)
-        self._outgoing_edge_partition_by_edge = OrderedDict()
         self._label = label
 
     @property
@@ -115,12 +112,6 @@ class Graph(ConstrainedObject, AbstractGraph):
         self._incoming_edges_by_partition_name[
             (edge.post_vertex, outgoing_edge_partition_name)].append(edge)
         self._incoming_edges[edge.post_vertex].add(edge)
-        self._outgoing_edge_partition_by_edge[edge] = partition
-
-    def get_outgoing_partition_for_edge(self, edge):
-        if edge in self._outgoing_edge_partition_by_edge:
-            return self._outgoing_edge_partition_by_edge[edge]
-        return None
 
     @overrides(AbstractGraph.add_outgoing_edge_partition)
     def add_outgoing_edge_partition(self, outgoing_edge_partition):

--- a/pacman/utilities/algorithm_utilities/machine_algorithm_utilities.py
+++ b/pacman/utilities/algorithm_utilities/machine_algorithm_utilities.py
@@ -1,3 +1,4 @@
+from pacman.utilities import constants
 from spinn_machine import SDRAM, Chip, Link, Processor, Router
 import sys
 
@@ -41,7 +42,7 @@ def create_virtual_chip(machine, link_data, virtual_chip_x, virtual_chip_y):
 
     # create the processors
     processors = list()
-    for virtual_core_id in range(0, 128):
+    for virtual_core_id in range(0, constants.CORES_PER_VIRTUAL_CHIP):
         processors.append(Processor.factory(virtual_core_id))
 
     # connect the real chip with the virtual one

--- a/pacman/utilities/constants.py
+++ b/pacman/utilities/constants.py
@@ -3,6 +3,8 @@ from enum import Enum
 DEFAULT_MASK = 0xfffff800  # DEFAULT LOCATION FOR THE APP MASK
 BITS_IN_KEY = 32
 
+CORES_PER_VIRTUAL_CHIP = 128
+
 EDGES = Enum(
     value="EDGES",
     names=[("EAST", 0),

--- a/pacman/utilities/utility_objs/resource_tracker.py
+++ b/pacman/utilities/utility_objs/resource_tracker.py
@@ -4,7 +4,7 @@ from pacman.model.constraints.placer_constraints\
     import ChipAndCoreConstraint, AbstractPlacerConstraint
 from pacman.model.resources import ResourceContainer, DTCMResource, \
     SDRAMResource, CPUCyclesPerTickResource
-from pacman.utilities import utility_calls
+from pacman.utilities import utility_calls, constants
 from pacman.exceptions import PacmanInvalidParameterException, \
     PacmanValueError, PacmanException
 
@@ -78,7 +78,11 @@ class ResourceTracker(object):
         "_chips_used",
 
         # The number of chips with the n cores currently available
-        "_chips_with_n_cores_available"
+        "_real_chips_with_n_cores_available",
+        
+        # the number of virtual chips with the n cores currently available
+        "_virtual_chips_with_n_cores_available"
+
     ]
 
     def __init__(self, machine, chips=None, preallocated_resources=None):
@@ -156,14 +160,21 @@ class ResourceTracker(object):
             preallocated_resources)
 
         # update tracker for n cores available per chip
-        self._chips_with_n_cores_available = \
+        self._real_chips_with_n_cores_available = \
             [0] * (machine.MAX_CORES_PER_CHIP + 1)
+        self._virtual_chips_with_n_cores_available = \
+            [0] * (constants.CORES_PER_VIRTUAL_CHIP + 1)
+
         for chip in machine.chips:
             pre_allocated = 0
             if (chip.x, chip.y) in self._n_cores_preallocated:
                 pre_allocated = self._n_cores_preallocated[(chip.x, chip.y)]
-            self._chips_with_n_cores_available[
-                chip.n_user_processors - pre_allocated] += 1
+            if chip.virtual:
+                self._virtual_chips_with_n_cores_available[
+                    chip.n_user_processors - pre_allocated] += 1
+            else:
+                self._real_chips_with_n_cores_available[
+                    chip.n_user_processors - pre_allocated] += 1
 
         # Set of (x, y) tuples of coordinates of chips which have available
         # processors
@@ -736,9 +747,16 @@ class ResourceTracker(object):
             processor_id = self._core_tracker[key].pop()
 
         # update number tracker
-        self._chips_with_n_cores_available[len(self._core_tracker[key])] -= 1
-        self._chips_with_n_cores_available[
-            len(self._core_tracker[key]) - 1] += 1
+        if chip.virtual:
+            self._virtual_chips_with_n_cores_available[
+                len(self._core_tracker[key])] -= 1
+            self._virtual_chips_with_n_cores_available[
+                len(self._core_tracker[key]) - 1] += 1
+        else:
+            self._real_chips_with_n_cores_available[
+                len(self._core_tracker[key])] -= 1
+            self._real_chips_with_n_cores_available[
+                len(self._core_tracker[key]) - 1] += 1
 
         if len(self._core_tracker[key]) == self._n_cores_preallocated[key]:
             self._chips_available.remove(key)
@@ -1211,16 +1229,28 @@ class ResourceTracker(object):
         return n_cores, n_chips, max_sdram, n_tags
 
     def get_maximum_cores_available_on_a_chip(self):
-        """ returns the number of available cores of the chip with the maximum\
-        number of available cores
+        """ returns the number of available cores of a real chip with the \
+        maximum number of available cores
 
-        :return: the max cores available on the best chip
+        :return: the max cores available on the best real chip
         :rtype: int
         """
         for n_cores_available, n_chips_with_n_cores in reversed(list(
-                enumerate(self._chips_with_n_cores_available))):
+                enumerate(self._real_chips_with_n_cores_available))):
             if n_chips_with_n_cores != 0:
                 return n_cores_available
+
+    def get_maximum_cores_available_on_a_virtual_chip(self):
+        """ returns the number of available cores of a virtual chip with the \
+        maximum number of available cores
+        :return: the max cores available on the best real chip
+        :rtype: int
+        """
+        for n_cores_available, n_chips_with_n_cores in reversed(list(
+                enumerate(self._virtual_chips_with_n_cores_available))):
+            if n_chips_with_n_cores != 0:
+                return n_cores_available
+
 
     def get_maximum_constrained_resources_available(
             self, resources, constraints):
@@ -1325,10 +1355,16 @@ class ResourceTracker(object):
         self._sdram_tracker[chip_x, chip_y] -= resources.sdram.get_value()
 
         # update number tracker
-        self._chips_with_n_cores_available[
-            len(self._core_tracker[chip_x, chip_y])] -= 1
-        self._chips_with_n_cores_available[
-            len(self._core_tracker[chip_x, chip_y]) + 1] += 1
+        if self._machine.get_chip_at(chip_x, chip_y).virtual:
+            self._virtual_chips_with_n_cores_available[
+                len(self._core_tracker[chip_x, chip_y])] -= 1
+            self._virtual_chips_with_n_cores_available[
+                len(self._core_tracker[chip_x, chip_y]) + 1] += 1
+        else:
+            self._real_chips_with_n_cores_available[
+                len(self._core_tracker[chip_x, chip_y])] -= 1
+            self._real_chips_with_n_cores_available[
+                len(self._core_tracker[chip_x, chip_y]) + 1] += 1
 
         self._core_tracker[chip_x, chip_y].add(processor_id)
 

--- a/pacman/utilities/utility_objs/resource_tracker.py
+++ b/pacman/utilities/utility_objs/resource_tracker.py
@@ -79,7 +79,7 @@ class ResourceTracker(object):
 
         # The number of chips with the n cores currently available
         "_real_chips_with_n_cores_available",
-        
+
         # the number of virtual chips with the n cores currently available
         "_virtual_chips_with_n_cores_available"
 
@@ -1250,7 +1250,6 @@ class ResourceTracker(object):
                 enumerate(self._virtual_chips_with_n_cores_available))):
             if n_chips_with_n_cores != 0:
                 return n_cores_available
-
 
     def get_maximum_constrained_resources_available(
             self, resources, constraints):


### PR DESCRIPTION
this tracks the virtual chips separately to the real chips. It also makes the constant for n_cores_per_virtual_chips a actual constant, and not a magic number (who did that in the first place ;-) ) 

It should fix the issue arren was seeing. It also allows users to ask for the vc with the most usable cores.......if this is usful........im not sure......... but as it comes out of the changes. it might as well be put in. 