### PR TITLE
Remove the cloning of the graph

### DIFF
--- a/pacman/data/pacman_data_view.py
+++ b/pacman/data/pacman_data_view.py
@@ -316,29 +316,6 @@ class PacmanDataView(MachineDataView):
         return cls.__pacman_data._graph.edges
 
     @classmethod
-    def get_runtime_graph(cls):
-        """
-        The runtime application graph
-
-        This is the run time version of the graph which is created by the
-        simulator to add system vertices.
-        Previously known as asb.application_graph.
-
-        Changes to this graph by anything except the insert algorithms is not
-        supported.
-
-         .. note::
-            This method is likely to be removed by another PR.
-            If not it will be replaced with add and iterate methods.
-
-        :rtype: ApplicationGraph
-        :raises ~spinn_utilities.exceptions.SpiNNUtilsException:
-            If the runtime_graph is currently unavailable, or if this method
-            is used except during run
-        """
-        raise NotImplementedError()
-
-    @classmethod
     def get_n_machine_vertices(cls):
         """
         Gets the number of machine vertices via the application graph

--- a/pacman/data/pacman_data_view.py
+++ b/pacman/data/pacman_data_view.py
@@ -264,7 +264,6 @@ class PacmanDataView(MachineDataView):
                 raise cls._exception("graph")
         return iter(cls.__pacman_data._graph.outgoing_edge_partitions)
 
-
     @classmethod
     def get_n_partitions(cls):
         """ The partitions in the user application graph.

--- a/pacman/data/pacman_data_view.py
+++ b/pacman/data/pacman_data_view.py
@@ -213,7 +213,7 @@ class PacmanDataView(MachineDataView):
         if isinstance(vertex, vertex_type)
 
         .. note::
-        The result is a generator so can only be used in a single loop
+            The result is a generator so can only be used in a single loop
 
         :param vertex_type: The type(s) to filter the vertices on
         :type vertex_type: Class or iterable(Class)

--- a/pacman/data/pacman_data_view.py
+++ b/pacman/data/pacman_data_view.py
@@ -336,14 +336,7 @@ class PacmanDataView(MachineDataView):
             If the runtime_graph is currently unavailable, or if this method
             is used except during run
         """
-        if cls.__pacman_data._graph is None:
-            if cls._is_mocked():
-                if cls.__pacman_data._graph is None:
-                    raise cls._exception("graph")
-                cls.__pacman_data._graph = cls.__pacman_data._graph
-            else:
-                raise cls._exception("graph")
-        return cls.__pacman_data._graph
+        raise NotImplementedError()
 
     @classmethod
     def get_n_machine_vertices(cls):
@@ -356,7 +349,7 @@ class PacmanDataView(MachineDataView):
             else:
                 raise cls._exception("graph")
         return sum(len(vertex.machine_vertices)
-                   for vertex in cls.get_graph().vertices)
+                   for vertex in cls.__pacman_data._graph.vertices)
 
     @classmethod
     def iterate_machine_vertices(cls):

--- a/pacman/data/pacman_data_view.py
+++ b/pacman/data/pacman_data_view.py
@@ -177,6 +177,7 @@ class PacmanDataView(MachineDataView):
         :raises SimulatorNotSetupException: If called before sim.setup
         :raises SimulatorShutdownException: If called after sim.end
         """
+        cls.check_valid_simulator()
         if cls.__pacman_data._graph is None:
             if cls._is_mocked():
                 cls.__pacman_data._graph = ApplicationGraph("Mocked")
@@ -210,9 +211,12 @@ class PacmanDataView(MachineDataView):
         Semantic sugar for vertex in get_graph().vertices
         if isinstance(vertex, vertex_type)
 
+        .. note::
+        The result is a generator so can only be used in a single loop
+
         :param vertex_type: The type(s) to filter the vertices on
         :type vertex_type: Class or iterable(Class)
