### PR TITLE
Fix virtual placement

### DIFF
--- a/pacman/model/graphs/machine/machine_spinnaker_link_vertex.py
+++ b/pacman/model/graphs/machine/machine_spinnaker_link_vertex.py
@@ -3,6 +3,7 @@ from pacman.model.resources import ResourceContainer
 from .machine_vertex import MachineVertex
 from pacman.model.graphs import (
     AbstractVirtualVertex, AbstractSpiNNakerLinkVertex)
+from pacman.model.constraints.placer_constraints import ChipAndCoreConstraint
 
 
 class MachineSpiNNakerLinkVertex(MachineVertex, AbstractSpiNNakerLinkVertex):
@@ -54,3 +55,5 @@ class MachineSpiNNakerLinkVertex(MachineVertex, AbstractSpiNNakerLinkVertex):
     def set_virtual_chip_coordinates(self, virtual_chip_x, virtual_chip_y):
         self._virtual_chip_x = virtual_chip_x
         self._virtual_chip_y = virtual_chip_y
+        self.add_constraint(ChipAndCoreConstraint(
+            self._virtual_chip_x, self._virtual_chip_y))

--- a/pacman/operations/placer_algorithms/__init__.py
+++ b/pacman/operations/placer_algorithms/__init__.py
@@ -1,5 +1,7 @@
 from .radial_placer import RadialPlacer
 from .basic_placer import BasicPlacer
 from .connective_based_placer import ConnectiveBasedPlacer
+from .one_to_one_placer import OneToOnePlacer
 
-__all__ = ['RadialPlacer', 'BasicPlacer', 'ConnectiveBasedPlacer']
+__all__ = ['RadialPlacer', 'BasicPlacer', 'ConnectiveBasedPlacer',
+           'OneToOnePlacer']

--- a/pacman/operations/placer_algorithms/one_to_one_placer.py
+++ b/pacman/operations/placer_algorithms/one_to_one_placer.py
@@ -1,14 +1,17 @@
 from spinn_utilities.progress_bar import ProgressBar
-from spinn_utilities.ordered_set import OrderedSet
 from pacman.exceptions import (
     PacmanException, PacmanInvalidParameterException, PacmanValueError)
 from pacman.model.placements import Placement, Placements
 from pacman.operations.placer_algorithms import RadialPlacer
 from pacman.utilities.utility_objs import ResourceTracker
 from pacman.utilities.algorithm_utilities.placer_algorithm_utilities import (
-    get_same_chip_vertex_groups, sort_vertices_by_known_constraints)
-from pacman.model.constraints.placer_constraints import SameChipAsConstraint
-from pacman.utilities.utility_calls import is_single
+    get_same_chip_vertex_groups, get_vertices_on_same_chip, group_vertices)
+from pacman.model.constraints.placer_constraints import (
+    SameChipAsConstraint, ChipAndCoreConstraint)
+from pacman.utilities.utility_calls import (
+    is_single, locate_constraints_of_type)
+from pacman.model.graphs import AbstractVirtualVertex
+import functools
 
 
 def _conflict(x, y, post_x, post_y):
@@ -17,6 +20,62 @@ def _conflict(x, y, post_x, post_y):
     if y is not None and post_y is not None and y != post_y:
         return True
     return False
+
+
+def _find_one_to_one_vertices(vertex, graph):
+    """ Find vertices which have one to one connections with the given\
+        vertex, and where their constraints don't force them onto\
+        different chips.
+
+    :param graph: the graph to look for other one to one vertices
+    :param vertex: the vertex to use as a basis for one to one connections
+    :return: set of one to one vertices
+    """
+    # Virtual vertices can't be forced on other chips
+    if isinstance(vertex, AbstractVirtualVertex):
+        return []
+    found_vertices = []
+    vertices_seen = {vertex}
+
+    # look for one to ones leaving this vertex
+    outgoing = graph.get_edges_starting_at_vertex(vertex)
+    vertices_to_try = [
+        edge.post_vertex for edge in outgoing
+        if edge.post_vertex not in vertices_seen]
+    while vertices_to_try:
+        next_vertex = vertices_to_try.pop()
+        if next_vertex not in vertices_seen:
+            vertices_seen.add(next_vertex)
+            edges = graph.get_edges_ending_at_vertex(next_vertex)
+            if is_single(edges):
+                found_vertices.append(next_vertex)
+                outgoing = graph.get_edges_starting_at_vertex(next_vertex)
+                vertices_to_try.extend([
+                    edge.post_vertex for edge in outgoing
+                    if edge.post_vertex not in vertices_seen])
+
+    # look for one to ones entering this vertex
+    incoming = graph.get_edges_ending_at_vertex(vertex)
+    vertices_to_try = [
+        edge.pre_vertex for edge in incoming
+        if edge.pre_vertex not in vertices_seen]
+    while vertices_to_try:
+        next_vertex = vertices_to_try.pop()
+        if next_vertex not in vertices_seen:
+            vertices_seen.add(next_vertex)
+            edges = graph.get_edges_starting_at_vertex(next_vertex)
+            if is_single(edges):
+                found_vertices.append(next_vertex)
+                incoming = graph.get_edges_ending_at_vertex(next_vertex)
+                vertices_to_try.extend([
+                    edge.pre_vertex for edge in incoming
+                    if edge.pre_vertex not in vertices_seen])
+
+    extra_vertices = get_vertices_on_same_chip(vertex, graph)
+    for vertex in extra_vertices:
+        if vertex not in vertices_seen:
+            found_vertices.append(extra_vertices)
+    return found_vertices
 
 
 class OneToOnePlacer(RadialPlacer):
