### PR TITLE
Multi Region Sdram 

### DIFF
--- a/pacman/model/resources/__init__.py
+++ b/pacman/model/resources/__init__.py
@@ -20,6 +20,7 @@ from .cpu_cycles_per_tick_resource import CPUCyclesPerTickResource
 from .dtcm_resource import DTCMResource
 from .element_free_space import ElementFreeSpace
 from .iptag_resource import IPtagResource
+from .multi_region_sdram import MultiRegionSDRAM
 from .pre_allocated_resource_container import PreAllocatedResourceContainer
 from .resource_container import ResourceContainer
 from .reverse_iptag_resource import ReverseIPtagResource
@@ -35,8 +36,8 @@ from .variable_sdram import VariableSDRAM
 
 __all__ = ["AbstractSDRAM", "ConstantSDRAM", "CoreResource",
            "CPUCyclesPerTickResource", "DTCMResource",
-           "ElementFreeSpace", "IPtagResource", "ResourceContainer",
-           "ReverseIPtagResource",
+           "ElementFreeSpace", "IPtagResource", "MultiRegionSDRAM",
+           "ResourceContainer", "ReverseIPtagResource",
            "PreAllocatedResourceContainer", "SpecificChipSDRAMResource",
            "SpecificCoreResource", "SpecificBoardIPtagResource",
            "SpecificBoardReverseIPtagResource", "VariableSDRAM"]

--- a/pacman/model/resources/abstract_sdram.py
+++ b/pacman/model/resources/abstract_sdram.py
@@ -81,10 +81,11 @@ class AbstractSDRAM(object):
         return other.per_timestep == self.per_timestep
 
     @abstractmethod
-    def report(self, indent = "", preamble="", target=None):
+    def report(self, timesteps, indent = "", preamble="", target=None):
         """
         Writes a description of this sdram to the target
 
+        :param int timesteps:  Number of timesteps to do total cost for
         :param String indent: Text at the start of this and all children
         :param String preamble:
             Additional text at the start but not in children

--- a/pacman/model/resources/abstract_sdram.py
+++ b/pacman/model/resources/abstract_sdram.py
@@ -81,7 +81,7 @@ class AbstractSDRAM(object):
         return other.per_timestep == self.per_timestep
 
     @abstractmethod
-    def report(self, timesteps, indent = "", preamble="", target=None):
+    def report(self, timesteps, indent="", preamble="", target=None):
         """
         Writes a description of this sdram to the target
 

--- a/pacman/model/resources/abstract_sdram.py
+++ b/pacman/model/resources/abstract_sdram.py
@@ -72,3 +72,10 @@ class AbstractSDRAM(object):
         .. warn:
             May well be zero.
         """
+
+    def __eq__(self, other):
+        if not isinstance(other, AbstractSDRAM):
+            return False
+        if other.fixed != self.fixed:
+            return False
+        return other.per_timestep == self.per_timestep

--- a/pacman/model/resources/abstract_sdram.py
+++ b/pacman/model/resources/abstract_sdram.py
@@ -79,3 +79,14 @@ class AbstractSDRAM(object):
         if other.fixed != self.fixed:
             return False
         return other.per_timestep == self.per_timestep
+
+    @abstractmethod
+    def report(self, indent = "", preamble="", target=None):
+        """
+        Writes a description of this sdram to the target
+
+        :param String indent: Text at the start of this and all children
+        :param String preamble:
+            Additional text at the start but not in children
+        :param file target: Where to write the output. None is stanrd print
+        """

--- a/pacman/model/resources/constant_sdram.py
+++ b/pacman/model/resources/constant_sdram.py
@@ -74,5 +74,5 @@ class ConstantSDRAM(AbstractSDRAM):
             return other - self
 
     @overrides(AbstractSDRAM.report)
-    def report(self, indent = "", preamble="", target=None):
+    def report(self, timesteps, indent = "", preamble="", target=None):
         print(indent, preamble, "Constant {} bytes".format(self._sdram), file=target)

--- a/pacman/model/resources/constant_sdram.py
+++ b/pacman/model/resources/constant_sdram.py
@@ -77,4 +77,4 @@ class ConstantSDRAM(AbstractSDRAM):
     @overrides(AbstractSDRAM.report)
     def report(self, timesteps, indent="", preamble="", target=None):
         print_(indent, preamble, "Constant {} bytes".format(self._sdram),
-              file=target)
+               file=target)

--- a/pacman/model/resources/constant_sdram.py
+++ b/pacman/model/resources/constant_sdram.py
@@ -74,5 +74,6 @@ class ConstantSDRAM(AbstractSDRAM):
             return other - self
 
     @overrides(AbstractSDRAM.report)
-    def report(self, timesteps, indent = "", preamble="", target=None):
-        print(indent, preamble, "Constant {} bytes".format(self._sdram), file=target)
+    def report(self, timesteps, indent="", preamble="", target=None):
+        print(indent, preamble, "Constant {} bytes".format(self._sdram),
+              file=target)

--- a/pacman/model/resources/constant_sdram.py
+++ b/pacman/model/resources/constant_sdram.py
@@ -13,6 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from six import print_
 from spinn_utilities.overrides import overrides
 from .abstract_sdram import AbstractSDRAM
 
@@ -75,5 +76,5 @@ class ConstantSDRAM(AbstractSDRAM):
 
     @overrides(AbstractSDRAM.report)
     def report(self, timesteps, indent="", preamble="", target=None):
-        print(indent, preamble, "Constant {} bytes".format(self._sdram),
+        print_(indent, preamble, "Constant {} bytes".format(self._sdram),
               file=target)

--- a/pacman/model/resources/constant_sdram.py
+++ b/pacman/model/resources/constant_sdram.py
@@ -13,6 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from spinn_utilities.overrides import overrides
 from .abstract_sdram import AbstractSDRAM
 
 
@@ -33,14 +34,17 @@ class ConstantSDRAM(AbstractSDRAM):
         """
         self._sdram = sdram
 
