### PR TITLE
api change to outgoing partition routing entry

### DIFF
--- a/pacman/model/routing_table_by_partition/multicast_routing_table_by_partition_entry.py
+++ b/pacman/model/routing_table_by_partition/multicast_routing_table_by_partition_entry.py
@@ -75,7 +75,7 @@ class MulticastRoutingTableByPartitionEntry(object):
             None if incoming_link is None else int(incoming_link))
 
     @property
-    def out_going_processors(self):
+    def processor_ids(self):
         """ The destination processors of the entry
 
         :rtype: set(int)
@@ -83,7 +83,7 @@ class MulticastRoutingTableByPartitionEntry(object):
         return self._out_going_processors
 
     @property
-    def out_going_links(self):
+    def link_ids(self):
         """ The destination links of the entry
 
         :rtype: set(int)
@@ -177,9 +177,9 @@ class MulticastRoutingTableByPartitionEntry(object):
         valid_incoming_link = self.__merge_noneables(
             self._incoming_link, other.incoming_link, "incoming_link")
         merged_outgoing_processors = self._out_going_processors.union(
-            other.out_going_processors)
+            other.processor_ids)
         merged_outgoing_links = self._out_going_links.union(
-            other.out_going_links)
+            other.link_ids)
 
         return MulticastRoutingTableByPartitionEntry(
             merged_outgoing_links, merged_outgoing_processors,

--- a/pacman/operations/fixed_route_router/fixed_route_router.py
+++ b/pacman/operations/fixed_route_router/fixed_route_router.py
@@ -210,8 +210,8 @@ class FixedRouteRouter(object):
             # only want the first entry, as that will all be the same.
             mc_entry = next(itervalues(mc_entries))
             fixed_route_entry = FixedRouteEntry(
-                link_ids=mc_entry.out_going_links,
-                processor_ids=mc_entry.out_going_processors)
+                link_ids=mc_entry.link_ids,
+                processor_ids=mc_entry.processor_ids)
             x = (chip_x + eth_x) % (machine.max_chip_x + 1)
             y = (chip_y + eth_y) % (machine.max_chip_y + 1)
             key = (x, y)

--- a/pacman/operations/routing_info_allocator_algorithms/malloc_based_routing_allocator/compressible_malloc_based_routing_info_allocator.py
+++ b/pacman/operations/routing_info_allocator_algorithms/malloc_based_routing_allocator/compressible_malloc_based_routing_info_allocator.py
@@ -143,10 +143,10 @@ class CompressibleMallocBasedRoutingInfoAllocator(ElementAllocatorAlgorithm):
                 if partition in continuous:
                     entry_hash = sum(
                         1 << i
-                        for i in entry.out_going_links)
+                        for i in entry.link_ids)
                     entry_hash += sum(
                         1 << (i + 6)
-                        for i in entry.out_going_processors)
+                        for i in entry.processor_ids)
                     partitions_by_route[entry_hash].add(partition)
 
             for entry_hash, partitions in iteritems(partitions_by_route):

--- a/pacman/operations/routing_table_generators/basic_routing_table_generator.py
+++ b/pacman/operations/routing_table_generators/basic_routing_table_generator.py
@@ -41,6 +41,6 @@ class BasicRoutingTableGenerator(object):
                 table.add_multicast_routing_entry(MulticastRoutingEntry(
                     routing_entry_key=key_and_mask.key_combo,
                     defaultable=entry.defaultable, mask=key_and_mask.mask,
-                    link_ids=entry.out_going_links,
-                    processor_ids=entry.out_going_processors))
+                    link_ids=entry.link_ids,
+                    processor_ids=entry.processor_ids))
         return table

--- a/unittests/operations_tests/router_algorithms_tests/test_basic_dijkstra_routing.py
+++ b/unittests/operations_tests/router_algorithms_tests/test_basic_dijkstra_routing.py
@@ -56,12 +56,12 @@ class MyTestCase(unittest.TestCase):
                     partition, x, y)
                 self.assertIsNotNone(entry)
                 chip = machine.get_chip_at(x, y)
-                for p in entry.out_going_processors:
+                for p in entry.processor_ids:
                     self.assertIsNotNone(chip.get_processor_with_id(p))
                     vertex_found = placements.get_vertex_on_processor(x, y, p)
                     vertices_reached.add(vertex_found)
                 seen_entries.add((x, y))
-                for link_id in entry.out_going_links:
+                for link_id in entry.link_ids:
                     link = chip.router.get_link(link_id)
                     self.assertIsNotNone(link)
                     dest_x, dest_y = link.destination_x, link.destination_y


### PR DESCRIPTION
puts it in line with the router table entry api, thus allowing functions that manipulate the router entry can be used to manuiplate the out going partition entry also. aka, router.convert_routing_table_entry_to_spinnaker_route. for nengo purposes of the graph colouring. 