### PR TITLE
Speedup Big FromListConnector 

### DIFF
--- a/pacman/model/graphs/application/application_vertex.py
+++ b/pacman/model/graphs/application/application_vertex.py
@@ -37,6 +37,8 @@ class ApplicationVertex(AbstractVertex, metaclass=AbstractBase):
         # List of machine verts associated with this app vertex
         "_machine_vertices",
 
+        "_vertex_slices",
+
         # The splitter object associated with this app vertex
         "_splitter"]
 
@@ -63,7 +65,7 @@ class ApplicationVertex(AbstractVertex, metaclass=AbstractBase):
         self._splitter = None
         super().__init__(label, constraints)
         self._machine_vertices = OrderedSet()
-
+        self._vertex_slices = None
         # Use setter as there is extra work to do
         self.splitter = splitter
 
@@ -127,6 +129,7 @@ class ApplicationVertex(AbstractVertex, metaclass=AbstractBase):
             raise PacmanAlreadyExistsException(
                 str(machine_vertex), machine_vertex)
         self._machine_vertices.add(machine_vertex)
+        self._vertex_slices = None
 
     @abstractproperty
     def n_atoms(self):
@@ -173,7 +176,10 @@ class ApplicationVertex(AbstractVertex, metaclass=AbstractBase):
 
         :rtype: iterable(Slice)
         """
-        return list(map(lambda x: x.vertex_slice, self._machine_vertices))
+        if self._vertex_slices is None:
+            self._vertex_slices = \
+                list(map(lambda x: x.vertex_slice, self._machine_vertices))
+        return self._vertex_slices
 
     def get_max_atoms_per_core(self):
         """ Gets the maximum number of atoms per core, which is either the\

--- a/pacman/model/partitioner_interfaces/abstract_slices_connect.py
+++ b/pacman/model/partitioner_interfaces/abstract_slices_connect.py
@@ -30,7 +30,7 @@ class AbstractSlicesConnect(object, metaclass=AbstractBase):
     __slots__ = ()
 
     @abstractmethod
-    def could_connect(self, pre_slice, post_slice):
+    def could_connect(self, src_machine_vertex, dest_machine_vertex):
         """ Determine if there is a chance that one of the indexes in the\
             pre-slice could connect to at least one of the indexes in the\
             post-slice.
@@ -39,8 +39,8 @@ class AbstractSlicesConnect(object, metaclass=AbstractBase):
             This method should never return a false negative,
             but may return a false positives
 
-        :param ~pacman.model.graphs.common.Slice pre_slice:
-        :param ~pacman.model.graphs.common.Slice post_slice:
+        :param ~pacman.model.graphs.machine.MachineVertex src_machine_vertexx:
+        :param ~pacman.model.graphs.machine.MachineVertex dest_machine_vertex:
         :return: True if a connection could be possible
         :rtype: bool
         """

--- a/pacman/operations/partition_algorithms/splitter_partitioner.py
+++ b/pacman/operations/partition_algorithms/splitter_partitioner.py
@@ -284,8 +284,7 @@ class SplitterPartitioner(AbstractSplitterPartitioner):
 
         if (isinstance(app_edge, AbstractSlicesConnect) and not
                 app_edge.could_connect(
-                    src_machine_vertex.vertex_slice,
-                    dest_machine_vertex.vertex_slice)):
+                    src_machine_vertex,  dest_machine_vertex)):
             return
 
         # build edge and add to machine graph


### PR DESCRIPTION
Needed for https://github.com/SpiNNakerManchester/sPyNNaker/pull/1095

Application_vertex caching slices has two benefits
1. Avoid recreating then every time
2. FromListConnector  slices == slices is the id based

could_connect change to vertexes
1. Allows FromList to use __split_conn_list which is MUCH faster!
