### PR TITLE
no need to allocate a list of len 0

### DIFF
--- a/pacman/operations/placer_algorithms/one_to_one_placer.py
+++ b/pacman/operations/placer_algorithms/one_to_one_placer.py
@@ -47,7 +47,8 @@ def _find_one_to_one_vertices(vertex, graph):
         if edge.post_vertex not in vertices_seen]
     while vertices_to_try:
         next_vertex = vertices_to_try.pop()
-        if next_vertex not in vertices_seen:
+        if next_vertex not in vertices_seen and \
+                not isinstance(next_vertex, AbstractVirtualVertex):
             vertices_seen.add(next_vertex)
             edges = graph.get_edges_ending_at_vertex(next_vertex)
             if is_single(edges):
@@ -147,21 +148,21 @@ class OneToOnePlacer(RadialPlacer):
                         "with the OneToOnePlacer algorithm; use the "
                         "RadialPlacer algorithm instead")
 
-        # Find vertices with harder constraints
-        constrained = list()
         unconstrained = list()
+        # Find and place vertices with hard constraints
         for vertex in machine_graph.vertices:
-            if locate_constraints_of_type(
+            if isinstance(vertex, AbstractVirtualVertex):
+                placements.add_placement(Placement(
+                    vertex, vertex.virtual_chip_x, vertex.virtual_chip_y, 0))
+                all_vertices_placed.add(vertex)
+            elif locate_constraints_of_type(
                     vertex.constraints, ChipAndCoreConstraint):
-                constrained.append(vertex)
+                self._allocate_same_chip_as_group(
+                    vertex, placements, resource_tracker,
+                    same_chip_vertex_groups,
+                    all_vertices_placed, progress)
             else:
                 unconstrained.append(vertex)
-
-        # Place vertices with hard constraints
-        for vertex in constrained:
-            self._allocate_same_chip_as_group(
-                vertex, placements, resource_tracker, same_chip_vertex_groups,
-                all_vertices_placed, progress)
 
         for grouped_vertices in one_to_one_groups:
             # Get unallocated vertices and placements of allocated vertices

--- a/pacman/operations/placer_algorithms/one_to_one_placer.py
+++ b/pacman/operations/placer_algorithms/one_to_one_placer.py
@@ -174,7 +174,7 @@ class OneToOnePlacer(RadialPlacer):
                 else:
                     unallocated.append(vert)
 
-            if len(unallocated) <=\
+            if 0 < len(unallocated) <=\
                     resource_tracker.get_maximum_cores_available_on_a_chip():
                 # Try to allocate all vertices to the same chip
                 self._allocate_one_to_one_group(


### PR DESCRIPTION
If you put constraints on all population there are no unallocated ones so calling 
self._allocate_one_to_one_group
makes no sense and give a weird exception.

found with:

import spynnaker8 as sim
from pacman.model.constraints.placer_constraints import (
    ChipAndCoreConstraint)

sim.setup(timestep=1.0)
sim.set_number_of_neurons_per_core(sim.IF_curr_exp, 100)

input = sim.Population(10, sim.SpikeSourceArray(
    spike_times=[0]), label="input")
input.set_constraint(ChipAndCoreConstraint(2, 2, 4))

pop_1 = sim.Population(10, sim.IF_curr_exp(), label="pop_1")
pop_1.set_constraint(ChipAndCoreConstraint(0, 0, 4))

input_proj = sim.Projection(input, pop_1, sim.OneToOneConnector(),
                            synapse_type=sim.StaticSynapse(weight=5, delay=1))

pop_2 = sim.Population(10, sim.IF_curr_exp(), label="pop_2")
pop_2.set_constraint(ChipAndCoreConstraint(4, 4, 4))

sim.Projection(pop_1, pop_2, sim.OneToOneConnector(),
               synapse_type=sim.StaticSynapse(weight=5, delay=1))

simtime = 10
sim.run(simtime)