-        :rtype: list(AbstractVertex)
+        :rtype: generator(AbstractVertex)
         :raises ~spinn_utilities.exceptions.SpiNNUtilsException:
             If the graph is currently unavailable
         """
@@ -223,7 +227,7 @@ class PacmanDataView(MachineDataView):
                 raise cls._exception("graph")
         for vertex in cls.__pacman_data._graph.vertices:
             if isinstance(vertex, vertex_type):
-                yield vertex_type
+                yield vertex
 
     @classmethod
     def get_n_vertices(cls):
@@ -259,25 +263,6 @@ class PacmanDataView(MachineDataView):
                 raise cls._exception("graph")
         return iter(cls.__pacman_data._graph.outgoing_edge_partitions)
 
-    @classmethod
-    def get_partitions_clone(cls):
-        """ The partitions in the user application graph as a list
-
-        Note: This is a shallow copy/ full slice of the original list.
-        Any changes to the output will not affect the original
-
-        Semantic sugar for list(get_graph().outgoing_edge_partitions)
-
-        :rtype: list(ApplicationEdgePartition)
-        :raises ~spinn_utilities.exceptions.SpiNNUtilsException:
-            If the graph is currently unavailable
-        """
-        if cls.__pacman_data._graph is None:
-            if cls._is_mocked():
-                cls.__pacman_data._graph = ApplicationGraph("Mocked")
-            else:
-                raise cls._exception("graph")
-        return cls.__pacman_data._graph.outgoing_edge_partitions[:]
 
     @classmethod
     def get_n_partitions(cls):

--- a/pacman/data/pacman_data_view.py
+++ b/pacman/data/pacman_data_view.py
@@ -151,6 +151,7 @@ class PacmanDataView(MachineDataView):
                 cls.__pacman_data._graph = ApplicationGraph("Mocked")
             else:
                 raise cls._exception("graph")
+        cls.check_valid_simulator()
         cls.__pacman_data._graph.add_vertex(vertex)
         cls.__pacman_data._vertices_or_edges_added = True
 

--- a/pacman/data/pacman_data_view.py
+++ b/pacman/data/pacman_data_view.py
@@ -48,7 +48,6 @@ class _PacmanDataModel(object):
         "_precompressed",
         "_routing_infos",
         "_routing_table_by_partition",
-        "_runtime_graph",
         "_tags",
         "_uncompressed",
         "_vertices_or_edges_added",
@@ -82,7 +81,6 @@ class _PacmanDataModel(object):
         self._placements = None
         self._precompressed = None
         self._uncompressed = None
-        self._runtime_graph = None
         self._routing_infos = None
         self._routing_table_by_partition = None
         self._tags = None
@@ -299,27 +297,27 @@ class PacmanDataView(MachineDataView):
             If the runtime_graph is currently unavailable, or if this method
             is used except during run
         """
-        if cls.__pacman_data._runtime_graph is None:
+        if cls.__pacman_data._graph is None:
             if cls._is_mocked():
                 if cls.__pacman_data._graph is None:
                     raise cls._exception("graph")
-                cls.__pacman_data._runtime_graph = cls.__pacman_data._graph
+                cls.__pacman_data._graph = cls.__pacman_data._graph
             else:
-                raise cls._exception("runtime_graph")
-        return cls.__pacman_data._runtime_graph
+                raise cls._exception("graph")
+        return cls.__pacman_data._graph
 
     @classmethod
     def get_runtime_n_machine_vertices(cls):
         """
         Gets the number of machine vertices via the application graph
         """
-        if cls.__pacman_data._runtime_graph is None:
+        if cls.__pacman_data._graph is None:
             if cls._is_mocked():
-                cls.__pacman_data._runtime_graph = ApplicationGraph("Mocked")
+                cls.__pacman_data._graph = ApplicationGraph("Mocked")
             else:
-                raise cls._exception("runtime_graph")
+                raise cls._exception("graph")
         return sum(len(vertex.machine_vertices)
-                   for vertex in cls.get_runtime_graph().vertices)
+                   for vertex in cls.get_graph().vertices)
 
     @classmethod
     def get_runtime_machine_vertices(cls):
