### PR TITLE
remembering machine_vertex called by machine_graph

### DIFF
--- a/pacman/model/graphs/application/application_vertex.py
+++ b/pacman/model/graphs/application/application_vertex.py
@@ -88,9 +88,13 @@ class ApplicationVertex(AbstractVertex):
             Constraints to be passed on to the machine vertex.
         """
 
-    def remember_associated_machine_vertex(self, machine_vertex):
+    def remember_machine_vertex(self, machine_vertex):
         """
         Adds the Machine vertex the iterable returned by machine_vertices
+
+        This method will be called by MachineVertex.app_vertex
+        No other place should call it.
+
         :param machine_vertex: A pointer to a machine_vertex.
             This vertex may not be fully initialized but will have a slice
         :raises PacmanValueError: If the slice of the machine_vertex is too big

--- a/pacman/model/graphs/machine/machine_graph.py
+++ b/pacman/model/graphs/machine/machine_graph.py
@@ -15,6 +15,7 @@
 
 from .machine_vertex import MachineVertex
 from .machine_edge import MachineEdge
+from spinn_utilities.overrides import overrides
 from pacman.model.graphs.graph import Graph
 from pacman.model.graphs import OutgoingEdgePartition
 
@@ -38,3 +39,9 @@ class MachineGraph(Graph):
             MachineVertex, MachineEdge, OutgoingEdgePartition, label)
         if application_graph:
             application_graph.forget_machine_graph()
+
+    @overrides(Graph.add_vertex)
+    def add_vertex(self, vertex):
+        super(MachineGraph, self).add_vertex(vertex)
+        if vertex.app_vertex:
+            vertex.app_vertex.remember_machine_vertex(vertex)

--- a/pacman/model/graphs/machine/machine_vertex.py
+++ b/pacman/model/graphs/machine/machine_vertex.py
@@ -58,17 +58,6 @@ class MachineVertex(AbstractVertex):
             self._vertex_slice = vertex_slice
         else:
             self._vertex_slice = self._DEFAULT_SLICE
-        # associate depends on self._vertex_slice and self._app_vertex
-        self.associate_application_vertex()
-
-    def associate_application_vertex(self):
-        """
-        Asks the application vertex (if any) to remember this machine vertex.
-        :raises PacmanValueError: If the slice of the machine_vertex is too big
-        """
-        # remember depends on slice already being set
-        if self._app_vertex:
-            self._app_vertex.remember_associated_machine_vertex(self)
 
     @property
     def app_vertex(self):

--- a/unittests/model_tests/application_graph_tests/test_application_vertex.py
+++ b/unittests/model_tests/application_graph_tests/test_application_vertex.py
@@ -143,16 +143,3 @@ class TestApplicationGraphModel(unittest.TestCase):
         self.assertEqual(len(subv_from_vert.constraints), 2)
         self.assertIn(constraint1, subv_from_vert.constraints)
         self.assertIn(constraint2, subv_from_vert.constraints)
-
-    def test_machine_vertexes(self):
-        vert = SimpleTestVertex(12, "New AbstractConstrainedVertex", 256)
-        sub1 = vert.create_machine_vertex(
-            Slice(0, 7),
-            vert.get_resources_used_by_atoms(Slice(0, 7)), "M1")
-        sub2 = vert.create_machine_vertex(
-            Slice(7, 11),
-            vert.get_resources_used_by_atoms(Slice(7, 11)), "M2")
-        self.assertIn(sub1, vert.machine_vertices)
-        self.assertIn(sub2, vert.machine_vertices)
-        self.assertIn(Slice(0, 7), vert.vertex_slices)
-        self.assertIn(Slice(7, 11), vert.vertex_slices)

