### PR TITLE
Write sphinx config right

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -378,7 +378,7 @@ def setup(app):
 
 # We want to document __call__ when encountered
 autodoc_default_options = {
-    "members": True,
+    "members": None,
     "special-members": "__call__"
 }
 


### PR DESCRIPTION
The config was only right with some versions of Sphinx; with the version deployed on readthedocs (1.8.5), it blew up (trying to split a boolean by commas, which doesn't work, whereas using `None` is fine).

None of this is at all helped by the fact that the configuration settings aren't very well described for programmatic use; there's a lot of outdated and plain bad descriptions out there. Sphinx's own documentation is good, but pretty much assumes that you hand-write everything in `.rst` files with all of the fiddly details all the time. Ain't _nobody_ got time for that!