### PR TITLE
Pylint fix

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,4 +1,4 @@
-# Copyright (c) 2019 The University of Manchester
+# Copyright (c) 2022 The University of Manchester
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -69,85 +69,7 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-disable=print-statement,
-        parameter-unpacking,
-        unpacking-in-except,
-        old-raise-syntax,
-        backtick,
-        long-suffix,
-        old-ne-operator,
-        old-octal-literal,
-        import-star-module-level,
-        non-ascii-bytes-literal,
-        raw-checker-failed,
-        bad-inline-option,
-        locally-disabled,
-        locally-enabled,
-        file-ignored,
-        suppressed-message,
-        useless-suppression,
-        deprecated-pragma,
-        apply-builtin,
-        basestring-builtin,
-        buffer-builtin,
-        cmp-builtin,
-        coerce-builtin,
-        execfile-builtin,
-        file-builtin,
-        long-builtin,
-        raw_input-builtin,
-        reduce-builtin,
-        standarderror-builtin,
-        unicode-builtin,
-        xrange-builtin,
-        coerce-method,
-        delslice-method,
-        getslice-method,
-        setslice-method,
-        no-absolute-import,
-        old-division,
-        dict-iter-method,
-        dict-view-method,
-        next-method-called,
-        metaclass-assignment,
-        indexing-exception,
-        raising-string,
-        reload-builtin,
-        oct-method,
-        hex-method,
-        nonzero-method,
-        cmp-method,
-        input-builtin,
-        round-builtin,
-        intern-builtin,
-        unichr-builtin,
-        map-builtin-not-iterating,
-        zip-builtin-not-iterating,
-        range-builtin-not-iterating,
-        filter-builtin-not-iterating,
-        using-cmp-argument,
-        eq-without-hash,
-        div-method,
-        idiv-method,
-        rdiv-method,
-        exception-message-attribute,
-        invalid-str-codec,
-        sys-max-int,
-        bad-python3-import,
-        deprecated-string-function,
-        deprecated-str-translate-call,
-        deprecated-itertools-function,
-        deprecated-types-field,
-        next-method-defined,
-        dict-items-not-iterating,
-        dict-keys-not-iterating,
-        dict-values-not-iterating,
-        invalid-name,
-        too-many-lines,
-        global-statement,
-        fixme,
-        protected-access,
-        attribute-defined-outside-init
+disable=
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
@@ -341,15 +263,14 @@ single-line-if-stmt=no
 
 # Logging modules to check that the string format arguments are in logging
 # function parameter format
-logging-modules=logging
+logging-modules=logging,FormatAdapter
 
 
 [MISCELLANEOUS]
 
 # List of note tags to take in consideration, separated by a comma.
 notes=FIXME,
-      XXX,
-      TODO
+      XXX
 
 
 [SIMILARITIES]

--- a/pacman/executor/injection_decorator.py
+++ b/pacman/executor/injection_decorator.py
@@ -75,6 +75,7 @@ def provide_injectables(injectables):
     :param injectables: A dict of type to value
     :type injectables: dict(str, ...)
     """
+    # pylint:disable=global-statement
     global _injectables
     if _injectables is not None:
         raise InjectionException("Injectables have already been defined")
@@ -84,6 +85,7 @@ def provide_injectables(injectables):
 def clear_injectables():
     """ Clear the current set of injectables
     """
+    # pylint:disable=global-statement
     global _injectables
     _injectables = None
 
@@ -132,6 +134,7 @@ class injection_context(object):
         self._mine = injection_dictionary
 
     def __enter__(self):
+        # pylint:disable=global-statement
         global _injectables
         dicts = [self._mine]
         if _injectables is not None:
@@ -140,6 +143,7 @@ class injection_context(object):
         _injectables = _DictFacade(dicts)
 
     def __exit__(self, a, b, c):
+        # pylint:disable=global-statement
         global _injectables
         _injectables = self._old
         return False

--- a/pacman/model/graphs/common/constrained_object.py
+++ b/pacman/model/graphs/common/constrained_object.py
@@ -38,9 +38,7 @@ class ConstrainedObject(object, metaclass=AbstractBase):
             Any initial constraints
         """
 
-        # safety point for diamond inheritance
-        if not hasattr(self, '_constraints') or self._constraints is None:
-            self._constraints = OrderedSet()
+        self._constraints = OrderedSet()
 
         # add new constraints to the set
         self.add_constraints(constraints)

--- a/pacman/model/graphs/common/constrained_object.py
+++ b/pacman/model/graphs/common/constrained_object.py
@@ -60,11 +60,7 @@ class ConstrainedObject(object, metaclass=AbstractBase):
                 "constraint", constraint,
                 "Must be a " + _get_class_name(AbstractConstraint))
 
