### PR TITLE
nuke future requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-future
 lxml
 jsonschema < 4.4; python_version == '3.6'
 jsonschema; python_version >= '3.7'


### PR DESCRIPTION
python 2.7 is history!

why keep Futures import?

Must be done after
https://github.com/SpiNNakerManchester/SupportScripts/pull/40
https://github.com/SpiNNakerManchester/SpiNNGym/pull/41
https://github.com/SpiNNakerManchester/PyNN8Examples/pull/80
https://github.com/SpiNNakerManchester/microcircuit_model/pull/17

tested by 
https://github.com/SpiNNakerManchester/IntegrationTests/pull/108