@@ -35,14 +94,19 @@ class OneToOnePlacer(RadialPlacer):
 
         # Get which vertices must be placed on the same chip as another vertex
         same_chip_vertex_groups = get_same_chip_vertex_groups(machine_graph)
-        sorted_vertices = self._sort_vertices_for_one_to_one_connection(
-            machine_graph, same_chip_vertex_groups)
+
+        # Work out the vertices that should be on the same chip by one-to-one
+        # connectivity
+        one_to_one_groups = group_vertices(
+            machine_graph.vertices, functools.partial(
+                _find_one_to_one_vertices, graph=machine_graph))
 
         return self._do_allocation(
-            sorted_vertices, machine, same_chip_vertex_groups, machine_graph)
+            one_to_one_groups, same_chip_vertex_groups, machine, machine_graph)
 
     def _do_allocation(
-            self, vertices, machine, same_chip_vertex_groups, machine_graph):
+            self, one_to_one_groups, same_chip_vertex_groups,
+            machine, machine_graph):
         placements = Placements()
 
         # Iterate over vertices and generate placements
@@ -52,35 +116,85 @@ class OneToOnePlacer(RadialPlacer):
             machine, self._generate_radial_chips(machine))
         all_vertices_placed = set()
 
-        # iterate over vertices
-        for vertex_list in vertices:
-            # if too many one to ones to fit on a chip, allocate individually
-            if len(vertex_list) > machine.maximum_user_cores_on_chip:
-                for vertex in progress.over(vertex_list, False):
-                    self._allocate_individual(
-                        vertex, placements, resource_tracker,
-                        same_chip_vertex_groups, all_vertices_placed)
-                continue
-            allocations = self._get_allocations(resource_tracker, vertex_list)
-            if allocations is not None:
-                # allocate cores to vertices
-                for vertex, (x, y, p, _, _) in progress.over(zip(
-                        vertex_list, allocations), False):
-                    placements.add_placement(Placement(vertex, x, y, p))
+        # Find vertices with harder constraints
+        constrained = list()
+        unconstrained = list()
+        for vertex in machine_graph.vertices:
+            if locate_constraints_of_type(
+                    vertex.constraints, ChipAndCoreConstraint):
+                constrained.append(vertex)
             else:
+                unconstrained.append(vertex)
+
+        # Place vertices with hard constraints
+        for vertex in constrained:
+            self._allocate_individual(
+                vertex, placements, resource_tracker, same_chip_vertex_groups,
+                all_vertices_placed, progress)
+
+        # iterate over the remaining unconstrained (or less constrained)
+        # vertices
+        for vertex in unconstrained:
+
+            # If the vertex has been placed, skip it
+            if vertex in all_vertices_placed:
+                continue
+
+            # Find vertices that are one-to-one connected to this one
+            one_to_one_vertices = one_to_one_groups[vertex]
+
+            # Get unallocated vertices and placements of allocated vertices
+            unallocated = list()
+            chips = list()
+            for vert in one_to_one_vertices:
+                if vert in all_vertices_placed:
+                    placement = placements.get_placement_of_vertex(vert)
+                    chips.append((placement.x, placement.y))
+                else:
+                    unallocated.append(vert)
+
+            # if too many one to ones to fit on a chip, allocate individually
+            if len(unallocated) > \
+                    resource_tracker.get_maximum_cores_available_on_a_chip():
+                for vert in one_to_one_vertices:
+                    if vert not in all_vertices_placed:
+                        self._allocate_individual(
+                            vert, placements, resource_tracker,
+                            same_chip_vertex_groups, all_vertices_placed,
+                            progress)
+                continue
+
+            # Try to allocate all vertices to the same chip
+            allocations = self._get_allocations(
+                resource_tracker, unallocated, progress, placements, chips,
+                all_vertices_placed)
+
+            if allocations is None:
+
                 # Something went wrong, try to allocate each individually
-                for vertex in progress.over(vertex_list, False):
+                for vertex in progress.over(unallocated, False):
                     self._allocate_individual(
                         vertex, placements, resource_tracker,
-                        same_chip_vertex_groups, all_vertices_placed)
+                        same_chip_vertex_groups, all_vertices_placed,
+                        progress)
         progress.end()
         return placements
 
     @staticmethod
-    def _get_allocations(resource_tracker, vertices):
+    def _get_allocations(
+            resource_tracker, vertices, progress, placements, chips,
+            all_vertices_placed):
         try:
