### PR TITLE
expose application_level_used

### DIFF
--- a/pacman/model/graphs/machine/machine_graph.py
+++ b/pacman/model/graphs/machine/machine_graph.py
@@ -111,3 +111,7 @@ class MachineGraph(Graph):
             if vertex.app_vertex:
                 raise PacmanInvalidParameterException(
                     "vertex", vertex, self.UNEXPECTED_APP_VERTEX_ERROR_MESSAGE)
+
+    @property
+    def application_level_used(self):
+        return self._application_level_used


### PR DESCRIPTION
This avoids algorithms having to be passed in an application graph just to check if they should also use the application level