### PR TITLE
Another small Sphinx fix

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -415,5 +415,5 @@ for fl in os.listdir("."):
         os.remove(fl)
 os.chdir("../..")  # WARNING! RELATIVE FILENAMES CHANGE MEANING HERE!
 apidoc.main([
-    '-q', '-o', _output_dir, _package_base,
+    '-o', _output_dir, _package_base,
     *filtered_files(_package_base, _unfiltered_files)])


### PR DESCRIPTION
Remove option not supported on RTD (`-q` just means “quiet” and we don't need it).