+    @overrides(AbstractSDRAM.get_total_sdram)
     def get_total_sdram(self, n_timesteps):  # @UnusedVariable
         return self._sdram
 
     @property
+    @overrides(AbstractSDRAM.fixed)
     def fixed(self):
         return self._sdram
 
     @property
+    @overrides(AbstractSDRAM.per_timestep)
     def per_timestep(self):
         return 0
 
@@ -60,6 +64,7 @@ class ConstantSDRAM(AbstractSDRAM):
             # The other is more complex so delegate to it
             return other.sub_from(self)
 
+    @overrides(AbstractSDRAM.sub_from)
     def sub_from(self, other):
         if isinstance(other, ConstantSDRAM):
             return ConstantSDRAM(
@@ -67,3 +72,7 @@ class ConstantSDRAM(AbstractSDRAM):
         else:
             # The other is more complex so delegate to it
             return other - self
+
+    @overrides(AbstractSDRAM.report)
+    def report(self, indent = "", preamble="", target=None):
+        print(indent, preamble, "Constant {} bytes".format(self._sdram), file=target)

--- a/pacman/model/resources/multi_region_sdram.py
+++ b/pacman/model/resources/multi_region_sdram.py
@@ -115,7 +115,8 @@ class MultiRegionSDRAM(VariableSDRAM):
 
     @overrides(AbstractSDRAM.report)
     def report(self, timesteps, indent="", preamble="", target=None):
-        super(MultiRegionSDRAM, self).report(timesteps, indent, preamble, target)
+        super(MultiRegionSDRAM, self).report(
+            timesteps, indent, preamble, target)
         for region in self.__regions:
             self.__regions[region].report(
                 timesteps, indent+"    ", str(region)+":", target)

--- a/pacman/model/resources/multi_region_sdram.py
+++ b/pacman/model/resources/multi_region_sdram.py
@@ -1,0 +1,98 @@
+# Copyright (c) 2017-2019 The University of Manchester
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from .abstract_sdram import AbstractSDRAM
+from .constant_sdram import ConstantSDRAM
+from .variable_sdram import VariableSDRAM
+from spinn_utilities.overrides import overrides
+
+
+class MultiRegionSDRAM(VariableSDRAM):
+    """ A resource for SDRAM that comes in regions
+
+        .. note:
+        Adding or Subtracting two MultiRegionSDRAM objects will be assumed to
+        be an operation over multiple cores/placements so these functions
+        return a VariableSDRAM object without the regions data.
+
+        To add extra SDRAM costs for the same core/placement use the method
+        add_cost
+        merge
+    """
+
+    __slots__ = [
+        # The regions of SDRAM, each of which is an AbstractSDRAM
+        "__regions"
+    ]
+
+    def __init__(self):
+        """
+
+        :param regions: A dict of AbstractSDRAM, one per "region" of SDRAM.
+
+        """
+        self.__regions = {}
+
+    @property
+    def regions(self):
+        return self.__regions
+
+    @overrides(AbstractSDRAM.get_total_sdram)
+    def get_total_sdram(self, n_timesteps):
+        return sum(
+            r.get_total_sdram(n_timesteps) for r in self.__regions.values())
+
+    @property
+    @overrides(AbstractSDRAM.fixed)
+    def fixed(self):
+        return sum(r.fixed for r in self.__regions.values())
+
+    @property
+    @overrides(AbstractSDRAM.per_timestep)
+    def per_timestep(self):
+        return sum(r.per_timestep for r in self.__regions.values())
+
+    def add_cost(self, region, fixed, variable=0):
+        """
+        Adds the cost for the specified region
+
+        :param region: Key to identify the region
+        :type region: int or String or enum
+        :param int fixed: The fixed cost for this region
+        :param int variable: The vaariable cost for this region is any
+        """
+        if variable:
+            sdram = VariableSDRAM(fixed, variable)
+        else:
+            sdram = ConstantSDRAM(fixed)
+        if region in self.__regions:
+            self.__regions[region] += sdram
+        else:
+            self.__regions[region] = sdram
+
+    def merge(self, other):
+        """
+        Combines the other sdram costs keeping the region mappings
+
+        .. note:
+            This method should only be called when combining cost for the same
+            core/ placement. Use + to combine for different cores
+
+        :param MultiRegionSDRAM other: Another mapping of costs by region
+        """
+        for region in other.__regions:
+            if region in self.__regions:
+                self.__regions[region] += other.__regions[region]
+            else:
+                self.__regions[region] = other.__regions[region]

--- a/pacman/model/resources/multi_region_sdram.py
+++ b/pacman/model/resources/multi_region_sdram.py
@@ -71,6 +71,18 @@ class MultiRegionSDRAM(VariableSDRAM):
             self.__regions[region] = sdram
 
     def nest(self, region, other):
+        """
+        Combines the other sdram cost, in a nested fashion.
+
+        The totals for the new region are added to the total of this one.
+        A new region is created summerizing the cost of others.
+        If other contains a regions which is the same as one in self they are
+            NOT combined, but kept seperate.
+
+        :param region: Key to identify the summary region
+        :param AbstractSDRAM other: Another sdram model to make combine by
+            nesting
+        """
         self._fixed_sdram = self._fixed_sdram + other.fixed
         self._per_timestep_sdram = \
             self._per_timestep_sdram + other.per_timestep

--- a/pacman/model/resources/multi_region_sdram.py
+++ b/pacman/model/resources/multi_region_sdram.py
@@ -102,7 +102,7 @@ class MultiRegionSDRAM(VariableSDRAM):
                 self.__regions[region] = other.__regions[region]
 
     @overrides(AbstractSDRAM.report)
-    def report(self, timesteps, indent = "", preamble="", target=None):
+    def report(self, timesteps, indent="", preamble="", target=None):
         super().report(timesteps, indent, preamble, target)
         for region in self.__regions:
             self.__regions[region].report(

--- a/pacman/model/resources/multi_region_sdram.py
+++ b/pacman/model/resources/multi_region_sdram.py
@@ -102,8 +102,8 @@ class MultiRegionSDRAM(VariableSDRAM):
                 self.__regions[region] = other.__regions[region]
 
     @overrides(AbstractSDRAM.report)
-    def report(self, indent = "", preamble="", target=None):
-        super().report(indent, preamble, target)
+    def report(self, timesteps, indent = "", preamble="", target=None):
+        super().report(timesteps, indent, preamble, target)
         for region in self.__regions:
             self.__regions[region].report(
-                indent+"    ", str(region)+":", target)
+                timesteps, indent+"    ", str(region)+":", target)

--- a/pacman/model/resources/multi_region_sdram.py
+++ b/pacman/model/resources/multi_region_sdram.py
@@ -115,7 +115,7 @@ class MultiRegionSDRAM(VariableSDRAM):
 
     @overrides(AbstractSDRAM.report)
     def report(self, timesteps, indent="", preamble="", target=None):
-        super().report(timesteps, indent, preamble, target)
+        super(MultiRegionSDRAM, self).report(timesteps, indent, preamble, target)
         for region in self.__regions:
             self.__regions[region].report(
                 timesteps, indent+"    ", str(region)+":", target)

--- a/pacman/model/resources/variable_sdram.py
+++ b/pacman/model/resources/variable_sdram.py
@@ -82,6 +82,6 @@ class VariableSDRAM(AbstractSDRAM):
     @overrides(AbstractSDRAM.report)
     def report(self, timesteps, indent="", preamble="", target=None):
         print_(indent, preamble,
-              "Fixed {} bytes Per_timestep {} bytes for a total of {}".format(
-                  self._fixed_sdram, self._per_timestep_sdram,
-                  self.get_total_sdram(timesteps)), file=target)
+               "Fixed {} bytes Per_timestep {} bytes for a total of {}".format(
+                   self._fixed_sdram, self._per_timestep_sdram,
+                   self.get_total_sdram(timesteps)), file=target)

