### PR TITLE
Bye bye outer_table_compression_target_length setting

### DIFF
--- a/pacman/operations/router_compressors/abstract_compressor.py
+++ b/pacman/operations/router_compressors/abstract_compressor.py
@@ -134,7 +134,7 @@ class AbstractCompressor(object):
         compressed_tables = MulticastRoutingTables()
         self._problems = ""
         if get_config_bool(
-            "Mapping", "router_table_compress_as_far_as_possible"):
+                "Mapping", "router_table_compress_as_far_as_possible"):
             # Compress as much as possible
             target_length = 0
         else:

--- a/pacman/operations/router_compressors/abstract_compressor.py
+++ b/pacman/operations/router_compressors/abstract_compressor.py
@@ -19,9 +19,10 @@ based on https://github.com/project-rig/
 
 from abc import abstractmethod
 import logging
-from spinn_utilities.config_holder import get_config_int
+from spinn_utilities.config_holder import get_config_bool
 from spinn_utilities.log import FormatAdapter
 from spinn_utilities.progress_bar import ProgressBar
+from spinn_machine import Machine
 from pacman.model.routing_tables import (
     CompressedMulticastRoutingTable, MulticastRoutingTables)
 from pacman.exceptions import MinimisationFailedError
@@ -31,22 +32,24 @@ logger = FormatAdapter(logging.getLogger(__name__))
 
 class AbstractCompressor(object):
 
-    MAX_SUPPORTED_LENGTH = 1023
-
     __slots__ = [
         # String of problems detected. Must be "" to finish
         "_problems",
         # Flag to say if the results can be order dependent
         "_ordered",
+        # Flag to say that results too large should be ignored
+        "_accept_overflow"
     ]
 
     def __init__(self, ordered=True):
         self._ordered = ordered
 
-    def __call__(self, router_tables, target_length=None):
+    def __call__(self, router_tables, accept_overflow=False):
         """
         :param MulticastRoutingTables router_tables:
-        :param int target_length:
+        :param bool accept_overflow:
+            A flag which should only be used in testing to stop raising an
+            exception if result is too big
         :rtype: MulticastRoutingTables
         """
         # create progress bar
@@ -54,6 +57,7 @@ class AbstractCompressor(object):
             router_tables.routing_tables,
             "Compressing routing Tables using {}".format(
                 self.__class__.__name__))
+        self._accept_overflow = accept_overflow
         return self.compress_tables(router_tables, progress)
 
     @staticmethod
@@ -129,11 +133,12 @@ class AbstractCompressor(object):
         """
         compressed_tables = MulticastRoutingTables()
         self._problems = ""
-        target_length = get_config_int(
-            "Mapping", "router_table_compression_target_length")
-        if target_length is None:
+        if get_config_bool(
+            "Mapping", "router_table_compress_as_far_as_possible"):
             # Compress as much as possible
             target_length = 0
+        else:
+            target_length = Machine.ROUTER_ENTRIES
         for table in progress.over(router_tables.routing_tables):
             if table.number_of_entries < target_length:
                 new_table = table
@@ -145,14 +150,14 @@ class AbstractCompressor(object):
                 for entry in compressed_table:
                     new_table.add_multicast_routing_entry(
                         entry.to_MulticastRoutingEntry())
-                if new_table.number_of_entries > self.MAX_SUPPORTED_LENGTH:
+                if new_table.number_of_entries > Machine.ROUTER_ENTRIES:
                     self._problems += "(x:{},y:{})={} ".format(
                         new_table.x, new_table.y, new_table.number_of_entries)
 
             compressed_tables.add_routing_table(new_table)
 
         if len(self._problems) > 0:
-            if self._ordered:
+            if self._ordered and not self._accept_overflow:
                 raise MinimisationFailedError(
                     "The routing table after compression will still not fit"
                     " within the machines router: {}".format(self._problems))

--- a/pacman/operations/router_compressors/checked_unordered_pair_compressor.py
+++ b/pacman/operations/router_compressors/checked_unordered_pair_compressor.py
@@ -14,6 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from spinn_utilities.progress_bar import ProgressBar
+from spinn_machine import Machine
 from pacman.exceptions import PacmanElementAllocationException
 from .unordered_pair_compressor import UnorderedPairCompressor
 
@@ -55,7 +56,7 @@ class CheckedUnorderedPairCompressor(UnorderedPairCompressor):
         """
         problems = ""
         for table in compressed:
-            if table.number_of_entries > self.MAX_SUPPORTED_LENGTH:
+            if table.number_of_entries > Machine.ROUTER_ENTRIES:
                 problems += "(x:{},y:{})={} ".format(
                     table.x, table.y, table.number_of_entries)
         if len(problems) > 0:

--- a/pacman/operations/router_compressors/ordered_covering_router_compressor/ordered_covering.py
+++ b/pacman/operations/router_compressors/ordered_covering_router_compressor/ordered_covering.py
@@ -13,7 +13,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from spinn_utilities.config_holder import get_config_int
+from spinn_utilities.config_holder import get_config_bool
+from spinn_machine import Machine
 from pacman.operations.router_compressors import Entry
 from pacman.exceptions import MinimisationFailedError
 from .remove_default_routes import remove_default_routes
@@ -54,8 +55,13 @@ def minimise(
         If the smallest table that can be produced is larger than
         ``target_length``.
     """
-    target_length = get_config_int(
-        "Mapping", "router_table_compression_target_length")
+    if get_config_bool(
+            "Mapping", "router_table_compress_as_far_as_possible"):
+        # Compress as much as possible
+        target_length = None
+    else:
+        target_length = Machine.ROUTER_ENTRIES
+
     # Keep None values as that flags as much as possible
     table, _ = ordered_covering(
         routing_table=routing_table, target_length=target_length,

--- a/pacman/operations/router_compressors/pair_compressor.py
+++ b/pacman/operations/router_compressors/pair_compressor.py
@@ -13,6 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from spinn_machine import Machine
 from .abstract_compressor import AbstractCompressor
 from .entry import Entry
 
@@ -337,8 +338,8 @@ class PairCompressor(AbstractCompressor):
         self._all_entries = []
         self._routes_count = 0
         # Imitate creating fixed size arrays
-        self._routes = self.MAX_SUPPORTED_LENGTH * [None]
-        self._routes_frequency = self.MAX_SUPPORTED_LENGTH * [None]
+        self._routes = Machine.ROUTER_ENTRIES * [None]
+        self._routes_frequency = Machine.ROUTER_ENTRIES * [None]
 
         for entry in router_table.multicast_routing_entries:
             self._all_entries.append(

--- a/pacman/pacman.cfg
+++ b/pacman/pacman.cfg
@@ -1,9 +1,6 @@
 # Adds or overwrites values in SpiNNMachine/spinn_machine/spinn_machine.cfg
 # Which in turn adds or overwrites values in SpiNNUtils/spinn_utilities/spinn_utilities.cfg
 
-[Mapping]
-router_table_compression_target_length = 1023
-
 [Reports]
 # NOTE ***that for bespoke file paths, folders will not be automatically deleted***
 # options are DEFAULT or a file path

--- a/pacman/pacman.cfg
+++ b/pacman/pacman.cfg
@@ -6,3 +6,6 @@
 # options are DEFAULT or a file path
 # Note for hard coded locations a "reports" sub directory will be added
 default_report_file_path = DEFAULT
+
+[Mapping]
+router_table_compress_as_far_as_possible = False

--- a/pacman_integration_tests/manual_runner.py
+++ b/pacman_integration_tests/manual_runner.py
@@ -15,6 +15,7 @@
 
 import json
 import time
+from spinn_machine import Machine
 from pacman.model.routing_tables.multicast_routing_tables import (from_json)
 from pacman.model.routing_tables.multicast_routing_tables import (to_json)
 from pacman.model.routing_tables import (MulticastRoutingTables)
@@ -23,10 +24,10 @@ from pacman.operations.router_compressors.routing_compression_checker import (
 from pacman.operations.router_compressors.ordered_covering_router_compressor \
     import OrderedCoveringCompressor
 from pacman.operations.router_compressors import (
-    AbstractCompressor, PairCompressor, UnorderedPairCompressor)
-from pacman.config_setup import reset_configs
+    PairCompressor, UnorderedPairCompressor)
+from pacman.config_setup import unittest_setup
 
-reset_configs()
+unittest_setup()
 # original_tables = from_json("routing_table_15_25.json")
 original_tables = from_json("malloc_hard_routing_tables.json.gz")
 # original_tables = from_json("routing_tables_speader_big.json.gz")
@@ -55,7 +56,7 @@ MUNDY = False
 PRE = False
 PAIR = True
 # Hack to stop it throwing a wobly for too many entries
-AbstractCompressor.MAX_SUPPORTED_LENGTH = 50000
+Machine.ROUTER_ENTRIES = 50000
 mundy_compressor = OrderedCoveringCompressor()
 pre_compressor = UnorderedPairCompressor()
 pair_compressor = PairCompressor()

--- a/pacman_integration_tests/test_big_compression.py
+++ b/pacman_integration_tests/test_big_compression.py
@@ -18,14 +18,13 @@ import time
 import sys
 import unittest
 
+from spinn_utilities.config_holder import set_config
 from pacman.config_setup import unittest_setup
 from pacman.model.routing_tables.multicast_routing_tables import (from_json)
 from pacman.operations.router_compressors.routing_compression_checker import (
     compare_tables)
 from pacman.operations.router_compressors.ordered_covering_router_compressor \
     import OrderedCoveringCompressor
-from pacman.operations.router_compressors.abstract_compressor import \
-    AbstractCompressor
 from pacman.operations.router_compressors import UnorderedPairCompressor
 
 
@@ -35,22 +34,21 @@ class TestBigCompression(unittest.TestCase):
         unittest_setup()
 
     def test_big(self):
+        set_config("Mapping", "router_table_compress_as_far_as_possible", True)
         class_file = sys.modules[self.__module__].__file__
         path = os.path.dirname(os.path.abspath(class_file))
         j_router = os.path.join(path, "malloc_hard_routing_tables.json.gz")
         original_tables = from_json(j_router)
 
         mundy_compressor = OrderedCoveringCompressor()
-        # Hack to stop it throwing a wobly for too many entries
-        AbstractCompressor.MAX_SUPPORTED_LENGTH = 5000
         pre_compressor = UnorderedPairCompressor()
 
         start = time.time()
-        mundy_tables = mundy_compressor(original_tables)
+        mundy_tables = mundy_compressor(original_tables, True)
         mundy_time = time.time()
-        pre_tables = pre_compressor(original_tables)
+        pre_tables = pre_compressor(original_tables, True)
         pre_time = time.time()
-        both_tables = mundy_compressor(pre_tables)
+        both_tables = mundy_compressor(pre_tables, True)
         both_time = time.time()
         for original in original_tables:
             org_routes = set()

--- a/unittests/operations_tests/router_compressor_tests/test_checked_unordered_pair_compression.py
+++ b/unittests/operations_tests/router_compressor_tests/test_checked_unordered_pair_compression.py
@@ -19,10 +19,9 @@ import unittest
 
 from pacman.config_setup import unittest_setup
 from pacman.model.routing_tables.multicast_routing_tables import (from_json)
-from pacman.operations.router_compressors.routing_compression_checker import (
-    compare_tables)
+from pacman.exceptions import PacmanElementAllocationException
 from pacman.operations.router_compressors import (
-    AbstractCompressor, CheckedUnorderedPairCompressor)
+    CheckedUnorderedPairCompressor)
 
 
 class TestUnorderedPairCompressor(unittest.TestCase):
@@ -33,15 +32,9 @@ class TestUnorderedPairCompressor(unittest.TestCase):
     def test_onordered_pair_big(self):
         class_file = sys.modules[self.__module__].__file__
         path = os.path.dirname(os.path.abspath(class_file))
-        j_router = os.path.join(path,
-                                "many_to_one.json.gz")
+        j_router = os.path.join(path, "many_to_one.json.gz")
         original_tables = from_json(j_router)
 
-        # Hack to stop it throwing a wobly for too many entries
-        AbstractCompressor.MAX_SUPPORTED_LENGTH = 50000
         compressor = CheckedUnorderedPairCompressor()
-        compressed_tables = compressor(original_tables)
-        for original in original_tables:
-            compressed = compressed_tables.get_routing_table_for_chip(
-                original.x, original.y)
-            compare_tables(original, compressed)
+        with self.assertRaises(PacmanElementAllocationException):
+            compressor(original_tables)

--- a/unittests/operations_tests/router_compressor_tests/test_compressors.py
+++ b/unittests/operations_tests/router_compressor_tests/test_compressors.py
@@ -55,7 +55,7 @@ class TestCompressor(unittest.TestCase):
         self.original_tables.add_routing_table(original_table)
         unittest_setup()
         set_config(
-            "Mapping", "router_table_compression_target_length", "None")
+            "Mapping", "router_table_compress_as_far_as_possible", True)
 
 
     def check_compression(self, compressed_tables):

--- a/unittests/operations_tests/router_compressor_tests/test_compressors.py
+++ b/unittests/operations_tests/router_compressor_tests/test_compressors.py
@@ -55,8 +55,6 @@ class TestCompressor(unittest.TestCase):
         self.original_tables.add_routing_table(original_table)
         reset_configs()
         load_config()
-        set_config(
-            "Mapping", "router_table_compression_target_length", "None")
 
     def tearDown(self):
         load_config()

--- a/unittests/operations_tests/router_compressor_tests/test_compressors.py
+++ b/unittests/operations_tests/router_compressor_tests/test_compressors.py
@@ -57,7 +57,6 @@ class TestCompressor(unittest.TestCase):
         set_config(
             "Mapping", "router_table_compress_as_far_as_possible", True)
 
-
     def check_compression(self, compressed_tables):
         for original in self.original_tables:
             compressed = compressed_tables.get_routing_table_for_chip(


### PR DESCRIPTION
Removes the cfg router_table_compression_target_length dial.

Fixes: https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/issues/793

Must be done at the same time as;
https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/pull/825

tested by
https://github.com/SpiNNakerManchester/IntegrationTests/pull/65