-            return resource_tracker.allocate_constrained_group_resources(
-                [(v.resources_required, v.constraints) for v in vertices])
+            allocs = resource_tracker.allocate_constrained_group_resources(
+                [(v.resources_required, v.constraints) for v in vertices],
+                chips)
+
+            # allocate cores to vertices
+            for vertex, (x, y, p, _, _) in progress.over(
+                    zip(vertices, allocs), False):
+                placements.add_placement(Placement(vertex, x, y, p))
+                all_vertices_placed.add(vertex)
+            return allocs
         except (PacmanValueError, PacmanException,
                 PacmanInvalidParameterException):
             return None
@@ -88,130 +202,12 @@ class OneToOnePlacer(RadialPlacer):
     @staticmethod
     def _allocate_individual(
             vertex, placements, tracker, same_chip_vertex_groups,
-            all_vertices_placed):
+            all_vertices_placed, progress):
         if vertex not in all_vertices_placed:
             vertices = same_chip_vertex_groups[vertex]
-
-            if len(vertices) > 1:
-                resources = tracker.allocate_constrained_group_resources([
-                    (v.resources_required, v.constraints) for v in vertices])
-                for (x, y, p, _, _), v in zip(resources, vertices):
-                    placements.add_placement(Placement(v, x, y, p))
-                    all_vertices_placed.add(v)
-            else:
-                (x, y, p, _, _) = tracker.\
-                    allocate_constrained_resources(
-                        vertex.resources_required, vertex.constraints)
-                placements.add_placement(Placement(vertex, x, y, p))
-                all_vertices_placed.add(vertex)
-
-    def _sort_vertices_for_one_to_one_connection(
-            self, machine_graph, same_chip_vertex_groups):
-        """
-
-        :param machine_graph: the graph to place
-        :return: list of sorted vertices
-        """
-        sorted_vertices = list()
-        found_list = set()
-
-        # order vertices based on constraint priority
-        vertices = sort_vertices_by_known_constraints(machine_graph.vertices)
-
-        for vertex in vertices:
-            if vertex not in found_list:
-
-                # vertices that are one to one connected with vertex and are
-                # not forced off chip
-                connected_vertices = self._find_one_to_one_vertices(
-                    vertex, machine_graph)
-
-                # create list for each vertex thats connected haven't already
-                #  been seen before
-                new_list = OrderedSet()
-                for found_vertex in connected_vertices:
-                    if found_vertex not in found_list:
-                        new_list.add(found_vertex)
-
-                # looks for vertices that have same chip constraints but not
-                # found by the one to one connection search.
-                same_chip_vertices = list()
-                for found_vertex in new_list:
-                    for same_chip_constrained_vertex in \
-                            same_chip_vertex_groups[found_vertex]:
-                        if same_chip_constrained_vertex not in new_list:
-                            same_chip_vertices.append(
-                                same_chip_constrained_vertex)
-
-                # add these newly found vertices to the list
-                new_list.update(same_chip_vertices)
-
-                sorted_vertices.append(new_list)
-                found_list.update(new_list)
-
-        # locate vertices which have no output or input, and add them for
-        # placement
-        for vertex in vertices:
-            if vertex not in found_list:
-                sorted_vertices.append([vertex])
-        return sorted_vertices
-
-    @staticmethod
-    def _find_one_to_one_vertices(vertex, graph):
-        """ Find vertices which have one to one connections with the given\
-            vertex, and where their constraints don't force them onto\
-            different chips.
-
-        :param vertex: the vertex to use as a basis for one to one connections
-        :param graph: the graph to look for other one to one vertices
-        :return: set of one to one vertices
-        """
-        x, y, _ = ResourceTracker.get_chip_and_core(vertex.constraints)
-        found_vertices = [vertex]
-        vertices_seen = {vertex}
-
-        # look for one to ones leaving this vertex
-        outgoing = graph.get_edges_starting_at_vertex(vertex)
-        vertices_to_try = [edge.post_vertex for edge in outgoing]
-        while vertices_to_try:
-            next_vertex = vertices_to_try.pop()
-            if next_vertex not in vertices_seen:
-                vertices_seen.add(next_vertex)
-                post_x, post_y, _ = ResourceTracker.get_chip_and_core(
-                    next_vertex.constraints)
-                edges = graph.get_edges_ending_at_vertex(next_vertex)
-                if is_single(edges) and not _conflict(x, y, post_x, post_y):
-                    found_vertices.append(next_vertex)
-                    if post_x is not None:
-                        x = post_x
-                    if post_y is not None:
-                        y = post_y
-                    outgoing = graph.get_edges_starting_at_vertex(next_vertex)
-                    vertices_to_try.extend([
-                        edge.post_vertex for edge in outgoing
-                        if edge.post_vertex not in vertices_seen])
-
-        # look for one to ones entering this vertex
-        incoming = graph.get_edges_ending_at_vertex(vertex)
-        vertices_to_try = [
-            edge.pre_vertex for edge in incoming
-            if edge.pre_vertex not in vertices_seen]
-        while vertices_to_try:
-            next_vertex = vertices_to_try.pop()
-            if next_vertex not in vertices_seen:
-                vertices_seen.add(next_vertex)
-                pre_x, pre_y, _ = ResourceTracker.get_chip_and_core(
-                    next_vertex.constraints)
-                edges = graph.get_edges_starting_at_vertex(next_vertex)
-                if is_single(edges) and not _conflict(x, y, pre_x, pre_y):
-                    found_vertices.append(next_vertex)
-                    if pre_x is not None:
-                        x = pre_x
-                    if pre_y is not None:
-                        y = pre_y
-                    incoming = graph.get_edges_ending_at_vertex(next_vertex)
-                    vertices_to_try.extend([
-                        edge.pre_vertex for edge in incoming
-                        if edge.pre_vertex not in vertices_seen])
-
-        return found_vertices
+            resources = tracker.allocate_constrained_group_resources([
+                (v.resources_required, v.constraints) for v in vertices])
+            for (x, y, p, _, _), v in progress.over(
+                    zip(resources, vertices), False):
+                placements.add_placement(Placement(v, x, y, p))
+                all_vertices_placed.add(v)

