### PR TITLE
reset_configs

### DIFF
--- a/unittests/operations_tests/router_compressor_tests/test_checked_unordered_pair_compression.py
+++ b/unittests/operations_tests/router_compressor_tests/test_checked_unordered_pair_compression.py
@@ -17,6 +17,7 @@ import os
 import sys
 import unittest
 
+from pacman.config_setup import reset_configs
 from pacman.model.routing_tables.multicast_routing_tables import (from_json)
 from pacman.operations.router_compressors.routing_compression_checker import (
     compare_tables)
@@ -25,6 +26,9 @@ from pacman.operations.router_compressors import (
 
 
 class TestUnorderedPairCompressor(unittest.TestCase):
+
+    def setUp(self):
+        reset_configs()
 
     def test_onordered_pair_big(self):
         class_file = sys.modules[self.__module__].__file__

--- a/unittests/operations_tests/router_compressor_tests/test_ordered_covering_compression.py
+++ b/unittests/operations_tests/router_compressor_tests/test_ordered_covering_compression.py
@@ -17,6 +17,7 @@ import os
 import sys
 import unittest
 
+from pacman.config_setup import reset_configs
 from pacman.model.routing_tables.multicast_routing_tables import (from_json)
 from pacman.operations.router_compressors.routing_compression_checker import (
     compare_tables)
@@ -25,6 +26,9 @@ from pacman.operations.router_compressors.ordered_covering_router_compressor \
 
 
 class TestOrderedCoveringCompressor(unittest.TestCase):
+
+    def setUp(self):
+        reset_configs()
 
     def test_oc_big(self):
         class_file = sys.modules[self.__module__].__file__

--- a/unittests/operations_tests/router_compressor_tests/test_pair_compression.py
+++ b/unittests/operations_tests/router_compressor_tests/test_pair_compression.py
@@ -17,6 +17,7 @@ import os
 import sys
 import unittest
 
+from pacman.config_setup import reset_configs
 from pacman.model.routing_tables.multicast_routing_tables import (from_json)
 from pacman.operations.router_compressors.routing_compression_checker import (
     compare_tables)
@@ -24,6 +25,9 @@ from pacman.operations.router_compressors import PairCompressor
 
 
 class TestPairCompressor(unittest.TestCase):
+
+    def setUp(self):
+        reset_configs()
 
     def test_pair_big(self):
         class_file = sys.modules[self.__module__].__file__

--- a/unittests/operations_tests/router_compressor_tests/test_unordered_pair_compression.py
+++ b/unittests/operations_tests/router_compressor_tests/test_unordered_pair_compression.py
@@ -17,6 +17,7 @@ import os
 import sys
 import unittest
 
+from pacman.config_setup import reset_configs
 from pacman.model.routing_tables.multicast_routing_tables import (from_json)
 from pacman.operations.router_compressors.routing_compression_checker import (
     compare_tables)
@@ -26,11 +27,13 @@ from pacman.operations.router_compressors import (
 
 class TestUnorderedPairCompressor(unittest.TestCase):
 
+    def setUp(self):
+        reset_configs()
+
     def test_onordered_pair_big(self):
         class_file = sys.modules[self.__module__].__file__
         path = os.path.dirname(os.path.abspath(class_file))
-        j_router = os.path.join(path,
-                                "many_to_one.json.gz")
+        j_router = os.path.join(path, "many_to_one.json.gz")
         original_tables = from_json(j_router)
 
         # Hack to stop it throwing a wobly for too many entries


### PR DESCRIPTION
This is a f fix due to unittest not being able to find the default configs.

# Short story:
If a unitest depends on a config add.
```
def setUp(self):
    reset_configs()
```

Where the reset_configs() comes from the config_setup,py in that repository

# Longer story
The get_config... calls normally just return a config value loaded when sim.setup() is run
If no sim.setup is run they will load configs logging a warning

To be able to load configs they have to know where they are.

The config files are added by a chain of add_xyz_cfg in each config_setup,py

The local reset_config() will 
1. clear any previous configs
2. call that change to define where the configs are.

Locally and in actions 1 unittest may find the config files from another test but to depend on this causes an BAD order dependency in tests.
Jenkins appears not to have the configs from a previous test available.

This explanation will be written up in the docs.
