### PR TITLE
fixed wrong offset into key_array

### DIFF
--- a/pacman/model/routing_info/partition_routing_info.py
+++ b/pacman/model/routing_info/partition_routing_info.py
@@ -59,8 +59,9 @@ class PartitionRoutingInfo(object):
         key_array = numpy.zeros(n_keys, dtype=">u4")
         offset = 0
         for key_and_mask in self._keys_and_masks:
-            _, offset = key_and_mask.get_keys(
+            _, km_offset = key_and_mask.get_keys(
                 key_array=key_array, offset=offset, n_keys=(n_keys - offset))
+            offset += km_offset
         return key_array
 
     @property


### PR DESCRIPTION
Hi all,

I'm currently experimenting with the `AbstractProvidesNKeyForPartition` and had the interesting case where I wanted one `OutgoingPartition` to have 5 consecutive keys: 1, 2, 3, 4, 5. So I went ahead and gave my `MachineVertex` a `FixedKeysAndMasksConstraint` with those 5 keys as `BaseKeyAndMask` with a mask of `0xFFFFFFFF`. When I wanted the keys during data spec generation I used `routing_info.get_routing_info_from_pre_vertex(self, "some_partition").get_keys()` which returned `[1, 5, 0, 0, 0]` which is clearly wrong. I looked how these keys are generated and found out that in the `get_keys` method the offset into the `key_array` is computed the wrong way (for my use case). Instead of adding up the offset for each visited `BaseKeyAndMask` the offset is just set to the size of the last visited `BaseKeyAndMask` which is always 1 in my case so the second key at index 1 is overwritten. Adding up the offset solved the problem for me.

Kind regards,
Jonas