### PR TITLE
Stop edges being added twice

### DIFF
--- a/pacman/model/graphs/graph.py
+++ b/pacman/model/graphs/graph.py
@@ -175,6 +175,8 @@ class Graph(ConstrainedObject):
         self._incoming_edges_by_partition_name[
             (edge.post_vertex, outgoing_edge_partition_name)].append(edge)
         self._incoming_edges[edge.post_vertex].add(edge)
+        if edge in self._outgoing_edge_partition_by_edge:
+            raise PacmanAlreadyExistsException("edge", edge)
         self._outgoing_edge_partition_by_edge[edge] = partition
 
     def _new_edge_partition(self, name):

--- a/unittests/model_tests/machine_graph_tests/test_machine_graph_model.py
+++ b/unittests/model_tests/machine_graph_tests/test_machine_graph_model.py
@@ -110,7 +110,8 @@ class TestMachineGraphModel(unittest.TestCase):
         edges.append(edge)
         graph = MachineGraph("foo")
         graph.add_vertices(vertices)
-        graph.add_edges(edges, "bar")
+        with self.assertRaises(PacmanAlreadyExistsException):
+            graph.add_edges(edges, "bar")
 
     def test_add_edge_with_no_existing_pre_vertex_in_graph(self):
         """

--- a/unittests/operations_tests/placer_algorithms_tests/test_connecitve_placer.py
+++ b/unittests/operations_tests/placer_algorithms_tests/test_connecitve_placer.py
@@ -62,7 +62,6 @@ class TestConnectivePlacer(unittest.TestCase):
         self.mach_graph.add_edge(edge3, "packet")
         edge4 = MachineEdge(self.vertex3, self.vertex1)
         self.edges.append(edge4)
-        self.mach_graph.add_edge(edge1, "bacon")
 
         self.plan_n_timesteps = 100
 


### PR DESCRIPTION
We even have a unit test that claims
 "test that adding the same machine edge will cause an error"

yet then checked that is can without an error.

tested by https://github.com/SpiNNakerManchester/sPyNNaker8/pull/465