### PR TITLE
use get_existing_xys_by_ethernet as you just want xy

### DIFF
--- a/pacman/utilities/utility_objs/resource_tracker.py
+++ b/pacman/utilities/utility_objs/resource_tracker.py
@@ -1323,8 +1323,8 @@ class ResourceTracker(object):
                 board_resources["n_tags"] = (
                     len(self._machine.get_chip_at(eth_x, eth_y).tag_ids))
             chips = list()
-            for chip in self._machine.get_chips_by_ethernet(eth_x, eth_y):
-                chip_resources = resources_for_chips.get((chip.x, chip.y))
+            for xy in self._machine.get_existing_xys_by_ethernet(eth_x, eth_y):
+                chip_resources = resources_for_chips.get(xy)
                 if chip_resources is not None:
                     chips.append(chip_resources)
             if chips:


### PR DESCRIPTION
found while investigation https://github.com/SpiNNakerManchester/SpiNNMachine/pull/155 but can be merged independent.

Why use a method that returns a chip to then ask the chip for its x and y when there is a cheaper method which returns xy directly.