### PR TITLE
sortedcollections needs version restriction for Python 2.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,7 @@ numpy; python_version >= '3.8'
 future
 lxml
 jsonschema
-sortedcollections
+sortedcollections < 2; python_version == '2.7'
+sortedcollections; python_version >= '3.6'
 SpiNNUtilities >= 1!5.1.1, < 1!6.0.0
 SpiNNMachine >= 1!5.1.1, < 1!6.0.0

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,8 @@ setup(
         "numpy; python_version >= '3.8'",
         'lxml',
         'jsonschema',
-        'sortedcollections'],
+        "sortedcollections < 2; python_version == '2.7'",
+        "sortedcollections; python_version >= '3.6'"],
     maintainer="SpiNNakerTeam",
     maintainer_email="spinnakerusers@googlegroups.com"
 )


### PR DESCRIPTION
This is blocking downstream builds, and is caused by sortedcollections 2 (strictly 2.0.1 as 2.0.0 wasn't released) dropping Python 2.7 support. Which wasn't loudly announced.