--- a/unittests/model_tests/graph_mapper_tests/test_graph_mapping.py
+++ b/unittests/model_tests/graph_mapper_tests/test_graph_mapping.py
@@ -17,7 +17,6 @@
 tests for graph mapping
 """
 import unittest
-from pacman.model.graphs.common import Slice
 from pacman.model.graphs.machine import MachineEdge, SimpleMachineVertex
 from uinit_test_objects import SimpleTestEdge, SimpleTestVertex
 

--- a/unittests/model_tests/graph_mapper_tests/test_graph_mapping.py
+++ b/unittests/model_tests/graph_mapper_tests/test_graph_mapping.py
@@ -48,40 +48,6 @@ class TestGraphMapping(unittest.TestCase):
         self.assertIn(edges[0], edges_from_edge)
         self.assertNotIn(edges[1], edges_from_edge)
 
-    def test_get_vertices_from_vertex(self):
-        """
-        test getting the vertex from a graph mapper via the vertex
-        """
-        vertices = list()
-        vert = SimpleTestVertex(4, "Some testing vertex")
-        vertices.append(SimpleMachineVertex(None, ""))
-        vertices.append(SimpleMachineVertex(None, ""))
-        vertex1 = SimpleMachineVertex(
-            None, "", vertex_slice=Slice(0, 1), app_vertex=vert)
-        vertex2 = SimpleMachineVertex(
-            None, "", vertex_slice=Slice(2, 3), app_vertex=vert)
-
-        returned_vertices = vert.machine_vertices
-
-        self.assertIn(vertex1, returned_vertices)
-        self.assertIn(vertex2, returned_vertices)
-        for v in vertices:
-            self.assertNotIn(v, returned_vertices)
-
-    def test_get_vertex_from_vertex(self):
-        """
-        test that the graph mapper can retrieve a vertex from a given vertex
-        """
-        vert = SimpleTestVertex(10, "Some testing vertex")
-        vertex1 = SimpleMachineVertex(None, "", app_vertex=vert,
-                                      vertex_slice=Slice(0, 1))
-        vertex2 = SimpleMachineVertex(None, "", app_vertex=vert,
-                                      vertex_slice=Slice(2, 3))
-
-        self.assertEqual(vert, vertex1.app_vertex)
-        self.assertEqual(vert, vertex2.app_vertex)
-        self.assertEqual([vertex1, vertex2], list(vert.machine_vertices))
-
     def test_get_edge_from_machine_edge(self):
         """
         test that tests getting a edge from a graph mapper

--- a/unittests/model_tests/machine_graph_tests/test_machine_graph_model.py
+++ b/unittests/model_tests/machine_graph_tests/test_machine_graph_model.py
@@ -14,10 +14,12 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import unittest
+from pacman.model.graphs.application import ApplicationGraph
 from pacman.model.graphs.machine import (
     MachineEdge, MachineGraph, SimpleMachineVertex)
 from pacman.exceptions import (
     PacmanAlreadyExistsException, PacmanInvalidParameterException)
+from uinit_test_objects import SimpleTestVertex
 
 
 class TestMachineGraphModel(unittest.TestCase):
@@ -147,6 +149,26 @@ class TestMachineGraphModel(unittest.TestCase):
             graph.add_vertices(vertices)
             graph.add_edges(edges, "bar")
 
+    def test_remember_machine_vertex(self):
+        app_graph = ApplicationGraph("Test")
+        graph = MachineGraph("foo", app_graph)
+        app1 = SimpleTestVertex(12, "app1")
+        app2 = SimpleTestVertex(12, "app2")
+        mach1 = SimpleMachineVertex("mach1",  app_vertex=app1)
+        mach2 = SimpleMachineVertex("mach2",  app_vertex=app1)
+        mach3 = SimpleMachineVertex("mach3",  app_vertex=app1)
+        mach4 = SimpleMachineVertex("mach4",  app_vertex=app2)
+        self.assertEquals(0, len(app1.machine_vertices))
+        self.assertEquals(0, len(app2.machine_vertices))
+        graph.add_vertices([mach1, mach2])
+        graph.add_vertex(mach3)
+        graph.add_vertex(mach4)
+        self.assertEquals(3, len(app1.machine_vertices))
+        self.assertEquals(1, len(app2.machine_vertices))
+        self.assertIn(mach1, app1.machine_vertices)
+        self.assertIn(mach2, app1.machine_vertices)
+        self.assertIn(mach3, app1.machine_vertices)
+        self.assertIn(mach4, app2.machine_vertices)
 
 if __name__ == '__main__':
     unittest.main()

--- a/unittests/model_tests/machine_graph_tests/test_machine_graph_model.py
+++ b/unittests/model_tests/machine_graph_tests/test_machine_graph_model.py
@@ -170,5 +170,6 @@ class TestMachineGraphModel(unittest.TestCase):
         self.assertIn(mach3, app1.machine_vertices)
         self.assertIn(mach4, app2.machine_vertices)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/unittests/utilities_tests/test_json_utils.py
+++ b/unittests/utilities_tests/test_json_utils.py
@@ -13,7 +13,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import unittest
-
 import json
 from pacman.model.constraints.key_allocator_constraints import (
     ContiguousKeyRangeContraint, FixedKeyAndMaskConstraint,


### PR DESCRIPTION
To allow vertices and splitters create a machine Vertex before asked to or to cache it between runs the call to 
remember_associated_machine_vertex has been delayed until the vertex is added to the machine graph.

method name change to hard break anywhere in other branches that used it.

Note: tests of app_vertex.machine_vertices behaviour have been moved not removed.

Must be doen together with https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/pull/678
tested by https://github.com/SpiNNakerManchester/sPyNNaker8/pull/477