@@ -328,12 +326,12 @@ class PacmanDataView(MachineDataView):
 
         :return:
         """
-        if cls.__pacman_data._runtime_graph is None:
+        if cls.__pacman_data._graph is None:
             if cls._is_mocked():
-                cls.__pacman_data._runtime_graph = ApplicationGraph("Mocked")
+                cls.__pacman_data._graph = ApplicationGraph("Mocked")
             else:
-                raise cls._exception("runtime_graph")
-        for app_vertex in cls.get_runtime_graph().vertices:
+                raise cls._exception("graph")
+        for app_vertex in cls.get_graph().vertices:
             yield from app_vertex.machine_vertices
 
     @classmethod

--- a/pacman/data/pacman_data_view.py
+++ b/pacman/data/pacman_data_view.py
@@ -142,16 +142,15 @@ class PacmanDataView(MachineDataView):
             If there is an attempt to add the same vertex more than once
         :raises ~spinn_utilities.exceptions.SpiNNUtilsException:
             If the graph is currently unavailable
-        :raises SimulatorRunningException: If sim.run is currently running
         :raises SimulatorNotSetupException: If called before sim.setup
         :raises SimulatorShutdownException: If called after sim.end
         """
+        cls.check_valid_simulator()
         if cls.__pacman_data._graph is None:
             if cls._is_mocked():
                 cls.__pacman_data._graph = ApplicationGraph("Mocked")
             else:
                 raise cls._exception("graph")
-        cls.check_user_can_act()
         cls.__pacman_data._graph.add_vertex(vertex)
         cls.__pacman_data._vertices_or_edges_added = True
 
@@ -175,7 +174,6 @@ class PacmanDataView(MachineDataView):
             one
         :raises ~spinn_utilities.exceptions.SpiNNUtilsException:
             If the graph is currently unavailable
-        :raises SimulatorRunningException: If sim.run is currently running
         :raises SimulatorNotSetupException: If called before sim.setup
         :raises SimulatorShutdownException: If called after sim.end
         """
@@ -184,7 +182,6 @@ class PacmanDataView(MachineDataView):
                 cls.__pacman_data._graph = ApplicationGraph("Mocked")
             else:
                 raise cls._exception("graph")
-        cls.check_user_can_act()
         cls.__pacman_data._graph.add_edge(edge, outgoing_edge_partition_name)
         cls.__pacman_data._vertices_or_edges_added = True
 
@@ -207,6 +204,28 @@ class PacmanDataView(MachineDataView):
         return iter(cls.__pacman_data._graph.vertices)
 
     @classmethod
+    def get_vertices_by_type(cls, vertex_type):
+        """ The application vertices in the graph of the specific type
+
+        Semantic sugar for vertex in get_graph().vertices
+        if isinstance(vertex, vertex_type)
+
+        :param vertex_type: The type(s) to filter the vertices on
+        :type vertex_type: Class or iterable(Class)
+        :rtype: list(AbstractVertex)
+        :raises ~spinn_utilities.exceptions.SpiNNUtilsException:
+            If the graph is currently unavailable
+        """
+        if cls.__pacman_data._graph is None:
+            if cls._is_mocked():
+                cls.__pacman_data._graph = ApplicationGraph("Mocked")
+            else:
+                raise cls._exception("graph")
+        for vertex in cls.__pacman_data._graph.vertices:
+            if isinstance(vertex, vertex_type):
+                yield vertex_type
+
+    @classmethod
     def get_n_vertices(cls):
         """ The number of vertices in the user application graph.
 
@@ -225,7 +244,7 @@ class PacmanDataView(MachineDataView):
 
     @classmethod
     def iterate_partitions(cls):
-        """ The partitions in the user application graph.
+        """ The partitions in the user application graphs an iterator
 
         Semantic sugar for get_graph().outgoing_edge_partitions
 
@@ -238,7 +257,27 @@ class PacmanDataView(MachineDataView):
                 cls.__pacman_data._graph = ApplicationGraph("Mocked")
             else:
                 raise cls._exception("graph")
