### PR TITLE
No need for "Ordered" dicts

### DIFF
--- a/pacman/model/graphs/abstract_multiple_partition.py
+++ b/pacman/model/graphs/abstract_multiple_partition.py
@@ -13,8 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from collections import OrderedDict
-from spinn_utilities.default_ordered_dict import DefaultOrderedDict
+from collections import defaultdict
 from spinn_utilities.ordered_set import OrderedSet
 from spinn_utilities.overrides import overrides
 from pacman.exceptions import PacmanConfigurationException
@@ -38,8 +37,8 @@ class AbstractMultiplePartition(AbstractEdgePartition):
             identifier=identifier,
             allowed_edge_types=allowed_edge_types, constraints=constraints,
             label=label, traffic_weight=traffic_weight, class_name=class_name)
-        self._pre_vertices = OrderedDict()
-        self._destinations = DefaultOrderedDict(OrderedSet)
+        self._pre_vertices = dict()
+        self._destinations = defaultdict(OrderedSet)
 
         # hard code dict of lists so that only these are acceptable.
         for pre_vertex in pre_vertices:

--- a/pacman/model/graphs/application/application_graph.py
+++ b/pacman/model/graphs/application/application_graph.py
@@ -13,10 +13,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from collections import defaultdict
 from .application_edge import ApplicationEdge
 from .application_vertex import ApplicationVertex
 from .application_edge_partition import ApplicationEdgePartition
-from spinn_utilities.default_ordered_dict import DefaultOrderedDict
 from spinn_utilities.ordered_set import OrderedSet
 from spinn_utilities.overrides import overrides
 from pacman.exceptions import (
@@ -40,7 +40,7 @@ class ApplicationGraph(Graph):
         """
         super().__init__(ApplicationVertex, ApplicationEdge, label)
         self._outgoing_edge_partitions_by_pre_vertex = \
-            DefaultOrderedDict(OrderedSet)
+            defaultdict(OrderedSet)
 
     def forget_machine_graph(self):
         """ Forget the whole mapping from this graph to an application graph.

--- a/pacman/model/graphs/graph.py
+++ b/pacman/model/graphs/graph.py
@@ -13,10 +13,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from collections import OrderedDict
+from collections import defaultdict
 from spinn_utilities.abstract_base import (
     AbstractBase, abstractmethod, abstractproperty)
-from spinn_utilities.default_ordered_dict import DefaultOrderedDict
 from spinn_utilities.ordered_set import OrderedSet
 from pacman.exceptions import (
     PacmanAlreadyExistsException, PacmanInvalidParameterException)
@@ -72,11 +71,11 @@ class Graph(ConstrainedObject, metaclass=AbstractBase):
         self._vertices = []
         self._vertex_by_label = dict()
         self._unlabelled_vertex_count = 0
-        self._outgoing_edge_partitions_by_name = OrderedDict()
-        self._outgoing_edges = DefaultOrderedDict(OrderedSet)
-        self._incoming_edges = DefaultOrderedDict(OrderedSet)
-        self._incoming_edges_by_partition_name = DefaultOrderedDict(list)
-        self._outgoing_edge_partition_by_edge = OrderedDict()
+        self._outgoing_edge_partitions_by_name = dict()
+        self._outgoing_edges = defaultdict(OrderedSet)
+        self._incoming_edges = defaultdict(OrderedSet)
+        self._incoming_edges_by_partition_name = defaultdict(list)
+        self._outgoing_edge_partition_by_edge = dict()
         self._label = label
 
     @property

--- a/pacman/model/graphs/machine/machine_graph.py
+++ b/pacman/model/graphs/machine/machine_graph.py
@@ -80,7 +80,7 @@ class MachineGraph(Graph):
             # Must be false as there is no App_graph
             self._application_level_used = False
         self._multicast_partitions = defaultdict(
-            lambda:defaultdict(set))
+            lambda: defaultdict(set))
         self._edge_partitions = OrderedSet()
         self._fixed_route_edge_partitions_by_pre_vertex = (
             defaultdict(OrderedSet))