-        try:
-            self._constraints.add(constraint)
-        except Exception:  # pylint: disable=broad-except
-            self._constraints = OrderedSet()
-            self._constraints.add(constraint)
+        self._constraints.add(constraint)
 
     def add_constraints(self, constraints):
         """ Add an iterable of constraints to the collection of constraints

--- a/pacman/model/graphs/common/constrained_object.py
+++ b/pacman/model/graphs/common/constrained_object.py
@@ -79,7 +79,4 @@ class ConstrainedObject(object, metaclass=AbstractBase):
 
         :rtype: iterable(AbstractConstraint)
         """
-        try:
-            return self._constraints
-        except Exception:  # pylint: disable=broad-except
-            return OrderedSet()
+        return self._constraints

--- a/pacman/model/partitioner_interfaces/legacy_partitioner_api.py
+++ b/pacman/model/partitioner_interfaces/legacy_partitioner_api.py
@@ -65,7 +65,7 @@ class LegacyPartitionerAPI(object, metaclass=AbstractBase):
         """
 
     @staticmethod
-    def _abstract_methods():
+    def abstract_methods():
         """ Exposes the abstract methods and properties defined in this class.
 
         :rtype frozenset(str)

--- a/pacman/model/partitioner_splitters/splitter_one_to_one_legacy.py
+++ b/pacman/model/partitioner_splitters/splitter_one_to_one_legacy.py
@@ -70,7 +70,7 @@ class SplitterOneToOneLegacy(AbstractSplitterCommon):
                 resources_required=self._resources_required, label=None,
                 constraints=None))
         if not isinstance(app_vertex, LegacyPartitionerAPI):
