### PR TITLE
jsonschema 4.17.3 last with python 3.7 support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-jsonschema
+jsonschema <= 4.17.3; python_version == '3.7'
+jsonschema; python_version >= '3.8'
 SpiNNUtilities == 1!6.0.1
 SpiNNMachine == 1!6.0.1

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,9 @@ setup(
     install_requires=[
         'SpiNNUtilities == 1!6.0.1',
         'SpiNNMachine == 1!6.0.1',
-        "jsonschema"],
+        "jsonschema <= 4.17.3; python_version == '3.7'",
+        "jsonschema; python_version >= '3.8'",
+    ],
     maintainer="SpiNNakerTeam",
     maintainer_email="spinnakerusers@googlegroups.com"
 )


### PR DESCRIPTION
Another dependency has decided to end support for python 3.7.

For now a simple cap is all that is needed.