### PR TITLE
Fix to print strings correctly, make messages more specific

### DIFF
--- a/pacman/executor/algorithm_decorators/algorithm_decorator.py
+++ b/pacman/executor/algorithm_decorators/algorithm_decorator.py
@@ -370,8 +370,8 @@ def scan_packages(packages, recursive=True):
                     __import__(package_name)
                     package = sys.modules[package_name]
                 except Exception as ex:  # pragma: no cover
-                    logger.warning("Failed to import %s : %s",
-                                   package_name, str(ex))
+                    logger.warning("Failed to import package {}: {}".format(
+                        package_name, str(ex)))
                     continue
             pkg_path = os.path.dirname(package.__file__)
 
@@ -386,8 +386,8 @@ def scan_packages(packages, recursive=True):
                     try:
                         __import__(module)
                     except Exception as ex:  # pragma: no cover
-                        logger.warning("Failed to import %s : %s",
-                                       module, str(ex))
+                        logger.warning("Failed to import module {}: {}".format(
+                            module, str(ex)))
                         continue
 
         new_algorithms = _algorithms


### PR DESCRIPTION
Can't use %s any more in logging messages, switching to "... {} .. ".format(..) instead.

Didn't find any more of these in this repository, will go through others and see if there's any there.