### PR TITLE
get_placement_on_processor

### DIFF
--- a/pacman/data/pacman_data_view.py
+++ b/pacman/data/pacman_data_view.py
@@ -369,7 +369,7 @@ class PacmanDataView(MachineDataView):
             raise PacmanNotPlacedError(vertex) from e
 
     @classmethod
-    def get_vertex_on_processor(cls, x, y, p):
+    def get_placement_on_processor(cls, x, y, p):
         """ Return the vertex on a specific processor or raises an exception
             if the processor has not been allocated
 
@@ -385,7 +385,8 @@ class PacmanDataView(MachineDataView):
         """
         if cls.__pacman_data._placements is None:
             raise cls._exception("placements")
-        return cls.__pacman_data._placements.get_vertex_on_processor(x, y, p)
+        return cls.__pacman_data._placements.get_placement_on_processor(
+            x, y, p)
 
     # routing_infos
 

--- a/pacman/model/placements/placements.py
+++ b/pacman/model/placements/placements.py
@@ -81,23 +81,6 @@ class Placements(object):
         self._placements[x, y][p] = placement
         self._machine_vertices[placement.vertex] = placement
 
-    def get_vertex_on_processor(self, x, y, p):
-        """ Return the vertex on a specific processor or raises an exception
-            if the processor has not been allocated
-
-        :param int x: the x coordinate of the chip
-        :param int y: the y coordinate of the chip
-        :param int p: the processor on the chip
-        :return: the vertex placed on the given processor
-        :rtype: MachineVertex
-        :raise PacmanProcessorNotOccupiedError:
-            If the processor is not occupied
-        """
-        try:
-            return self._placements[x, y][p].vertex
-        except KeyError as e:
-            raise PacmanProcessorNotOccupiedError((x, y, p)) from e
-
     def get_placement_on_processor(self, x, y, p):
         """ Return the placement on a specific processor or raises an exception
             if the processor has not been allocated


### PR DESCRIPTION
The view.get_placement_on_processor  was missing and needed by ASB.__recover_from _error 

As view.get_vertex_on_processor differed only by where the .vertex was placed I choose to remove the get_vertex_on_processor from both Placements and View and instead replaced its only use with
view.get_placement_on_processor().vertex

Needed for: https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/pull/979