-        return cls.__pacman_data._graph.outgoing_edge_partitions
+        return iter(cls.__pacman_data._graph.outgoing_edge_partitions)
+
+    @classmethod
+    def get_partitions_clone(cls):
+        """ The partitions in the user application graph as a list
+
+        Note: This is a shallow copy/ full slice of the original list.
+        Any changes to the output will not affect the original
+
+        Semantic sugar for list(get_graph().outgoing_edge_partitions)
+
+        :rtype: list(ApplicationEdgePartition)
+        :raises ~spinn_utilities.exceptions.SpiNNUtilsException:
+            If the graph is currently unavailable
+        """
+        if cls.__pacman_data._graph is None:
+            if cls._is_mocked():
+                cls.__pacman_data._graph = ApplicationGraph("Mocked")
+            else:
+                raise cls._exception("graph")
+        return cls.__pacman_data._graph.outgoing_edge_partitions[:]
 
     @classmethod
     def get_n_partitions(cls):
@@ -277,6 +316,21 @@ class PacmanDataView(MachineDataView):
             get_outgoing_edge_partitions_starting_at_vertex(vertex)
 
     @classmethod
+    def get_edges(cls):
+        """ Get all the edges in the graph.
+
+        Semantic sugar for get_graph().edges
+
+        :rtype: list(AbstractEdge)
+        """
+        if cls.__pacman_data._graph is None:
+            if cls._is_mocked():
+                cls.__pacman_data._graph = ApplicationGraph("Mocked")
+            else:
+                raise cls._exception("graph")
+        return cls.__pacman_data._graph.edges
+
+    @classmethod
     def get_runtime_graph(cls):
         """
         The runtime application graph
@@ -307,7 +361,7 @@ class PacmanDataView(MachineDataView):
         return cls.__pacman_data._graph
 
     @classmethod
-    def get_runtime_n_machine_vertices(cls):
+    def get_n_machine_vertices(cls):
         """
         Gets the number of machine vertices via the application graph
         """
@@ -320,9 +374,9 @@ class PacmanDataView(MachineDataView):
                    for vertex in cls.get_graph().vertices)
 
     @classmethod
-    def get_runtime_machine_vertices(cls):
+    def iterate_machine_vertices(cls):
         """
-        Gets the Machine vertioces viua the application graph
+        Iterate the Machine vertices viua the application graph
 
         :return:
         """
@@ -331,7 +385,7 @@ class PacmanDataView(MachineDataView):
                 cls.__pacman_data._graph = ApplicationGraph("Mocked")
             else:
                 raise cls._exception("graph")
-        for app_vertex in cls.get_graph().vertices:
+        for app_vertex in cls.__pacman_data._graph.vertices:
             yield from app_vertex.machine_vertices
 
     @classmethod

--- a/pacman/data/pacman_data_writer.py
+++ b/pacman/data/pacman_data_writer.py
@@ -80,7 +80,7 @@ class PacmanDataWriter(MachineDataWriter, PacmanDataView):
 
         :rtype: ApplicationGraph
         """
-        return self.__pacman_data._runtime_graph
+        return self.__pacman_data._graph
 
     def create_graphs(self, graph_label):
         """
@@ -94,13 +94,6 @@ class PacmanDataWriter(MachineDataWriter, PacmanDataView):
 
         self.__pacman_data._graph = ApplicationGraph(label=graph_label)
 
-    def clone_graphs(self):
-        """
-        Clones the user/ original graphs and creates runtime ones
-
-        """
-        self.__pacman_data._runtime_graph = self.__pacman_data._graph.clone()
-
     def _set_runtime_graph(self, graph):
         """
         Only used in unittests
@@ -109,7 +102,7 @@ class PacmanDataWriter(MachineDataWriter, PacmanDataView):
         """
         if not self._is_mocked():
             raise NotImplementedError("Only valid in Mocked state!")
-        self.__pacman_data._runtime_graph = graph
+        self.__pacman_data._graph = graph
 
     def set_placements(self, placements):
         """