--- a/pacman/model/graphs/machine/machine_graph.py
+++ b/pacman/model/graphs/machine/machine_graph.py
@@ -13,11 +13,11 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from collections import defaultdict
 from .machine_vertex import MachineVertex
 from .machine_edge import MachineEdge
 from spinn_utilities.ordered_set import OrderedSet
 from spinn_utilities.overrides import overrides
-from spinn_utilities.default_ordered_dict import DefaultOrderedDict
 from pacman.exceptions import (
     PacmanAlreadyExistsException, PacmanInvalidParameterException)
 from pacman.model.graphs import Graph
@@ -79,21 +79,21 @@ class MachineGraph(Graph):
         else:
             # Must be false as there is no App_graph
             self._application_level_used = False
-        self._multicast_partitions = DefaultOrderedDict(
-            lambda: DefaultOrderedDict(set))
+        self._multicast_partitions = defaultdict(
+            lambda:defaultdict(set))
         self._edge_partitions = OrderedSet()
         self._fixed_route_edge_partitions_by_pre_vertex = (
-            DefaultOrderedDict(OrderedSet))
+            defaultdict(OrderedSet))
         self._multicast_edge_partitions_by_pre_vertex = (
-            DefaultOrderedDict(OrderedSet))
+            defaultdict(OrderedSet))
         self._sdram_edge_partitions_by_pre_vertex = (
-            DefaultOrderedDict(OrderedSet))
+            defaultdict(OrderedSet))
         self._fixed_route_edge_partitions_by_post_vertex = (
-            DefaultOrderedDict(OrderedSet))
+            defaultdict(OrderedSet))
         self._multicast_edge_partitions_by_post_vertex = (
-            DefaultOrderedDict(OrderedSet))
+            defaultdict(OrderedSet))
         self._sdram_edge_partitions_by_post_vertex = (
-            DefaultOrderedDict(OrderedSet))
+            defaultdict(OrderedSet))
 
     @overrides(Graph.add_edge)
     def add_edge(self, edge, outgoing_edge_partition_name):

--- a/pacman/model/partitioner_splitters/abstract_splitters/abstract_splitter_common.py
+++ b/pacman/model/partitioner_splitters/abstract_splitters/abstract_splitter_common.py
@@ -13,7 +13,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import sys
-from collections import OrderedDict
 from spinn_utilities.abstract_base import AbstractBase, abstractmethod
 from pacman.exceptions import PacmanConfigurationException
 from pacman.model.constraints.partitioner_constraints import (
@@ -85,7 +84,7 @@ class AbstractSplitterCommon(object, metaclass=AbstractBase):
         :return: dict of vertex as key, edge types as list in value
         :rtype: dict(MachineVertex, EdgeType)
         """
-        result = OrderedDict()
+        result = dict()
         for vertex in self._governed_app_vertex.machine_vertices:
             result[vertex] = edge_types
         return result

--- a/pacman/model/placements/placements.py
+++ b/pacman/model/placements/placements.py
@@ -13,7 +13,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from collections import OrderedDict
 from pacman.exceptions import (
     PacmanAlreadyPlacedError, PacmanNotPlacedError,
     PacmanProcessorAlreadyOccupiedError, PacmanProcessorNotOccupiedError)
@@ -41,8 +40,8 @@ class Placements(object):
         :raise PacmanProcessorAlreadyOccupiedError:
             If two placements are made to the same processor.
         """
-        self._placements = OrderedDict()
-        self._machine_vertices = OrderedDict()
+        self._placements = dict()
+        self._machine_vertices = dict()
         if placements is not None:
             self.add_placements(placements)
 

--- a/pacman/model/routing_table_by_partition/multicast_routing_table_by_partition.py
+++ b/pacman/model/routing_table_by_partition/multicast_routing_table_by_partition.py
@@ -13,7 +13,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from collections import OrderedDict
 
 
 class MulticastRoutingTableByPartition(object):
@@ -26,7 +25,7 @@ class MulticastRoutingTableByPartition(object):
     ]
 
     def __init__(self):
