### PR TITLE
Moved get_n_keys_for_partition to MachineVertex

### DIFF
--- a/pacman/model/graphs/machine/machine_vertex.py
+++ b/pacman/model/graphs/machine/machine_vertex.py
@@ -89,6 +89,17 @@ class MachineVertex(AbstractVertex):
         return self._vertex_slice
 
     @property
+    def get_n_keys_for_partition(self, partition):
+        """ Get the number of keys required by the given partition of edges.
+
+        :param ~pacman.model.graphs.OutgoingEdgePartition partition:
+            An partition that comes out of this vertex
+        :return: The number of keys required
+        :rtype: int
+        """
+        return self._vertex_slice.n_atoms
+
+    @property
     def index(self):
         """ The index into the collection of machine vertices for an
             application vertex.


### PR DESCRIPTION
In more than one place the code  makes the assumption that is get_n_keys_for_partition is not provided by the machine vertex than just use vertex_slice.n_atoms

Instead if that is assume just make it explict.

If someone really dislikes that there vertex which does not provides keys claims it does they can overwrite to throw NotImplemented 

In the current implementation the vertex can not control who assumes that get_n_keys_for_partition == vertex_slice.n_atoms
