### PR TITLE
Move bits_needed function into utility_calls

### DIFF
--- a/pacman/operations/routing_info_allocator_algorithms/zoned_routing_info_allocator.py
+++ b/pacman/operations/routing_info_allocator_algorithms/zoned_routing_info_allocator.py
@@ -14,7 +14,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-import math
 from spinn_utilities.log import FormatAdapter
 from spinn_utilities.progress_bar import ProgressBar
 from spinn_utilities.ordered_set import OrderedSet
@@ -238,7 +237,8 @@ class ZonedRoutingInfoAllocator(object):
 
     def __check_zones(self):
         # See if it could fit even before considerding fixed
-        app_part_bits = allocator_bits_needed(len(self.__atom_bits_per_app_part))
+        app_part_bits = allocator_bits_needed(
+            len(self.__atom_bits_per_app_part))
         if app_part_bits + self.__n_bits_atoms_and_mac > BITS_IN_KEY:
             raise PacmanRouteInfoAllocationException(
                 "Unable to use ZonedRoutingInfoAllocator please select a "

--- a/pacman/utilities/utility_calls.py
+++ b/pacman/utilities/utility_calls.py
@@ -214,3 +214,15 @@ def get_n_bits_for_fields(field_sizes):
     """
     field_size = [get_n_bits(n) for n in field_sizes]
     return sum(field_size)
+
+
+def allocator_bits_needed(size):
+    """ Get the bits needed for the routing info allocator
+
+    :param int size: The size to calculate the number of bits for
+    :return: the number of bits required for that size
+    :rtype: int
+    """
+    if size == 0:
+        return 0
+    return int(math.ceil(math.log2(size)))


### PR DESCRIPTION
Move the bits_needed function from the allocator to utility_calls for easier access from elsewhere.

Needed for https://github.com/SpiNNakerManchester/sPyNNaker/pull/1284