--- a/pacman/model/partitioner_splitters/splitter_reset.py
+++ b/pacman/model/partitioner_splitters/splitter_reset.py
@@ -19,6 +19,6 @@ from pacman.data import PacmanDataView
 def splitter_reset():
     """ Performs resetting of splitters to indicate a new phase of operation
     """
-    for vertex in PacmanDataView.get_runtime_graph().vertices:
+    for vertex in PacmanDataView.iterate_vertices():
         if vertex.splitter is not None:
             vertex.splitter.reset_called()

--- a/pacman/operations/partition_algorithms/splitter_partitioner.py
+++ b/pacman/operations/partition_algorithms/splitter_partitioner.py
@@ -46,12 +46,12 @@ class _SplitterPartitioner(AbstractSplitterPartitioner):
         :raise PacmanPartitionException:
             If something goes wrong with the partitioning
         """
-        vertices = PacmanDataView.get_runtime_graph().vertices
-        progress = ProgressBar(len(vertices), "Partitioning Graph")
+        progress = ProgressBar(
+            PacmanDataView.get_n_vertices(), "Partitioning Graph")
 
         # Partition one vertex at a time
         chip_counter = ChipCounter()
-        for vertex in progress.over(vertices):
+        for vertex in progress.over(PacmanDataView.iterate_vertices()):
             vertex.splitter.create_machine_vertices(chip_counter)
 
         return chip_counter.n_chips

--- a/pacman/operations/placer_algorithms/application_placer.py
+++ b/pacman/operations/placer_algorithms/application_placer.py
@@ -42,14 +42,14 @@ def place_application_graph(system_placements):
     placements = Placements(system_placements)
     # board_colours = dict()
 
-    app_graph = PacmanDataView.get_runtime_graph()
     machine = PacmanDataView.get_machine()
     plan_n_timesteps = PacmanDataView.get_plan_n_timestep()
     spaces = _Spaces(machine, placements, plan_n_timesteps)
 
     # Go through the application graph by application vertex
-    progress = ProgressBar(app_graph.n_vertices, "Placing Vertices")
-    for app_vertex in progress.over(app_graph.vertices):
+    progress = ProgressBar(
+        PacmanDataView.get_n_vertices(), "Placing Vertices")
+    for app_vertex in progress.over(PacmanDataView.iterate_vertices()):
         spaces.restore_chips()
 
         # Try placements from the next chip, but try again if fails
@@ -69,8 +69,8 @@ def place_application_graph(system_placements):
                     next_chip_space, space = spaces.get_next_chip_and_space()
                 except PacmanPlaceException as e:
                     _place_error(
-                        app_graph, placements, system_placements, e,
-                        plan_n_timesteps, machine)
+                        placements, system_placements, e,  plan_n_timesteps,
+                        machine)
                 logger.debug(f"Starting placement from {next_chip_space}")
 
                 placements_to_make = list()
@@ -126,12 +126,12 @@ def place_application_graph(system_placements):
 
 
 def _place_error(
-        app_graph, placements, system_placements, exception, plan_n_timesteps,
+        placements, system_placements, exception, plan_n_timesteps,
         machine):
     unplaceable = list()
     vertex_count = 0
     n_vertices = 0
-    for app_vertex in app_graph.vertices:
+    for app_vertex in PacmanDataView.iterate_vertices():
         same_chip_groups = app_vertex.splitter.get_same_chip_groups()
         app_vertex_placed = True
         found_placed_cores = False
@@ -152,8 +152,8 @@ def _place_error(
     report_file = os.path.join(
         PacmanDataView.get_report_dir_path(), "placements_error.txt")
     with open(report_file, 'w', encoding="utf-8") as f:
-        f.write(f"Could not place {len(unplaceable)} of {app_graph.n_vertices}"
-                " application vertices.\n")
+        f.write(f"Could not place {len(unplaceable)} of "
+                f"{PacmanDataView.get_n_vertices()} application vertices.\n")
         f.write(f"    Could not place {vertex_count} of {n_vertices} in the"
                 " last app vertex\n\n")
         for x, y in placements.chips_with_placements:

--- a/pacman/operations/routing_info_allocator_algorithms/zoned_routing_info_allocator.py
+++ b/pacman/operations/routing_info_allocator_algorithms/zoned_routing_info_allocator.py
@@ -116,14 +116,13 @@ class ZonedRoutingInfoAllocator(object):
         :raise PacmanRouteInfoAllocationException:
             If something goes wrong with the allocation
         """
