### PR TITLE
all or nothing for machinevertex.appvertex

### DIFF
--- a/pacman/model/graphs/machine/machine_graph.py
+++ b/pacman/model/graphs/machine/machine_graph.py
@@ -62,7 +62,9 @@ class MachineGraph(Graph):
     def add_vertex(self, vertex):
         super(MachineGraph, self).add_vertex(vertex)
         if self._application_level_used:
-            if not vertex.app_vertex:
+            try:
+                vertex.app_vertex.remember_machine_vertex(vertex)
+            except AttributeError:
                 if self.n_vertices == 1:
                     self._application_level_used = False
                 else:
@@ -73,6 +75,3 @@ class MachineGraph(Graph):
             if vertex.app_vertex:
                 raise PacmanInvalidParameterException(
                     "vertex", vertex, self.UNEXPECTED_APP_VERTEX_ERROR_MESSAGE)
-            assert(vertex.app_vertex is None)
-        if vertex.app_vertex:
-            vertex.app_vertex.remember_machine_vertex(vertex)

--- a/pacman/model/graphs/machine/machine_graph.py
+++ b/pacman/model/graphs/machine/machine_graph.py
@@ -53,7 +53,7 @@ class MachineGraph(Graph):
         if application_graph:
             application_graph.forget_machine_graph()
             # Check the first vertex added
-            self._application_level_used = None
+            self._application_level_used = True
         else:
             # Must be false as there is no App_graph
             self._application_level_used = False
@@ -61,12 +61,14 @@ class MachineGraph(Graph):
     @overrides(Graph.add_vertex)
     def add_vertex(self, vertex):
         super(MachineGraph, self).add_vertex(vertex)
-        if self._application_level_used is None:
-            self._application_level_used = vertex.app_vertex is not None
         if self._application_level_used:
             if not vertex.app_vertex:
-                raise PacmanInvalidParameterException(
-                    "vertex", vertex, self.MISSING_APP_VERTEX_ERROR_MESSAGE)
+                if self.n_vertices == 1:
+                    self._application_level_used = False
+                else:
+                    raise PacmanInvalidParameterException(
+                        "vertex", vertex,
+                        self.MISSING_APP_VERTEX_ERROR_MESSAGE)
         else:
             if vertex.app_vertex:
                 raise PacmanInvalidParameterException(

--- a/unittests/model_tests/machine_graph_tests/test_machine_graph_model.py
+++ b/unittests/model_tests/machine_graph_tests/test_machine_graph_model.py
@@ -14,10 +14,12 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import unittest
+from pacman.model.graphs.application import ApplicationGraph
 from pacman.model.graphs.machine import (
     MachineEdge, MachineGraph, SimpleMachineVertex)
 from pacman.exceptions import (
     PacmanAlreadyExistsException, PacmanInvalidParameterException)
+from uinit_test_objects import SimpleTestVertex
 
 
 class TestMachineGraphModel(unittest.TestCase):
@@ -112,6 +114,41 @@ class TestMachineGraphModel(unittest.TestCase):
         graph.add_vertices(vertices)
         with self.assertRaises(PacmanAlreadyExistsException):
             graph.add_edges(edges, "bar")
+
+    def test_all_have_app_vertex(self):
+        app_graph = ApplicationGraph("Test")
+        graph = MachineGraph("foo", app_graph)
+        app1 = SimpleTestVertex(12, "app1")
+        mach1 = SimpleMachineVertex("mach1",  app_vertex=app1)
+        mach2 = SimpleMachineVertex("mach2",  app_vertex=app1)
+        mach3 = SimpleMachineVertex("mach3",  app_vertex=None)
+        graph.add_vertices([mach1, mach2])
+        with self.assertRaises(PacmanInvalidParameterException):
+            graph.add_vertex(mach3)
+
+    def test_none_have_app_vertex(self):
+        app_graph = ApplicationGraph("Test")
+        graph = MachineGraph("foo", app_graph)
+        app1 = SimpleTestVertex(12, "app1")
+        mach1 = SimpleMachineVertex("mach1",  app_vertex=None)
+        mach2 = SimpleMachineVertex("mach2",  app_vertex=None)
+        mach3 = SimpleMachineVertex("mach3",  app_vertex=app1)
+        graph.add_vertices([mach1, mach2])
+        with self.assertRaises(PacmanInvalidParameterException):
+            graph.add_vertex(mach3)
+
+    def test_no_app_graph_no_app_vertex(self):
+        graph = MachineGraph("foo")
+        app1 = SimpleTestVertex(12, "app1")
+        mach1 = SimpleMachineVertex("mach1", app_vertex=app1)
+        mach2 = SimpleMachineVertex("mach2", app_vertex=None)
+        mach3 = SimpleMachineVertex("mach3", app_vertex=app1)
+        with self.assertRaises(PacmanInvalidParameterException):
+            graph.add_vertex(mach1)
+        graph.add_vertex(mach2)
+        with self.assertRaises(PacmanInvalidParameterException):
+            graph.add_vertex(mach3)
+
 
     def test_add_edge_with_no_existing_pre_vertex_in_graph(self):
         """

--- a/unittests/model_tests/machine_graph_tests/test_machine_graph_model.py
+++ b/unittests/model_tests/machine_graph_tests/test_machine_graph_model.py
@@ -149,7 +149,6 @@ class TestMachineGraphModel(unittest.TestCase):
         with self.assertRaises(PacmanInvalidParameterException):
             graph.add_vertex(mach3)
 
-
     def test_add_edge_with_no_existing_pre_vertex_in_graph(self):
         """
         test that adding a edge where the pre vertex has not been added


### PR DESCRIPTION
Better check if all or none of the machine vertices have app_vertex.

one test fix in https://github.com/SpiNNakerManchester/PACMAN/pull/312
tested by https://github.com/SpiNNakerManchester/sPyNNaker8/pull/476

Note that @dkfellows and @rowleya wondered why this is needed.
Answer only a safety check.