-            for abstractmethod in LegacyPartitionerAPI._abstract_methods():
+            for abstractmethod in LegacyPartitionerAPI.abstract_methods():
                 check = getattr(app_vertex, abstractmethod, None)
                 if not check:
                     raise PacmanConfigurationException(

--- a/pacman/model/partitioner_splitters/splitter_slice_legacy.py
+++ b/pacman/model/partitioner_splitters/splitter_slice_legacy.py
@@ -50,7 +50,7 @@ class SplitterSliceLegacy(AbstractSplitterSlice):
     def set_governed_app_vertex(self, app_vertex):
         super().set_governed_app_vertex(app_vertex)
         if not isinstance(app_vertex, LegacyPartitionerAPI):
-            for abstractmethod in LegacyPartitionerAPI._abstract_methods():
+            for abstractmethod in LegacyPartitionerAPI.abstract_methods():
                 check = getattr(app_vertex, abstractmethod, None)
                 if not check:
                     raise PacmanConfigurationException(

--- a/pacman/model/resources/multi_region_sdram.py
+++ b/pacman/model/resources/multi_region_sdram.py
@@ -101,11 +101,11 @@ class MultiRegionSDRAM(VariableSDRAM):
         self._fixed_sdram = self._fixed_sdram + other.fixed
         self._per_timestep_sdram = \
             self._per_timestep_sdram + other.per_timestep
-        for region in other.__regions:
-            if region in self.__regions:
-                self.__regions[region] += other.__regions[region]
+        for region in other.regions:
+            if region in self.regions:
+                self.__regions[region] += other.regions[region]
             else:
-                self.__regions[region] = other.__regions[region]
+                self.__regions[region] = other.regions[region]
 
     @overrides(AbstractSDRAM.report)
     def report(self, timesteps, indent="", preamble="", target=None):

--- a/pacman/model/routing_tables/uncompressed_multicast_routing_table.py
+++ b/pacman/model/routing_tables/uncompressed_multicast_routing_table.py
@@ -241,5 +241,5 @@ def from_csv(file_name):
         with gzip.open(file_name, mode="rt", newline='') as csvfile:
             return _from_csv_file(csvfile)
     else:
-        with open(file_name, newline='') as csvfile:
+        with open(file_name, newline='', encoding="utf-8") as csvfile:
             return _from_csv_file(csvfile)

--- a/pacman/operations/chip_id_allocator_algorithms/malloc_based_chip_id_allocator.py
+++ b/pacman/operations/chip_id_allocator_algorithms/malloc_based_chip_id_allocator.py
@@ -52,6 +52,7 @@ def malloc_based_chip_id_allocator(machine, graph):
         If a virtual chip is in an impossible position.
     """
     allocator = _MallocBasedChipIdAllocator()
+    # pylint:disable=protected-access
     return allocator._run(machine, graph)
 
 

--- a/pacman/operations/fixed_route_router/fixed_route_router.py
+++ b/pacman/operations/fixed_route_router/fixed_route_router.py
@@ -34,6 +34,7 @@ def fixed_route_router(machine, placements, destination_class):
     :raises PacmanAlreadyExistsException:
     """
     router = _FixedRouteRouter(machine, placements, destination_class)
+    # pylint:disable=protected-access
     return router._run()
 
 

--- a/pacman/operations/fixed_route_router/fixed_route_router.py
+++ b/pacman/operations/fixed_route_router/fixed_route_router.py
@@ -66,7 +66,6 @@ class _FixedRouteRouter(object):
         :raises PacmanRoutingException:
         :raises PacmanAlreadyExistsException:
         """
-        # pylint: disable=attribute-defined-outside-init
         progress = ProgressBar(
             len(self._machine.ethernet_connected_chips),
             "Generating fixed router routes")

--- a/pacman/operations/partition_algorithms/splitter_partitioner.py
+++ b/pacman/operations/partition_algorithms/splitter_partitioner.py
@@ -51,6 +51,7 @@ def splitter_partitioner(
          If something goes wrong with the partitioning
      """
     partitioner = _SplitterPartitioner()
+    # pylint:disable=protected-access
     return partitioner._run(
         app_graph, machine, plan_n_time_steps, pre_allocated_resources)
 

--- a/pacman/operations/placer_algorithms/connective_based_placer.py
+++ b/pacman/operations/placer_algorithms/connective_based_placer.py
@@ -48,6 +48,7 @@ def connective_based_placer(machine_graph, machine, plan_n_timesteps):
         If something goes wrong with the placement
     """
     placer = _ConnectiveBasedPlacer()
+    # pylint:disable=protected-access
     return placer._run(machine_graph, machine, plan_n_timesteps)
 
 

--- a/pacman/operations/placer_algorithms/one_to_one_placer.py
+++ b/pacman/operations/placer_algorithms/one_to_one_placer.py
@@ -57,6 +57,7 @@ def one_to_one_placer(machine_graph, machine, plan_n_timesteps):
         If something goes wrong with the placement
     """
     placer = _OneToOnePlacer()
+    # pylint:disable=protected-access
     return placer._run(machine_graph, machine, plan_n_timesteps)
 
 

--- a/pacman/operations/placer_algorithms/radial_placer.py
+++ b/pacman/operations/placer_algorithms/radial_placer.py
@@ -44,6 +44,7 @@ def radial_placer(machine_graph, machine, plan_n_timesteps):
             If something goes wrong with the placement
     """
     placer = _RadialPlacer()
+    # pylint:disable=protected-access
     return placer._run(machine_graph, machine, plan_n_timesteps)
 
 

--- a/pacman/operations/placer_algorithms/spreader_placer.py
+++ b/pacman/operations/placer_algorithms/spreader_placer.py
@@ -42,6 +42,7 @@ def spreader_placer(machine_graph, machine, n_keys_map, plan_n_timesteps):
     :rtype: Placements
     """
     placer = _SpreaderPlacer()
+    # pylint:disable=protected-access
     return placer._run(machine_graph, machine, n_keys_map, plan_n_timesteps)
 
 

--- a/pacman/operations/router_algorithms/basic_dijkstra_routing.py
+++ b/pacman/operations/router_algorithms/basic_dijkstra_routing.py
@@ -72,6 +72,7 @@ def basic_dijkstra_routing(
         If something goes wrong with the routing
     """
     router = _BasicDijkstraRouting(machine, bw_per_route_entry, max_bw)
+    # pylint:disable=protected-access
     return router._run(placements, machine_graph)
 
 

--- a/pacman/operations/router_algorithms/routing_tree.py
+++ b/pacman/operations/router_algorithms/routing_tree.py
@@ -144,6 +144,7 @@ class RoutingTree(object):
             # Determine the set of directions we must travel to reach the
             # children
             out_directions = set()
+            # pylint:disable=protected-access
             for child_direction, child in node._children:
                 # Note that if the direction is unspecified, we simply
                 # (silently) don't add a route for that child.

--- a/pacman/operations/router_compressors/abstract_compressor.py
+++ b/pacman/operations/router_compressors/abstract_compressor.py
@@ -44,6 +44,7 @@ class AbstractCompressor(object):
     def __init__(self, ordered=True, accept_overflow=False):
         self._ordered = ordered
         self._accept_overflow = accept_overflow
+        self._problems = ""
 
     def _run(self, router_tables):
         """
@@ -82,7 +83,6 @@ class AbstractCompressor(object):
         :raises MinimisationFailedError: on failure
         """
         compressed_tables = MulticastRoutingTables()
-        self._problems = ""
         if get_config_bool(
                 "Mapping", "router_table_compress_as_far_as_possible"):
             # Compress as much as possible

--- a/pacman/operations/router_compressors/entry.py
+++ b/pacman/operations/router_compressors/entry.py
@@ -47,6 +47,7 @@ class Entry(object):
         :rtype: Entry
         """
         # Yes I know using _params is ugly but this is for speed
+        # pylint:disable=protected-access
         return Entry(
             mre._routing_entry_key, mre._mask, mre._defaultable,
             mre._spinnaker_route)

--- a/pacman/operations/router_compressors/ordered_covering_router_compressor/ordered_covering_compressor.py
+++ b/pacman/operations/router_compressors/ordered_covering_router_compressor/ordered_covering_compressor.py
@@ -32,6 +32,7 @@ def ordered_covering_compressor(router_tables):
     :rtype: MulticastRoutingTables
     """
     compressor = _OrderedCoveringCompressor()
+    # pylint:disable=protected-access
     return compressor._run(router_tables)
 
 

--- a/pacman/operations/router_compressors/pair_compressor.py
+++ b/pacman/operations/router_compressors/pair_compressor.py
@@ -31,6 +31,7 @@ def pair_compressor(
     :rtype: MulticastRoutingTables
     """
     compressor = _PairCompressor(ordered, accept_overflow)
+    # pylint:disable=protected-access
     compressed = compressor._run(router_tables)
     # TODO currenly normal pari compressor does not verify lengths
     if verify:
@@ -159,6 +160,16 @@ class _PairCompressor(AbstractCompressor):
         # Number of unique routes found so far
         "_routes_count",
     ]
+
+    def __init__(self):
+        self._all_entries = None
+        self._write_index = None
+        self._max_index = None
+        self._previous_index = None
+        self._remaining_index = None
+        self._routes = None
+        self._routes_frequency = None
+        self._routes_count = None
 
     def _compare_routes(self, route_a, route_b):
         """

--- a/pacman/operations/router_compressors/pair_compressor.py
+++ b/pacman/operations/router_compressors/pair_compressor.py
@@ -161,7 +161,8 @@ class _PairCompressor(AbstractCompressor):
         "_routes_count",
     ]
 
-    def __init__(self):
+    def __init__(self, ordered=True, accept_overflow=False):
+        super().__init__(ordered, accept_overflow)
         self._all_entries = None
         self._write_index = None
         self._max_index = None

--- a/pacman/operations/router_compressors/ranged_compressor.py
+++ b/pacman/operations/router_compressors/ranged_compressor.py
@@ -68,6 +68,10 @@ class RangeCompressor(object):
         "_entries"
     ]
 
+    def __init__(self):
+        self._compressed = None
+        self._entries = None
+
     def compress_table(self, uncompressed):
         """ Compresses all the entries for a single table.
 
@@ -108,7 +112,7 @@ class RangeCompressor(object):
                 first = i
                 route = entry.spinnaker_route
         # Merge the last range
-        self._merge_range(first, i)
+        self._merge_range(first, i)  # pylint:disable=undefined-loop-variable
 
         # return the results as a list
         return self._compressed

--- a/pacman/utilities/algorithm_utilities/routing_info_allocator_utilities.py
+++ b/pacman/utilities/algorithm_utilities/routing_info_allocator_utilities.py
@@ -138,6 +138,7 @@ def get_mulitcast_edge_groups(machine_graph):
         # If constraints found, put the group in the appropriate constraint
         # group
         if constraints:
+            # pylint:disable=protected-access
             group._set_constraint(constraints[0])
             constraint_type = type(constraints[0])
             groups_by_type[constraint_type].append(group)

--- a/pacman/utilities/utility_calls.py
+++ b/pacman/utilities/utility_calls.py
@@ -176,15 +176,6 @@ def md5(string):
     return hashlib.md5(string.encode()).hexdigest()
 
 
-def ident(object):
-    """ Get the ID of the given object.
-
-    :param object object:
-    :rtype: str
-    """
-    return str(id(object))
-
-
 def get_key_ranges(key, mask):
     """ Get a generator of base_key, n_keys pairs that represent ranges
         allowed by the mask.

--- a/pacman/utilities/utility_calls.py
+++ b/pacman/utilities/utility_calls.py
@@ -176,7 +176,7 @@ def md5(string):
     return hashlib.md5(string.encode()).hexdigest()
 
 
-def ident(object):  # @ReservedAssignment pylint: disable=redefined-builtin
+def ident(object):
     """ Get the ID of the given object.
 
     :param object object:

--- a/unittests/operations_tests/partition_algorithms_tests/test_splitter_partitioner.py
+++ b/unittests/operations_tests/partition_algorithms_tests/test_splitter_partitioner.py
@@ -58,7 +58,6 @@ class TestSplitterPartitioner(unittest.TestCase):
     """
     test for SplitterPartitioner functions
     """
-    # pylint: disable=attribute-defined-outside-init
 
     def setUp(self):
         unittest_setup()


### PR DESCRIPTION
More pylint fixes.

Turns off all global disables.

ConstrainedObject simplified as it is the only place _constraints is actually set

A few underscore method renamed to none underscore as called from outside

Many of the ._run calls could be converted from create object run object but that is out of scope here.

a few other minor fixes/ local disables,