-        self._router_to_entries_map = OrderedDict()
+        self._router_to_entries_map = dict()
 
     def add_path_entry(self, entry, router_x, router_y, partition):
         """ Adds a multicast routing path entry
@@ -41,7 +40,7 @@ class MulticastRoutingTableByPartition(object):
         # update router_to_entries_map
         key = (router_x, router_y)
         if key not in self._router_to_entries_map:
-            self._router_to_entries_map[key] = OrderedDict()
+            self._router_to_entries_map[key] = dict()
 
         if partition not in self._router_to_entries_map[key]:
             self._router_to_entries_map[key][partition] = entry

--- a/pacman/model/routing_table_by_partition/multicast_routing_table_by_partition.py
+++ b/pacman/model/routing_table_by_partition/multicast_routing_table_by_partition.py
@@ -14,7 +14,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-
 class MulticastRoutingTableByPartition(object):
     """ A set of multicast routing path objects
     """

--- a/pacman/model/routing_tables/multicast_routing_tables.py
+++ b/pacman/model/routing_tables/multicast_routing_tables.py
@@ -15,7 +15,6 @@
 
 import json
 import gzip
-from collections import OrderedDict
 from pacman.exceptions import PacmanAlreadyExistsException
 from .uncompressed_multicast_routing_table import \
     UnCompressedMulticastRoutingTable
@@ -119,12 +118,12 @@ class MulticastRoutingTables(object):
 def to_json(router_table):
     json_list = []
     for routing_table in router_table:
-        json_routing_table = OrderedDict()
+        json_routing_table = dict()
         json_routing_table["x"] = routing_table.x
         json_routing_table["y"] = routing_table.y
         entries = []
         for entry in routing_table.multicast_routing_entries:
-            json_entry = OrderedDict()
+            json_entry = dict()
             json_entry["key"] = entry.routing_entry_key
             json_entry["mask"] = entry.mask
             json_entry["defaultable"] = entry.defaultable

--- a/pacman/model/routing_tables/uncompressed_multicast_routing_table.py
+++ b/pacman/model/routing_tables/uncompressed_multicast_routing_table.py
@@ -13,7 +13,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from collections import OrderedDict
 import csv
 import gzip
 import logging
@@ -70,7 +69,7 @@ class UnCompressedMulticastRoutingTable(AbstractMulticastRoutingTable):
         self._y = y
         self._number_of_defaulted_routing_entries = 0
         self._multicast_routing_entries = list()
-        self._entries_by_key_mask = OrderedDict()
+        self._entries_by_key_mask = dict()
         self._entries_by_key = dict()
 
         if multicast_routing_entries is not None:

--- a/pacman/operations/partition_algorithms/splitter_partitioner.py
+++ b/pacman/operations/partition_algorithms/splitter_partitioner.py
@@ -13,7 +13,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from collections import OrderedDict
 from pacman.exceptions import (PacmanConfigurationException)
 from pacman.model.constraints.partitioner_constraints import (
     MaxVertexAtomsConstraint, FixedVertexAtomsConstraint)
@@ -157,7 +156,7 @@ class _SplitterPartitioner(AbstractSplitterPartitioner):
         :return: vertices in list with new ordering
         :rtype: iterable(ApplicationVertex)
         """
-        dependent_vertices = OrderedDict()
+        dependent_vertices = dict()
         other_vertices = set()
         for vertex in vertices:
             if isinstance(vertex.splitter, AbstractDependentSplitter):

--- a/pacman/operations/router_compressors/routing_compression_checker.py
+++ b/pacman/operations/router_compressors/routing_compression_checker.py
@@ -13,7 +13,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from collections import OrderedDict
 import logging
 from spinn_utilities.log import FormatAdapter
 from pacman.exceptions import PacmanRoutingException
@@ -62,7 +61,7 @@ def codify_table(table, length=32):
     :param int length:
     :rtype: dict(str, ~spinn_machine.MulticastRoutingEntry)
     """
-    code_dict = OrderedDict()
+    code_dict = dict()
     for route in table.multicast_routing_entries:
         code_dict[codify(route, length)] = route
     return code_dict

--- a/pacman/operations/routing_table_generators/zoned_routing_table_generator.py
+++ b/pacman/operations/routing_table_generators/zoned_routing_table_generator.py
@@ -13,8 +13,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from collections import defaultdict
 from spinn_utilities.progress_bar import ProgressBar
-from spinn_utilities.default_ordered_dict import DefaultOrderedDict
 from spinn_machine import MulticastRoutingEntry
 from pacman.model.routing_tables import (
     UnCompressedMulticastRoutingTable, MulticastRoutingTables)
@@ -89,7 +89,7 @@ class ZonedRoutingTableGenerator(object):
         :rtype: MulticastRoutingTable
         """
         table = UnCompressedMulticastRoutingTable(chip.x, chip.y)
