### PR TITLE
If an optional param/token can be provided it must be

### DIFF
--- a/pacman/executor/pacman_algorithm_executor.py
+++ b/pacman/executor/pacman_algorithm_executor.py
@@ -384,16 +384,6 @@ class PACMANAlgorithmExecutor(object):
 
             # Check optional algorithms forcing optional inputs
             (optionals_to_use, True, True),
-
-            # Check required algorithms without optional inputs
-            # - shouldn't need to do this, but might if an optional input
-            # is also a generated output of the same algorithm
-            (algorithms_to_find, False, False),
-
-            # Check optional algorithms without optional inputs
-            # - as above, it shouldn't be necessary but might be if an
-            # optional input is also an output of the same algorithm
-            (optionals_to_use, True, False)
         ]
 
         for (algorithms, check_outputs, force_required) in order:


### PR DESCRIPTION
I discovered a toekn optionally required loop

ChipIOBufClearer had an input <token>ReadIOBuf, ChipIOBufExtractor had an input <token>ApplicationRun and an has an input <token>ClearedIOBuf

This resulted in PACMANAlgorithmExecutor picking the order by implementation rather than by design.

This was caused by the support for an algorithm that inputs and outputs the same ParamType

Removal of this safety requires https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/pull/835

Tested by https://github.com/SpiNNakerManchester/IntegrationTests/pull/68