### PR TITLE
Support for iptags no ports

### DIFF
--- a/pacman/model/graphs/impl/graph.py
+++ b/pacman/model/graphs/impl/graph.py
@@ -174,7 +174,7 @@ class Graph(ConstrainedObject, AbstractGraph):
 
     @overrides(AbstractGraph.get_outgoing_partition_for_edge)
     def get_outgoing_partition_for_edge(self, edge):
-        return self._outgoing_edge_partition_by_edge[edge]
+        return self._outgoing_edge_partition_by_edge.get(edge, None)
 
     @overrides(AbstractGraph.get_edges_starting_at_vertex)
     def get_edges_starting_at_vertex(self, vertex):

--- a/pacman/operations/tag_allocator_algorithms/basic_tag_allocator.py
+++ b/pacman/operations/tag_allocator_algorithms/basic_tag_allocator.py
@@ -93,7 +93,8 @@ class BasicTagAllocator(object):
                     tag_collector.add_ip_tag(ip_tag, vertex)
                 else:
                     tag_port_tasks.append(
-                        (tag_constraint, board_address, tag, vertex, placement))
+                        (tag_constraint, board_address, tag, vertex,
+                         placement))
 
         if returned_reverse_ip_tags is None:
             return


### PR DESCRIPTION
this functionality allows iptags to not have ports too. not fully tested and have fear that its missing something. but it allows nengo feeds to in theory have multiple instances, if i decide to go down iptag level. Currently leaving it as sdp messages due to the limit of iptags (note we might want a more flexible way to allocate iptags space on the monitor core). 