-        partitions_by_app_vertex = DefaultOrderedDict(set)
+        partitions_by_app_vertex = defaultdict(set)
         for partition in partitions_in_table:
             partitions_by_app_vertex[partition.pre_vertex.app_vertex].add(
                 partition)

--- a/pacman/utilities/algorithm_utilities/partition_algorithm_utilities.py
+++ b/pacman/utilities/algorithm_utilities/partition_algorithm_utilities.py
@@ -16,7 +16,6 @@
 """ A collection of methods which support partitioning algorithms.
 """
 
-from collections import OrderedDict
 from spinn_utilities.ordered_set import OrderedSet
 from pacman.utilities import utility_calls as utils
 from pacman.exceptions import PacmanPartitionException
@@ -82,7 +81,7 @@ def get_same_size_vertex_groups(vertices):
 
     # Dict of vertex to list of vertices with same size
     # (repeated lists expected)
-    same_size_vertices = OrderedDict()
+    same_size_vertices = dict()
 
     for vertex in vertices:
 

--- a/pacman/utilities/algorithm_utilities/placer_algorithm_utilities.py
+++ b/pacman/utilities/algorithm_utilities/placer_algorithm_utilities.py
@@ -14,7 +14,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import functools
-from collections import OrderedDict
 
 from pacman.model.resources import ResourceContainer, ConstantSDRAM
 from spinn_utilities.ordered_set import OrderedSet
@@ -75,7 +74,7 @@ def get_same_chip_vertex_groups(graph):
         get_vertices_on_same_chip, graph=graph))
     # Dict of vertex to set of vertices on same chip (repeated lists expected)
     # A empty set value indicates a set that is too big.
-    same_chip_vertices = OrderedDict()
+    same_chip_vertices = dict()
     for group in groups:
         for vertex in group:
             same_chip_vertices[vertex] = group

--- a/pacman/utilities/algorithm_utilities/routing_info_allocator_utilities.py
+++ b/pacman/utilities/algorithm_utilities/routing_info_allocator_utilities.py
@@ -13,7 +13,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from collections import OrderedDict
 import logging
 from spinn_utilities.log import FormatAdapter
 from spinn_utilities.ordered_set import OrderedSet
@@ -81,7 +80,7 @@ def get_mulitcast_edge_groups(machine_graph):
     """
 
     # mapping between partition and shared key group it is in
-    partition_groups = OrderedDict()
+    partition_groups = dict()
 
     # process each partition one by one in a bubble sort kinda way
     for vertex in machine_graph.vertices:

--- a/pacman/utilities/json_utils.py
+++ b/pacman/utilities/json_utils.py
@@ -16,7 +16,6 @@
 Miscellaneous minor functions for converting between JSON and Python objects.
 """
 