--- a/pacman/model/resources/variable_sdram.py
+++ b/pacman/model/resources/variable_sdram.py
@@ -79,6 +79,8 @@ class VariableSDRAM(AbstractSDRAM):
             other.per_timestep - self._per_timestep_sdram)
 
     @overrides(AbstractSDRAM.report)
-    def report(self, indent = "", preamble="", target=None):
-        print(indent, preamble, "Fixed {} bytes Per_timestep {} bytes".format(
-            self._fixed_sdram, self._per_timestep_sdram), file=target)
+    def report(self, timesteps, indent = "", preamble="", target=None):
+        print(indent, preamble,
+              "Fixed {} bytes Per_timestep {} bytes for a total of {}".format(
+                  self._fixed_sdram, self._per_timestep_sdram,
+                  self.get_total_sdram(timesteps)), file=target)

--- a/pacman/model/resources/variable_sdram.py
+++ b/pacman/model/resources/variable_sdram.py
@@ -79,7 +79,7 @@ class VariableSDRAM(AbstractSDRAM):
             other.per_timestep - self._per_timestep_sdram)
 
     @overrides(AbstractSDRAM.report)
-    def report(self, timesteps, indent = "", preamble="", target=None):
+    def report(self, timesteps, indent="", preamble="", target=None):
         print(indent, preamble,
               "Fixed {} bytes Per_timestep {} bytes for a total of {}".format(
                   self._fixed_sdram, self._per_timestep_sdram,

--- a/pacman/model/resources/variable_sdram.py
+++ b/pacman/model/resources/variable_sdram.py
@@ -14,6 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from .abstract_sdram import AbstractSDRAM
+from spinn_utilities.overrides import overrides
 from pacman.exceptions import PacmanConfigurationException
 
 
@@ -41,6 +42,7 @@ class VariableSDRAM(AbstractSDRAM):
         self._fixed_sdram = fixed_sdram
         self._per_timestep_sdram = per_timestep_sdram
 
+    @overrides(AbstractSDRAM.get_total_sdram)
     def get_total_sdram(self, n_timesteps):
         if n_timesteps is not None:
             return (self._fixed_sdram +
@@ -51,10 +53,12 @@ class VariableSDRAM(AbstractSDRAM):
             "Unable to run forever with a variable SDRAM cost")
 
     @property
+    @overrides(AbstractSDRAM.fixed)
     def fixed(self):
         return self._fixed_sdram
 
     @property
+    @overrides(AbstractSDRAM.per_timestep)
     def per_timestep(self):
         return self._per_timestep_sdram
 
@@ -68,7 +72,13 @@ class VariableSDRAM(AbstractSDRAM):
             self._fixed_sdram - other.fixed,
             self._per_timestep_sdram - other.per_timestep)
 
+    @overrides(AbstractSDRAM.sub_from)
     def sub_from(self, other):
         return VariableSDRAM(
             other.fixed - self._fixed_sdram,
             other.per_timestep - self._per_timestep_sdram)
+
+    @overrides(AbstractSDRAM.report)
+    def report(self, indent = "", preamble="", target=None):
+        print(indent, preamble, "Fixed {} bytes Per_timestep {} bytes".format(
+            self._fixed_sdram, self._per_timestep_sdram), file=target)

--- a/pacman/model/resources/variable_sdram.py
+++ b/pacman/model/resources/variable_sdram.py
@@ -13,6 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from six import print_
 from .abstract_sdram import AbstractSDRAM
 from spinn_utilities.overrides import overrides
 from pacman.exceptions import PacmanConfigurationException
@@ -80,7 +81,7 @@ class VariableSDRAM(AbstractSDRAM):
 
     @overrides(AbstractSDRAM.report)
     def report(self, timesteps, indent="", preamble="", target=None):
-        print(indent, preamble,
+        print_(indent, preamble,
               "Fixed {} bytes Per_timestep {} bytes for a total of {}".format(
                   self._fixed_sdram, self._per_timestep_sdram,
                   self.get_total_sdram(timesteps)), file=target)

--- a/pacman/operations/algorithm_reports/reports.py
+++ b/pacman/operations/algorithm_reports/reports.py
@@ -620,7 +620,8 @@ def sdram_usage_report_per_chip(
             f.write("Planned by partitioner\n")
             f.write("----------------------\n")
             _sdram_usage_report_per_chip_with_timesteps(
-                f, placements, machine, plan_n_timesteps, progress, False, False)
+                f, placements, machine, plan_n_timesteps, progress, False,
+                False)
             f.write("\nActual space reserved on the machine\n")
             f.write("----------------------\n")
             _sdram_usage_report_per_chip_with_timesteps(
@@ -651,8 +652,8 @@ def _sdram_usage_report_per_chip_with_timesteps(
         x, y, p = placement.x, placement.y, placement.p
         if details:
             vertex_sdram.report(
-                timesteps=timesteps, preamble="core ({},{},{})".format(x,y,p),
-                target=f)
+                timesteps=timesteps,
+                preamble="core ({},{},{})".format(x, y, p), target=f)
         else:
             f.write(
                 "SDRAM reqs for core ({},{},{}) is {} KB ({} bytes) for {}\n"

--- a/pacman/operations/algorithm_reports/reports.py
+++ b/pacman/operations/algorithm_reports/reports.py
@@ -645,16 +645,16 @@ def _sdram_usage_report_per_chip_with_timesteps(
     placements = sorted(placements.placements,
                         key=lambda x: x.vertex.label)
     for placement in progress.over(placements, False):
-        sdram = placement.vertex.resources_required.sdram.get_total_sdram(
-            timesteps)
+        vertex_sdram = placement.vertex.resources_required.sdram
+        core_sdram = vertex_sdram.get_total_sdram(timesteps)
         x, y, p = placement.x, placement.y, placement.p
-        f.write("SDRAM reqs for core ({},{},{}) is {} KB ({} bytes) for {}\n"
-                "".format(x, y, p, int(sdram / 1024.0), sdram, placement))
+
+        vertex_sdram.report(preamble="core ({},{},{})".format(x,y,p), target=f)
         key = (x, y)
         if key not in used_sdram_by_chip:
-            used_sdram_by_chip[key] = sdram
+            used_sdram_by_chip[key] = core_sdram
         else:
-            used_sdram_by_chip[key] += sdram
+            used_sdram_by_chip[key] += core_sdram
     for chip in progress.over(machine.chips, end_progress):
         try:
             used_sdram = used_sdram_by_chip[chip.x, chip.y]

--- a/unittests/model_tests/resources_tests/test_resources_model.py
+++ b/unittests/model_tests/resources_tests/test_resources_model.py
@@ -74,12 +74,15 @@ class TestResourceModels(unittest.TestCase):
         multi2.add_cost(MockEnum.ZERO, 88)
         multi2.add_cost(MockEnum.ONE, 72)
         multi2.add_cost("overheads", 22)
+        combo = multi1 + multi2
+        self.assertEqual(combo.get_total_sdram(150),
+                         100 + 50 + 20 + 88 + 72 + 22 + (4 + 3) * 150)
         multi1.merge(multi2)
         self.assertEqual(len(multi1.regions), 5)
         self.assertEqual(multi1.regions["overheads"], ConstantSDRAM(20 + 22))
         self.assertEqual(multi1.get_total_sdram(150),
                          100 + 50 + 20 + 88 + 72 + 22 + (4 + 3) * 150)
-
+        self.assertEqual(multi1, combo)
 
 
     def test_dtcm(self):

--- a/unittests/model_tests/resources_tests/test_resources_model.py
+++ b/unittests/model_tests/resources_tests/test_resources_model.py
@@ -16,12 +16,17 @@
 """
 test for the resources model
 """
+from enum import Enum
 import unittest
 from pacman.model.resources import (
     ConstantSDRAM, CPUCyclesPerTickResource, DTCMResource, ResourceContainer,
-    IPtagResource, ReverseIPtagResource, SpecificBoardIPtagResource,
-    SpecificBoardReverseIPtagResource, VariableSDRAM)
+    IPtagResource, MultiRegionSDRAM, ReverseIPtagResource,
+    SpecificBoardIPtagResource, SpecificBoardReverseIPtagResource,
+    VariableSDRAM)
 
+class MockEnum(Enum):
+    ZERO = 0
+    ONE = 1
 
 class TestResourceModels(unittest.TestCase):
     """
@@ -60,6 +65,22 @@ class TestResourceModels(unittest.TestCase):
         self.assertEqual(combo.get_total_sdram(150), 234 + 124 + (6 + 8) * 150)
         combo = var2 - var1
         self.assertEqual(combo.get_total_sdram(150), 234 - 124 + (6 - 8) * 150)
+
+        multi1 = MultiRegionSDRAM()
+        multi1.add_cost(1, 100, 4)
+        multi1.add_cost(2, 50, 3)
+        multi1.add_cost("overheads", 20)
+        multi2 = MultiRegionSDRAM()
+        multi2.add_cost(MockEnum.ZERO, 88)
+        multi2.add_cost(MockEnum.ONE, 72)
+        multi2.add_cost("overheads", 22)
+        multi1.merge(multi2)
+        self.assertEqual(len(multi1.regions), 5)
+        self.assertEqual(multi1.regions["overheads"], ConstantSDRAM(20 + 22))
+        self.assertEqual(multi1.get_total_sdram(150),
+                         100 + 50 + 20 + 88 + 72 + 22 + (4 + 3) * 150)
+
+
 
     def test_dtcm(self):
         """

--- a/unittests/model_tests/resources_tests/test_resources_model.py
+++ b/unittests/model_tests/resources_tests/test_resources_model.py
@@ -92,7 +92,7 @@ class TestResourceModels(unittest.TestCase):
         self.assertEqual(multi1, combo)
         self.assertEqual(multi1, multi3)
         with tempfile.TemporaryFile(mode="w") as target:
-            multi3.report(target=target)
+            multi3.report(1000, target=target)
         # multi3.report(preamble="core (0,0,1):")
 
     def test_dtcm(self):

--- a/unittests/model_tests/resources_tests/test_resources_model.py
+++ b/unittests/model_tests/resources_tests/test_resources_model.py
@@ -25,9 +25,11 @@ from pacman.model.resources import (
     SpecificBoardIPtagResource, SpecificBoardReverseIPtagResource,
     VariableSDRAM)
 
+
 class MockEnum(Enum):
     ZERO = 0
     ONE = 1
+
 
 class TestResourceModels(unittest.TestCase):
     """

--- a/unittests/model_tests/resources_tests/test_resources_model.py
+++ b/unittests/model_tests/resources_tests/test_resources_model.py
@@ -17,6 +17,7 @@
 test for the resources model
 """
 from enum import Enum
+import tempfile
 import unittest
 from pacman.model.resources import (
     ConstantSDRAM, CPUCyclesPerTickResource, DTCMResource, ResourceContainer,
@@ -74,16 +75,25 @@ class TestResourceModels(unittest.TestCase):
         multi2.add_cost(MockEnum.ZERO, 88)
         multi2.add_cost(MockEnum.ONE, 72)
         multi2.add_cost("overheads", 22)
+
         combo = multi1 + multi2
         self.assertEqual(combo.get_total_sdram(150),
                          100 + 50 + 20 + 88 + 72 + 22 + (4 + 3) * 150)
+
+        multi3 = MultiRegionSDRAM()
+        multi3.nest("foo", multi1)
+        multi3.nest("bar", multi2)
+
         multi1.merge(multi2)
         self.assertEqual(len(multi1.regions), 5)
         self.assertEqual(multi1.regions["overheads"], ConstantSDRAM(20 + 22))
         self.assertEqual(multi1.get_total_sdram(150),
                          100 + 50 + 20 + 88 + 72 + 22 + (4 + 3) * 150)
         self.assertEqual(multi1, combo)
-
+        self.assertEqual(multi1, multi3)
+        with tempfile.TemporaryFile(mode="w") as target:
+            multi3.report(target=target)
+        # multi3.report(preamble="core (0,0,1):")
 
     def test_dtcm(self):
         """


### PR DESCRIPTION
Inspired by https://github.com/SpiNNakerManchester/PACMAN/pull/293

This provides a working of a dictionary based MultiRegionSDRAM
Allows the sdram cost to be assigned to specific causes and even nested
Unless the details are needed this acts like a normal VariableSDRAM

Different MultiRegionSDRAM can be combined using merge(..) which retains the dictionary.
Or even nested using the nest() method

However when doing add or sub the dictionary information is not retained as it is assumed that at a gobal level this is not interesting.

Added a report method to all sdram types so they can print/write to file in the most suitable way.

This PR is reguired for but can be merged before later PRs.