--- a/pacman/operations/placer_algorithms/one_to_one_placer.py
+++ b/pacman/operations/placer_algorithms/one_to_one_placer.py
@@ -127,7 +127,7 @@ class OneToOnePlacer(RadialPlacer):
 
         # Place vertices with hard constraints
         for vertex in constrained:
-            self._allocate_individual(
+            self._allocate_same_chip_as_group(
                 vertex, placements, resource_tracker, same_chip_vertex_groups,
                 all_vertices_placed, progress)
 
@@ -156,14 +156,14 @@ class OneToOnePlacer(RadialPlacer):
             if len(unallocated) > \
                     resource_tracker.get_maximum_cores_available_on_a_chip():
                 for vert in unallocated:
-                    self._allocate_individual(
+                    self._allocate_same_chip_as_group(
                         vert, placements, resource_tracker,
                         same_chip_vertex_groups, all_vertices_placed,
                         progress)
                 continue
 
             # Try to allocate all vertices to the same chip
-            success = self._get_allocations(
+            success = self._allocate_one_to_one_group(
                 resource_tracker, unallocated, progress, placements, chips,
                 all_vertices_placed)
 
@@ -171,7 +171,7 @@ class OneToOnePlacer(RadialPlacer):
 
                 # Something went wrong, try to allocate each individually
                 for vertex in progress.over(unallocated, False):
-                    self._allocate_individual(
+                    self._allocate_same_chip_as_group(
                         vertex, placements, resource_tracker,
                         same_chip_vertex_groups, all_vertices_placed,
                         progress)
@@ -179,7 +179,7 @@ class OneToOnePlacer(RadialPlacer):
         return placements
 
     @staticmethod
-    def _get_allocations(
+    def _allocate_one_to_one_group(
             resource_tracker, vertices, progress, placements, chips,
             all_vertices_placed):
         try:
@@ -198,7 +198,7 @@ class OneToOnePlacer(RadialPlacer):
             return False
 
     @staticmethod
-    def _allocate_individual(
+    def _allocate_same_chip_as_group(
             vertex, placements, tracker, same_chip_vertex_groups,
             all_vertices_placed, progress):
         if vertex not in all_vertices_placed:

--- a/pacman/operations/placer_algorithms/one_to_one_placer.py
+++ b/pacman/operations/placer_algorithms/one_to_one_placer.py
@@ -156,20 +156,19 @@ class OneToOnePlacer(RadialPlacer):
             # if too many one to ones to fit on a chip, allocate individually
             if len(unallocated) > \
                     resource_tracker.get_maximum_cores_available_on_a_chip():
-                for vert in one_to_one_vertices:
-                    if vert not in all_vertices_placed:
-                        self._allocate_individual(
-                            vert, placements, resource_tracker,
-                            same_chip_vertex_groups, all_vertices_placed,
-                            progress)
+                for vert in unallocated:
+                    self._allocate_individual(
+                        vert, placements, resource_tracker,
+                        same_chip_vertex_groups, all_vertices_placed,
+                        progress)
                 continue
 
             # Try to allocate all vertices to the same chip
-            allocations = self._get_allocations(
+            success = self._get_allocations(
                 resource_tracker, unallocated, progress, placements, chips,
                 all_vertices_placed)
 
-            if allocations is None:
+            if not success:
 
                 # Something went wrong, try to allocate each individually
                 for vertex in progress.over(unallocated, False):
@@ -194,10 +193,10 @@ class OneToOnePlacer(RadialPlacer):
                     zip(vertices, allocs), False):
                 placements.add_placement(Placement(vertex, x, y, p))
                 all_vertices_placed.add(vertex)
-            return allocs
+            return True
         except (PacmanValueError, PacmanException,
                 PacmanInvalidParameterException):
-            return None
+            return False
 
     @staticmethod
     def _allocate_individual(

--- a/pacman/operations/placer_algorithms/one_to_one_placer.py
+++ b/pacman/operations/placer_algorithms/one_to_one_placer.py
@@ -34,7 +34,7 @@ def _find_one_to_one_vertices(vertex, graph):
     # Virtual vertices can't be forced on other chips
     if isinstance(vertex, AbstractVirtualVertex):
         return []
-    found_vertices = []
+    found_vertices = set()
     vertices_seen = {vertex}
 
     # look for one to ones leaving this vertex
@@ -48,7 +48,7 @@ def _find_one_to_one_vertices(vertex, graph):
             vertices_seen.add(next_vertex)
             edges = graph.get_edges_ending_at_vertex(next_vertex)
             if is_single(edges):
-                found_vertices.append(next_vertex)
+                found_vertices.add(next_vertex)
                 outgoing = graph.get_edges_starting_at_vertex(next_vertex)
                 vertices_to_try.extend([
                     edge.post_vertex for edge in outgoing
@@ -65,7 +65,7 @@ def _find_one_to_one_vertices(vertex, graph):
             vertices_seen.add(next_vertex)
             edges = graph.get_edges_starting_at_vertex(next_vertex)
             if is_single(edges):
-                found_vertices.append(next_vertex)
+                found_vertices.add(next_vertex)
                 incoming = graph.get_edges_ending_at_vertex(next_vertex)
                 vertices_to_try.extend([
                     edge.pre_vertex for edge in incoming
@@ -73,8 +73,7 @@ def _find_one_to_one_vertices(vertex, graph):
 
     extra_vertices = get_vertices_on_same_chip(vertex, graph)
     for vertex in extra_vertices:
-        if vertex not in vertices_seen:
-            found_vertices.append(extra_vertices)
+        found_vertices.add(vertex)
     return found_vertices
 
 

--- a/pacman/utilities/algorithm_utilities/placer_algorithm_utilities.py
+++ b/pacman/utilities/algorithm_utilities/placer_algorithm_utilities.py
@@ -3,6 +3,8 @@ from pacman.model.constraints.placer_constraints import (
     RadialPlacementFromChipConstraint)
 from pacman.model.graphs.common.edge_traffic_type import EdgeTrafficType
 from pacman.utilities import VertexSorter, ConstraintOrder
+import functools
+from pacman.model.graphs.abstract_virtual_vertex import AbstractVirtualVertex
 
 
 def sort_vertices_by_known_constraints(vertices):
@@ -18,26 +20,55 @@ def sort_vertices_by_known_constraints(vertices):
     return sorter.sort(vertices)
 
 
+def get_vertices_on_same_chip(vertex, graph):
+    """ Get the vertices that must be on the same chip as the given vertex
+
+    :param vertex: The vertex to search with
+    :param graph: The graph containing the vertex
+    """
+    # Virtual vertices can't be forced on different chips
+    if isinstance(vertex, AbstractVirtualVertex):
+        return []
+    same_chip_as_vertices = list()
+    for constraint in vertex.constraints:
+        if isinstance(constraint, SameChipAsConstraint):
+            same_chip_as_vertices.append(constraint.vertex)
+
+    for edge in filter(
+            lambda edge: edge.traffic_type == EdgeTrafficType.SDRAM,
+            graph.get_edges_starting_at_vertex(vertex)):
+        same_chip_as_vertices.append(edge.post_vertex)
+    return same_chip_as_vertices
+
+
 def get_same_chip_vertex_groups(graph):
     """ Get a dictionary of vertex to list of vertices that must be placed on\
        the same chip
+
+    :param graph: The graph containing the vertices
+    """
+    return group_vertices(graph.vertices, functools.partial(
+        get_vertices_on_same_chip, graph=graph))
+
+
+def group_vertices(vertices, same_group_as_function):
+    """ Group vertices according to some function that can indicate the groups\
+        that any vertex can be contained within
+
+    :param vertices: The vertices to group
+    :param same_group_as_function:\
+        A function which takes a vertex and returns vertices that should be in\
+        the same group (excluding the original vertex)
+    :return:\
+        A dictionary of vertex to list of vertices that are grouped with it
     """
 
     # Dict of vertex to list of vertices on same chip (repeated lists expected)
     same_chip_vertices = dict()
 
-    for vertex in graph.vertices:
-        # Find all vertices that have a same chip constraint associated with
-        #  this vertex
-        same_chip_as_vertices = list()
-        for constraint in vertex.constraints:
-            if isinstance(constraint, SameChipAsConstraint):
-                same_chip_as_vertices.append(constraint.vertex)
-
-        for edge in filter(
-                lambda edge: edge.traffic_type == EdgeTrafficType.SDRAM,
-                graph.get_edges_starting_at_vertex(vertex)):
-            same_chip_as_vertices.append(edge.post_vertex)
+    for vertex in vertices:
+        # Find all vertices that should be grouped with this vertex
+        same_chip_as_vertices = same_group_as_function(vertex)
 
         if same_chip_as_vertices:
             # Go through all the vertices that want to be on the same chip as

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
 flake8
-pytest>=2.8
+pytest>=3.6
 pytest-cov
 sphinx==1.5.3

--- a/unittests/operations_tests/placer_algorithms_tests/test_one_to_one_placer.py
+++ b/unittests/operations_tests/placer_algorithms_tests/test_one_to_one_placer.py
@@ -4,29 +4,116 @@ from pacman.model.graphs.machine import (
     MachineGraph, SimpleMachineVertex, MachineSpiNNakerLinkVertex, MachineEdge)
 from pacman.model.resources.resource_container import ResourceContainer
 from pacman.model.constraints.placer_constraints import ChipAndCoreConstraint
-from pacman.model.resources.sdram_resource import SDRAMResource
 from pacman.operations.chip_id_allocator_algorithms \
     import MallocBasedChipIdAllocator
 from pacman.operations.placer_algorithms import OneToOnePlacer
 
 
 def test_virtual_vertices_one_to_one():
+    """ Test that the placer works with a virtual vertex
+    """
+
+    # Create a graph with a virtual vertex
     machine_graph = MachineGraph("Test")
-    virtual_vertex = MachineSpiNNakerLinkVertex(spinnaker_link_id=0)
+    virtual_vertex = MachineSpiNNakerLinkVertex(
+        spinnaker_link_id=0, label="Virtual")
     machine_graph.add_vertex(virtual_vertex)
-    for _ in range(3):
+
+    # These vertices are fixed on 0, 0
+    misc_vertices = list()
+    for i in range(3):
         misc_vertex = SimpleMachineVertex(
             resources=ResourceContainer(), constraints=[
-                ChipAndCoreConstraint(0, 0)])
+                ChipAndCoreConstraint(0, 0)],
+            label="Fixed_0_0_{}".format(i))
         machine_graph.add_vertex(misc_vertex)
-    for _ in range(16):
+        misc_vertices.append(misc_vertex)
+
+    # These vertices are 1-1 connected to the virtual vertex
+    one_to_one_vertices = list()
+    for i in range(16):
         one_to_one_vertex = SimpleMachineVertex(
-            resources=ResourceContainer(sdram=SDRAMResource(10)))
+            resources=ResourceContainer(),
+            label="Vertex_{}".format(i))
         machine_graph.add_vertex(one_to_one_vertex)
         edge = MachineEdge(virtual_vertex, one_to_one_vertex)
         machine_graph.add_edge(edge, "SPIKES")
+        one_to_one_vertices.append(one_to_one_vertex)
 
+    # Get and extend the machine for the virtual chip
     machine = VirtualMachine(version=5)
     extended_machine = MallocBasedChipIdAllocator()(machine, machine_graph)
 
+    # Do placements
     placements = OneToOnePlacer()(machine_graph, extended_machine)
+
+    # The virtual vertex should be on a virtual chip
+    placement = placements.get_placement_of_vertex(virtual_vertex)
+    assert machine.get_chip_at(placement.x, placement.y).virtual
+
+    # The 0, 0 vertices should be on 0, 0
+    for vertex in misc_vertices:
+        placement = placements.get_placement_of_vertex(vertex)
+        assert placement.x == placement.y == 0
+
+    # The other vertices should *not* be on a virtual chip
+    for vertex in one_to_one_vertices:
+        placement = placements.get_placement_of_vertex(vertex)
+        assert not machine.get_chip_at(placement.x, placement.y).virtual
+
+
+def test_one_to_one():
+    """ Test normal 1-1 placement
+    """
+
+    # Create a graph
+    machine_graph = MachineGraph("Test")
+
+    # Connect a set of vertices in a chain of length 3
+    one_to_one_chains = list()
+    for i in range(10):
+        last_vertex = None
+        chain = list()
+        for j in range(3):
+            vertex = SimpleMachineVertex(
+                resources=ResourceContainer(),
+                label="Vertex_{}_{}".format(i, j))
+            machine_graph.add_vertex(vertex)
+            if last_vertex is not None:
+                edge = MachineEdge(last_vertex, vertex)
+                machine_graph.add_edge(edge, "SPIKES")
+            last_vertex = vertex
+            chain.append(vertex)
+        one_to_one_chains.append(chain)
+
+    # Connect a set of 20 vertices in a chain
+    too_many_vertices = list()
+    last_vertex = None
+    for i in range(20):
+        vertex = SimpleMachineVertex(
+            resources=ResourceContainer(), label="Vertex_{}".format(i))
+        machine_graph.add_vertex(vertex)
+        if last_vertex is not None:
+            edge = MachineEdge(last_vertex, vertex)
+            machine_graph.add_edge(edge, "SPIKES")
+        too_many_vertices.append(vertex)
+        last_vertex = vertex
+
+    # Do placements
+    machine = VirtualMachine(version=5)
+    placements = OneToOnePlacer()(machine_graph, machine)
+
+    # The 1-1 connected vertices should be on the same chip
+    for chain in one_to_one_chains:
+        first_placement = placements.get_placement_of_vertex(chain[0])
+        for i in range(1, 3):
+            placement = placements.get_placement_of_vertex(chain[i])
+            assert placement.x == first_placement.x
+            assert placement.y == first_placement.y
+
+    # The other vertices should be on more than one chip
+    too_many_chips = set()
+    for vertex in too_many_vertices:
+        placement = placements.get_placement_of_vertex(vertex)
+        too_many_chips.add((placement.x, placement.y))
+    assert len(too_many_chips) > 1

--- a/unittests/operations_tests/placer_algorithms_tests/test_one_to_one_placer.py
+++ b/unittests/operations_tests/placer_algorithms_tests/test_one_to_one_placer.py
@@ -1,3 +1,5 @@
+from pacman.exceptions import PacmanException
+from pacman.model.graphs.common import EdgeTrafficType
 from spinn_machine.virtual_machine import VirtualMachine
 
 from pacman.model.graphs.machine import (
@@ -117,3 +119,33 @@ def test_one_to_one():
         placement = placements.get_placement_of_vertex(vertex)
         too_many_chips.add((placement.x, placement.y))
     assert len(too_many_chips) > 1
+
+def test_sdram_links():
+    """ Test sdram edges which should explode
+        """
+
+    # Create a graph
+    machine_graph = MachineGraph("Test")
+
+    # Connect a set of vertices in a chain of length 3
+    last_vertex = None
+    for x in range(20):
+        vertex = SimpleMachineVertex(
+            resources=ResourceContainer(),
+            label="Vertex_{}".format(x))
+        machine_graph.add_vertex(vertex)
+        last_vertex = vertex
+
+    for vertex in machine_graph.vertices:
+        edge = MachineEdge(vertex, last_vertex,
+                           traffic_type=EdgeTrafficType.SDRAM)
+
+    # Do placements
+    machine = VirtualMachine(version=5)
+    try:
+        OneToOnePlacer()(machine_graph, machine)
+        raise Exception("should blow up here")
+    except PacmanException:
+        pass
+
+

--- a/unittests/operations_tests/placer_algorithms_tests/test_one_to_one_placer.py
+++ b/unittests/operations_tests/placer_algorithms_tests/test_one_to_one_placer.py
@@ -149,5 +149,3 @@ def test_sdram_links():
         raise Exception("should blow up here")
     except PacmanException as e:
         pass
-
-

--- a/unittests/operations_tests/placer_algorithms_tests/test_one_to_one_placer.py
+++ b/unittests/operations_tests/placer_algorithms_tests/test_one_to_one_placer.py
@@ -1,0 +1,32 @@
+from spinn_machine.virtual_machine import VirtualMachine
+
+from pacman.model.graphs.machine import (
+    MachineGraph, SimpleMachineVertex, MachineSpiNNakerLinkVertex, MachineEdge)
+from pacman.model.resources.resource_container import ResourceContainer
+from pacman.model.constraints.placer_constraints import ChipAndCoreConstraint
+from pacman.model.resources.sdram_resource import SDRAMResource
+from pacman.operations.chip_id_allocator_algorithms \
+    import MallocBasedChipIdAllocator
+from pacman.operations.placer_algorithms import OneToOnePlacer
+
+
+def test_virtual_vertices_one_to_one():
+    machine_graph = MachineGraph("Test")
+    virtual_vertex = MachineSpiNNakerLinkVertex(spinnaker_link_id=0)
+    machine_graph.add_vertex(virtual_vertex)
+    for _ in range(3):
+        misc_vertex = SimpleMachineVertex(
+            resources=ResourceContainer(), constraints=[
+                ChipAndCoreConstraint(0, 0)])
+        machine_graph.add_vertex(misc_vertex)
+    for _ in range(16):
+        one_to_one_vertex = SimpleMachineVertex(
+            resources=ResourceContainer(sdram=SDRAMResource(10)))
+        machine_graph.add_vertex(one_to_one_vertex)
+        edge = MachineEdge(virtual_vertex, one_to_one_vertex)
+        machine_graph.add_edge(edge, "SPIKES")
+
+    machine = VirtualMachine(version=5)
+    extended_machine = MallocBasedChipIdAllocator()(machine, machine_graph)
+
+    placements = OneToOnePlacer()(machine_graph, extended_machine)

--- a/unittests/operations_tests/placer_algorithms_tests/test_one_to_one_placer.py
+++ b/unittests/operations_tests/placer_algorithms_tests/test_one_to_one_placer.py
@@ -120,6 +120,7 @@ def test_one_to_one():
         too_many_chips.add((placement.x, placement.y))
     assert len(too_many_chips) > 1
 
+
 def test_sdram_links():
     """ Test sdram edges which should explode
         """

--- a/unittests/operations_tests/placer_algorithms_tests/test_one_to_one_placer.py
+++ b/unittests/operations_tests/placer_algorithms_tests/test_one_to_one_placer.py
@@ -147,5 +147,5 @@ def test_sdram_links():
     try:
         OneToOnePlacer()(machine_graph, machine)
         raise Exception("should blow up here")
-    except PacmanException as e:
+    except PacmanException:
         pass

--- a/unittests/operations_tests/placer_algorithms_tests/test_one_to_one_placer.py
+++ b/unittests/operations_tests/placer_algorithms_tests/test_one_to_one_placer.py
@@ -139,13 +139,14 @@ def test_sdram_links():
     for vertex in machine_graph.vertices:
         edge = MachineEdge(vertex, last_vertex,
                            traffic_type=EdgeTrafficType.SDRAM)
+        machine_graph.add_edge(edge, "SDRAM")
 
     # Do placements
     machine = VirtualMachine(version=5)
     try:
         OneToOnePlacer()(machine_graph, machine)
         raise Exception("should blow up here")
-    except PacmanException:
+    except PacmanException as e:
         pass
 
 

--- a/unittests/operations_tests/placer_algorithms_tests/test_sdram_edge_placement.py
+++ b/unittests/operations_tests/placer_algorithms_tests/test_sdram_edge_placement.py
@@ -43,8 +43,8 @@ class TestSameChipConstraint(unittest.TestCase):
         for edge in sdram_edges:
             pre_place = placements.get_placement_of_vertex(edge.pre_vertex)
             post_place = placements.get_placement_of_vertex(edge.post_vertex)
-            self.assert_(pre_place.x == post_place.x)
-            self.assert_(pre_place.y == post_place.y)
+            assert pre_place.x == post_place.x
+            assert pre_place.y == post_place.y
 
     def test_one_to_one(self):
         self._do_test(OneToOnePlacer())

--- a/unittests/operations_tests/placer_algorithms_tests/test_virtual_placement.py
+++ b/unittests/operations_tests/placer_algorithms_tests/test_virtual_placement.py
@@ -1,0 +1,25 @@
+import pytest
+
+from pacman.operations.placer_algorithms import (
+    OneToOnePlacer, BasicPlacer, RadialPlacer)
+from pacman.model.graphs.machine import (
+    MachineGraph, MachineSpiNNakerLinkVertex)
+from pacman.operations.chip_id_allocator_algorithms import (
+    MallocBasedChipIdAllocator)
+
+from spinn_machine import VirtualMachine
+
+
+@pytest.mark.parametrize(
+    "placer", [OneToOnePlacer(), BasicPlacer(), RadialPlacer()])
+def test_virtual_placement(placer):
+    machine = VirtualMachine(version=5)
+    graph = MachineGraph("Test")
+    virtual_vertex = MachineSpiNNakerLinkVertex(spinnaker_link_id=0)
+    graph.add_vertex(virtual_vertex)
+    extended_machine = MallocBasedChipIdAllocator()(machine, graph)
+    placements = placer(graph, extended_machine)
+
+    placement = placements.get_placement_of_vertex(virtual_vertex)
+    chip = extended_machine.get_chip_at(placement.x, placement.y)
+    assert chip.virtual

--- a/unittests/utilities_tests/test_format_converters.py
+++ b/unittests/utilities_tests/test_format_converters.py
@@ -14,6 +14,7 @@ from pacman.utilities.file_format_converters import (
     ConvertToFileCoreAllocations, ConvertToMemoryMultiCastRoutes,
     ConvertToMemoryPlacements, CreateConstraintsToFile)
 from pacman.utilities.utility_calls import md5, ident
+from pacman.operations.chip_id_allocator_algorithms.malloc_based_chip_id_allocator import MallocBasedChipIdAllocator
 
 
 def test_convert_to_file_core_allocations(tmpdir):
@@ -193,12 +194,12 @@ def test_create_constraints_to_file(tmpdir):
         ChipAndCoreConstraint(1, 1, 3)])
     graph.add_vertex(v0)
     v0_id = ident(v0)
-    v1 = MachineSpiNNakerLinkVertex(2, constraints=[
-        ChipAndCoreConstraint(1, 1)])
+    v1 = MachineSpiNNakerLinkVertex(0)
     v1.set_virtual_chip_coordinates(0, 2)
     graph.add_vertex(v1)
     v1_id = ident(v1)
 
+    machine = MallocBasedChipIdAllocator()(machine, graph)
     algo = CreateConstraintsToFile()
     fn = tmpdir.join("foo.json")
     filename, mapping = algo(graph, machine, str(fn))
@@ -225,10 +226,10 @@ def test_create_constraints_to_file(tmpdir):
             "resource": "reverse_iptag", "range": [0, 1], "vertex": v0_id},
         {
             "type": "route_endpoint",
-            "direction": "south", "vertex": v1_id},
+            "direction": "west", "vertex": v1_id},
         {
             "type": "location",
-            "location": [1, 0], "vertex": v1_id}]
+            "location": [0, 0], "vertex": v1_id}]
     assert obj == baseline
 
 

--- a/unittests/utilities_tests/test_format_converters.py
+++ b/unittests/utilities_tests/test_format_converters.py
@@ -14,7 +14,8 @@ from pacman.utilities.file_format_converters import (
     ConvertToFileCoreAllocations, ConvertToMemoryMultiCastRoutes,
     ConvertToMemoryPlacements, CreateConstraintsToFile)
 from pacman.utilities.utility_calls import md5, ident
-from pacman.operations.chip_id_allocator_algorithms.malloc_based_chip_id_allocator import MallocBasedChipIdAllocator
+from pacman.operations.chip_id_allocator_algorithms \
+    import MallocBasedChipIdAllocator
 
 
 def test_convert_to_file_core_allocations(tmpdir):


### PR DESCRIPTION
Fixes #190.  Replaces #191.

The issue turned out to be that the one-to-one placer was not ordering constraints correctly, so it was possible for it to assign vertices to a chip and then not have enough space for vertices constrained to be placed on that chip.

The fix required a fair amount of refactoring of the code, but I think it is in a better place for it, with easier to understand code (I hope).  Tests have also been added to test for the specific case, and for one-to-one placement in general.