-from collections import OrderedDict
 import json
 import gzip
 from pacman.model.constraints.key_allocator_constraints import (
@@ -78,7 +77,7 @@ def constraint_to_json(constraint):
     :return: A dict describing the constraint
     :rtype: dict
     """
-    json_dict = OrderedDict()
+    json_dict = dict()
     try:
         json_dict["class"] = constraint.__class__.__name__
         if isinstance(constraint, BoardConstraint):
@@ -167,7 +166,7 @@ def constraints_from_json(json_list, graph):
 
 def key_mask_to_json(key_mask):
     try:
-        json_object = OrderedDict()
+        json_object = dict()
         json_object["key"] = key_mask.key
         json_object["mask"] = key_mask.mask
     except Exception as ex:  # pylint: disable=broad-except
@@ -194,7 +193,7 @@ def key_masks_from_json(json_list):
 
 
 def resource_container_to_json(container):
-    json_dict = OrderedDict()
+    json_dict = dict()
     try:
         json_dict["dtcm"] = container.dtcm.get_value()
         json_dict["cpu_cycles"] = container.cpu_cycles.get_value()
@@ -221,7 +220,7 @@ def resource_container_from_json(json_dict):
 
 
 def iptag_resource_to_json(iptag):
-    json_dict = OrderedDict()
+    json_dict = dict()
     try:
         json_dict["ip_address"] = iptag.ip_address
         if iptag.port is not None:
@@ -258,7 +257,7 @@ def iptag_resources_from_json(json_list):
 
 
 def vertex_to_json(vertex):
-    json_dict = OrderedDict()
+    json_dict = dict()
     try:
         json_dict["class"] = vertex.__class__.__name__
         json_dict["label"] = vertex.label
@@ -289,7 +288,7 @@ def vertex_add_contstraints_from_json(json_dict, graph):
 
 
 def edge_to_json(edge):
-    json_dict = OrderedDict()
+    json_dict = dict()
     try:
         json_dict["pre_vertex"] = edge.pre_vertex.label
         json_dict["post_vertex"] = edge.post_vertex.label
@@ -312,7 +311,7 @@ def edge_from_json(json_dict, graph=None):
 
 def graph_to_json(graph):
     #  TODO Appplication vertex info needed for ZonedRoutingInfoAllocator
-    json_dict = OrderedDict()
+    json_dict = dict()
     try:
         if graph.label is not None:
             json_dict["label"] = graph.label
@@ -350,7 +349,7 @@ def vertex_lookup(label, graph=None):
 
 
 def placement_to_json(placement):
-    json_dict = OrderedDict()
+    json_dict = dict()
     try:
         json_dict["vertex_label"] = placement.vertex.label
         json_dict["x"] = placement.x
@@ -377,7 +376,7 @@ def placement_from_json(json_dict, graph=None):
 def partition_to_n_keys_map_to_json(partition_to_n_keys_map):
     json_list = []
     for partition in partition_to_n_keys_map:
-        json_dict = OrderedDict()
+        json_dict = dict()
         try:
             json_dict["pre_vertex_label"] = partition.pre_vertex.label
             json_dict["identifier"] = partition.identifier

--- a/pacman/utilities/vertex_sorter.py
+++ b/pacman/utilities/vertex_sorter.py
@@ -16,6 +16,7 @@
 from collections import defaultdict
 import sys
 
+
 class ConstraintOrder(object):
     """ A constraint order definition for sorting.
     """

--- a/pacman/utilities/vertex_sorter.py
+++ b/pacman/utilities/vertex_sorter.py
@@ -13,9 +13,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from collections import defaultdict
 import sys
-from spinn_utilities.default_ordered_dict import DefaultOrderedDict
-
 
 class ConstraintOrder(object):
     """ A constraint order definition for sorting.
@@ -91,7 +90,7 @@ class VertexSorter(object):
             The order in which the constraints are to be sorted
         """
         # Group constraints based on the class
-        self._constraints = DefaultOrderedDict(list)
+        self._constraints = defaultdict(list)
         for c in constraint_order:
             self._constraints[c.constraint_class].append(
                 (c.relative_order, c.required_optional_properties))


### PR DESCRIPTION
As of python 3.7 (the first version we officially support) all dicts are now order guaranteed.
Even python 3.6 had it just not made if a guarantee

The OrderedDict and our DefaultOrderedDict have a few minor advantages
such as ability to iterate reversed. (python 3.8 normal dicts can but not 3.7 or 3.6)
Ability to .move_to_end() In normal dicts you have to remove and readded to get that affects
But are about 30% slower and do use more ram
ref: https://realpython.com/python-ordereddict/

This set of PRs changes the "ordered" to normal as far as  possible.

They are all independent except that this PACMAN one must be done before (or at the same time as) the utils one!

OrderDict was kept in SpinUtils Ordered Sets as that supports reverse.  

SpallocServer not done as 1. it uses move_to_end and 2 is actively being replaced with a Java version.

tested by:

TODO!