-        app_graph = PacmanDataView.get_runtime_graph()
         self.__vertex_partitions = OrderedSet(
             (p.pre_vertex, p.identifier)
-            for p in app_graph.outgoing_edge_partitions)
+            for p in PacmanDataView.iterate_partitions())
         self.__vertex_partitions.update(extra_allocations)
         self.__vertex_partitions.update(
             (v, p.identifier)
-            for v in app_graph.vertices
+            for v in PacmanDataView.iterate_vertices()
             for p in v.splitter.get_internal_multicast_partitions())
 
         self.__n_bits_atoms_and_mac = 0

--- a/pacman/utilities/algorithm_utilities/routing_algorithm_utilities.py
+++ b/pacman/utilities/algorithm_utilities/routing_algorithm_utilities.py
@@ -42,7 +42,6 @@ def get_app_partitions():
         edges and internal partitions to get a complete picture of all
         targets for each source machine vertex at once.
 
-    :param ApplicationGraph app_graph: The application graph to consider
     :return: list of partitions; note where there are only internal multicast
         partitions, the partition will have no edges.  Caller should use
         vertex.splitter.get_internal_multicast_partitions for details.
@@ -50,12 +49,11 @@ def get_app_partitions():
     """
 
     # Find all partitions that need to be dealt with
-    app_graph = PacmanDataView.get_runtime_graph()
-    partitions = list(app_graph.outgoing_edge_partitions)
+    partitions = PacmanDataView.get_partitions_clone()
     sources = set(p.pre_vertex for p in partitions)
 
     # Convert internal partitions to self-connected partitions
-    for v in app_graph.vertices:
+    for v in PacmanDataView.iterate_partitions():
         internal_partitions = v.splitter.get_internal_multicast_partitions()
         if v not in sources and internal_partitions:
             part_ids = set(p.identifier for p in internal_partitions)

--- a/pacman/utilities/algorithm_utilities/routing_algorithm_utilities.py
+++ b/pacman/utilities/algorithm_utilities/routing_algorithm_utilities.py
@@ -49,11 +49,12 @@ def get_app_partitions():
     """
 
     # Find all partitions that need to be dealt with
-    partitions = PacmanDataView.get_partitions_clone()
+    # Make a copy which we can edit
+    partitions = list(PacmanDataView.iterate_partitions())
     sources = set(p.pre_vertex for p in partitions)
 
     # Convert internal partitions to self-connected partitions
-    for v in PacmanDataView.iterate_partitions():
+    for v in PacmanDataView.iterate_vertices():
         internal_partitions = v.splitter.get_internal_multicast_partitions()
         if v not in sources and internal_partitions:
             part_ids = set(p.identifier for p in internal_partitions)

--- a/unittests/data/test_data.py
+++ b/unittests/data/test_data.py
@@ -15,7 +15,8 @@
 
 import unittest
 from spinn_utilities.exceptions import (
-    DataNotYetAvialable, SimulatorRunningException)
+    DataNotYetAvialable,
+    SimulatorNotSetupException, SimulatorShutdownException)
 from pacman.config_setup import unittest_setup
 from pacman.data import PacmanDataView
 from pacman.data.pacman_data_writer import PacmanDataWriter
@@ -28,6 +29,10 @@ from pacman.model.routing_table_by_partition import (
 from pacman.model.routing_tables import MulticastRoutingTables
 from pacman.model.tags import Tags
 from pacman_test_objects import SimpleTestVertex
+
+
+class SimpleTestVertex2(SimpleTestVertex):
+    pass
 
 
 class TestSimulatorData(unittest.TestCase):
@@ -47,39 +52,16 @@ class TestSimulatorData(unittest.TestCase):
         # check there is a value not what it is
         PacmanDataView.get_run_dir_path()
 
-    def test_graphs(self):
-        writer = PacmanDataWriter.setup()
-        with self.assertRaises(DataNotYetAvialable):
-            PacmanDataView.get_n_vertices()
-        with self.assertRaises(DataNotYetAvialable):
-            PacmanDataView.get_runtime_graph()
-
-        writer.create_graphs("bacon")
-        with self.assertRaises(DataNotYetAvialable):
-            PacmanDataView.get_runtime_graph()
-
-        writer.start_run()
-        writer.clone_graphs()
-        PacmanDataView.get_runtime_graph()
-
-        writer.finish_run()
-        PacmanDataView.get_n_vertices()
-        PacmanDataView.get_runtime_graph()
-        # the writer still has access to the runtime graphs
-        writer.get_runtime_graph()
-
-        writer.stopping()
-        PacmanDataView.get_runtime_graph()
-
     def test_graph_functions(self):
         writer = PacmanDataWriter.setup()
         app1 = SimpleTestVertex(12, "app1")
-        app2 = SimpleTestVertex(23, "app21")
-        app3 = SimpleTestVertex(33, "app3")
+        app2 = SimpleTestVertex2(23, "app21")
+        app3 = SimpleTestVertex2(33, "app3")
         edge12 = ApplicationEdge(app1, app2)
         edge32 = ApplicationEdge(app3, app2)
         edge13 = ApplicationEdge(app1, app3)
         edge11 = ApplicationEdge(app1, app1)
+
         with self.assertRaises(DataNotYetAvialable):
             PacmanDataView.get_n_vertices()
         with self.assertRaises(DataNotYetAvialable):
@@ -94,6 +76,8 @@ class TestSimulatorData(unittest.TestCase):
             PacmanDataView.get_n_vertices()
         with self.assertRaises(DataNotYetAvialable):
             PacmanDataView.iterate_partitions()
+        with self.assertRaises(DataNotYetAvialable):
+            list(PacmanDataView.get_vertices_by_type(SimpleTestVertex2))
 
         writer.create_graphs("test")
         self.assertFalse(PacmanDataView.get_n_vertices() == 1)
@@ -117,28 +101,12 @@ class TestSimulatorData(unittest.TestCase):
         self.assertEqual(2, len(partitions))
         self.assertEqual(2, PacmanDataView.get_n_partitions())
 
-        writer.start_run()
-        # the add methods go boom
-        with self.assertRaises(SimulatorRunningException):
-            PacmanDataView.add_vertex(app1)
-        with self.assertRaises(SimulatorRunningException):
-            PacmanDataView.add_edge(edge12, "foo")
-        # The info methods do still work
-        self.assertTrue(PacmanDataView.get_n_vertices() > 0)
-        self.assertSetEqual(
-            set([app1, app2, app3]),
-            set(PacmanDataView.iterate_vertices()))
-        self.assertEqual(3, PacmanDataView.get_n_vertices())
+        writer.shut_down()
+        # Graph info calls still work
+        PacmanDataView.get_edges_ending_at_vertex(app1)
+        with self.assertRaises(SimulatorShutdownException):
+            PacmanDataView.add_vertex( SimpleTestVertex(12, "new"))
 
-        writer.finish_run()
-        app4 = SimpleTestVertex(44, "app4")
-        edge14 = ApplicationEdge(app1, app4)
-        PacmanDataView.add_vertex(app4)
-        self.assertSetEqual(
-            set([app1, app2, app3, app4]),
-            set(PacmanDataView.iterate_vertices()))
-        self.assertEqual(4, PacmanDataView.get_n_vertices())
-        PacmanDataView.add_edge(edge14, "other")
 
     def test_placements(self):
         writer = PacmanDataWriter.setup()

--- a/unittests/data/test_data.py
+++ b/unittests/data/test_data.py
@@ -77,7 +77,14 @@ class TestSimulatorData(unittest.TestCase):
         with self.assertRaises(DataNotYetAvialable):
             PacmanDataView.iterate_partitions()
         with self.assertRaises(DataNotYetAvialable):
+            PacmanDataView.get_n_partitions()
+        with self.assertRaises(DataNotYetAvialable):
+            PacmanDataView.get_outgoing_edge_partitions_starting_at_vertex(
+                app1)
+        with self.assertRaises(DataNotYetAvialable):
             list(PacmanDataView.get_vertices_by_type(SimpleTestVertex2))
+        with self.assertRaises(DataNotYetAvialable):
+            PacmanDataView.get_edges()
 
         writer.create_graphs("test")
         self.assertFalse(PacmanDataView.get_n_vertices() == 1)
@@ -96,17 +103,34 @@ class TestSimulatorData(unittest.TestCase):
         self.assertSetEqual(
             set([app1, app2, app3]),
             set(PacmanDataView.iterate_vertices()))
+        self.assertEqual(
+            [app2, app3],
+            list(PacmanDataView.get_vertices_by_type(SimpleTestVertex2)))
         self.assertEqual(3, PacmanDataView.get_n_vertices())
         partitions = set(PacmanDataView.iterate_partitions())
         self.assertEqual(2, len(partitions))
         self.assertEqual(2, PacmanDataView.get_n_partitions())
+        ps = PacmanDataView.get_outgoing_edge_partitions_starting_at_vertex(
+            app1)
+        self.assertEqual(1, len(ps))
+        self.assertEqual([edge12, edge13, edge11, edge32],
+                         PacmanDataView.get_edges())
 
         writer.shut_down()
         # Graph info calls still work
         PacmanDataView.get_edges_ending_at_vertex(app1)
+        list(PacmanDataView.iterate_vertices())
+        list(PacmanDataView.get_vertices_by_type(SimpleTestVertex2))
+        PacmanDataView.get_n_vertices()
+        set(PacmanDataView.iterate_partitions())
+        PacmanDataView.get_n_partitions()
+        PacmanDataView.get_outgoing_edge_partitions_starting_at_vertex(app1)
+        PacmanDataView.get_edges()
+        # Adding will no longer work
         with self.assertRaises(SimulatorShutdownException):
-            PacmanDataView.add_vertex( SimpleTestVertex(12, "new"))
-
+            PacmanDataView.add_vertex(SimpleTestVertex(12, "new"))
+        with self.assertRaises(SimulatorShutdownException):
+            PacmanDataView.add_edge(ApplicationEdge(app1, app2), "new")
 
     def test_placements(self):
         writer = PacmanDataWriter.setup()

--- a/unittests/data/test_data.py
+++ b/unittests/data/test_data.py
@@ -133,7 +133,7 @@ class TestSimulatorData(unittest.TestCase):
                          PacmanDataView.get_edges())
         self.assertEqual(6, PacmanDataView.get_n_machine_vertices())
         self.assertEqual([m11, m12, m21, m31, m32, m33],
-            list(PacmanDataView.iterate_machine_vertices()))
+                         list(PacmanDataView.iterate_machine_vertices()))
 
         writer.shut_down()
         # Graph info calls still work


### PR DESCRIPTION
This PR and associated removed the cloning of the Application graph and hides the graph so that it is only accessible through semantic sugar methods.

Semantic sugar methods are listed in
https://github.com/SpiNNakerManchester/SpiNNakerManchester.github.io/pull/42

Should be done at the same time as.
https://github.com/SpiNNakerManchester/SpiNNUtils/pull/184
https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/pull/959
https://github.com/SpiNNakerManchester/sPyNNaker/pull/1194

Tested by 
http://apollo.cs.man.ac.uk:8080/blue/organizations/jenkins/Integration%20Tests/detail/delays/3/pipeline


