### PR TITLE
Things that are meant to be overridden need fully-qualified type names

### DIFF
--- a/pacman/model/graphs/abstract_edge.py
+++ b/pacman/model/graphs/abstract_edge.py
@@ -34,7 +34,7 @@ class AbstractEdge(object, metaclass=AbstractBase):
         """
         The vertex at the start of the edge.
 
-        :rtype: AbstractVertex
+        :rtype: ~pacman.model.graphs.AbstractVertex
         """
 
     @abstractproperty
@@ -42,5 +42,5 @@ class AbstractEdge(object, metaclass=AbstractBase):
         """
         The vertex at the end of the edge.
 
-        :rtype: AbstractVertex
+        :rtype: ~pacman.model.graphs.AbstractVertex
         """

--- a/pacman/model/graphs/abstract_edge_partition.py
+++ b/pacman/model/graphs/abstract_edge_partition.py
@@ -49,11 +49,10 @@ class AbstractEdgePartition(object, metaclass=AbstractBase):
         """
         Add an edge to the edge partition.
 
-        :param AbstractEdge edge: the edge to add
+        :param ~pacman.model.graphs.AbstractEdge edge: the edge to add
         :raises PacmanInvalidParameterException:
             If the edge does not belong in this edge partition
         """
-
         # Check for an incompatible edge
         if not isinstance(edge, self._allowed_edge_types):
             raise PacmanInvalidParameterException(
@@ -82,7 +81,7 @@ class AbstractEdgePartition(object, metaclass=AbstractBase):
             The order in which the edges are added is preserved for when they
             are requested later. If not, please talk to the software team.
 
-        :rtype: iterable(AbstractEdge)
+        :rtype: iterable(~pacman.model.graphs.AbstractEdge)
         """
         return self._edges
 
@@ -106,7 +105,7 @@ class AbstractEdgePartition(object, metaclass=AbstractBase):
         """
         Check if the edge is contained within this partition.
 
-        :param AbstractEdge edge: the edge to search for.
+        :param ~pacman.model.graphs.AbstractEdge edge: the edge to search for.
         :rtype: bool
         """
         return edge in self._edges
@@ -121,5 +120,5 @@ class AbstractEdgePartition(object, metaclass=AbstractBase):
             :py:class:`AbstractSingleSourcePartition`
             and therefore provide the ``pre_vertex`` method.
 
-        :rtype: iter(AbstractVertex)
+        :rtype: iterable(~pacman.model.graphs.AbstractVertex)
         """

--- a/pacman/model/graphs/abstract_single_source_partition.py
+++ b/pacman/model/graphs/abstract_single_source_partition.py
@@ -45,7 +45,7 @@ class AbstractSingleSourcePartition(
         """
         The vertex at which all edges in this outgoing edge partition start.
 
-        :rtype: AbstractVertex
+        :rtype: ~pacman.model.graphs.AbstractVertex
         """
         return self._pre_vertex
 

--- a/pacman/model/graphs/abstract_supports_sdram_edges.py
+++ b/pacman/model/graphs/abstract_supports_sdram_edges.py
@@ -28,8 +28,10 @@ class AbstractSupportsSDRAMEdges(object, metaclass=AbstractBase):
         """
         Asks a machine vertex for the SDRAM requirement it needs.
 
-        :param SDRAMMachineEdge sdram_machine_edge:
+        :param sdram_machine_edge:
             The SDRAM edge in question
+        :type sdram_machine_edge:
+            ~pacman.model.graphs.machine.SDRAMMachineEdge
         :return: The size in bytes this vertex needs for the SDRAM edge.
         :rtype: int (most likely a multiple of 4)
         """

--- a/pacman/model/graphs/abstract_vertex.py
+++ b/pacman/model/graphs/abstract_vertex.py
@@ -80,7 +80,7 @@ class AbstractVertex(object):
 
         Used instead of `ChipAndCoreConstraint`.
 
-        :rtype: None or ChipAndCore
+        :rtype: None or ~pacman.model.graphs.common.ChipAndCore
         """
         return self._fixed_location
 

--- a/pacman/model/graphs/abstract_virtual.py
+++ b/pacman/model/graphs/abstract_virtual.py
@@ -25,7 +25,7 @@ class AbstractVirtual(object):
 
     .. note::
         Everything that is an instance of ``AbstractVirtual`` is also an
-        instance of :py:class:`AbstractVertex`.
+        instance of :py:class:`~pacman.model.graphs.AbstractVertex`.
     """
 
     __slots__ = ()
@@ -55,7 +55,7 @@ class AbstractVirtual(object):
         Get the keys sent by the device or `None` if there aren't any
         explicitly defined.
 
-        :rtype: list(BaseKeyAndMask) or None
+        :rtype: list(~pacman.model.routing_info.BaseKeyAndMask) or None
         """
 
     @abstractproperty

--- a/pacman/model/graphs/application/application_2d_fpga_vertex.py
+++ b/pacman/model/graphs/application/application_2d_fpga_vertex.py
@@ -44,12 +44,14 @@ class Application2DFPGAVertex(ApplicationFPGAVertex, Abstract2DDeviceVertex):
             The connections from one or more FPGAs that that packets are
             expected to be received from for this device, or `None` if no
             incoming traffic is expected from the device
-        :type incoming_fpga_connections: list(FPGAConnection) or None
+        :type incoming_fpga_connections:
+            list(~pacman.model.graphs.application.FPGAConnection) or None
         :param outgoing_fpga_connection:
             The connection to an FPGA that packets to be sent to this device
             should be sent down, or `None` if no outgoing traffic is expected
             to be sent to the device.
-        :type outgoing_fpga_connection: FPGAConnection or None
+        :type outgoing_fpga_connection:
+            ~pacman.model.graphs.application.FPGAConnection or None
         :param str label: The optional name of the vertex.
         """
         # Set variables first as this lets us call properties

--- a/pacman/model/graphs/application/application_edge.py
+++ b/pacman/model/graphs/application/application_edge.py
@@ -34,16 +34,12 @@ class ApplicationEdge(AbstractEdge):
 
     def __init__(self, pre_vertex, post_vertex, label=None):
         """
-        :param ApplicationVertex pre_vertex:
+        :param ~pacman.model.graphs.application.ApplicationVertex pre_vertex:
             The application vertex at the start of the edge.
-        :param ApplicationVertex post_vertex:
+        :param ~pacman.model.graphs.application.ApplicationVertex post_vertex:
             The application vertex at the end of the edge.
         :param label: The name of the edge.
         :type label: str or None
-        :param machine_edge_type:
-            The type of machine edges made from this app edge. If ``None``,
-            standard machine edges will be made.
-        :type machine_edge_type: type(MachineEdge)
         """
         self._label = label
         self._pre_vertex = pre_vertex

--- a/pacman/model/graphs/application/application_edge_partition.py
+++ b/pacman/model/graphs/application/application_edge_partition.py
@@ -29,7 +29,8 @@ class ApplicationEdgePartition(AbstractSingleSourcePartition):
     def __init__(self, identifier, pre_vertex):
         """
         :param str identifier: The identifier of the partition
-        :param ApplicationVertex pre_vertex: The source of this partition
+        :param ~pacman.model.graphs.application.ApplicationVertex pre_vertex:
+            The source of this partition
         """
         super().__init__(
             pre_vertex=pre_vertex, identifier=identifier,

--- a/pacman/model/graphs/application/application_fpga_vertex.py
+++ b/pacman/model/graphs/application/application_fpga_vertex.py
@@ -39,12 +39,14 @@ class ApplicationFPGAVertex(ApplicationVirtualVertex):
             The connections from one or more FPGAs that that packets are
             expected to be received from for this device, or `None` if no
             incoming traffic is expected from the device
-        :type incoming_fpga_connections: list(FPGAConnection) or None
+        :type incoming_fpga_connections:
+            list(~pacman.model.graphs.application.FPGAConnection) or None
         :param outgoing_fpga_connection:
             The connection to an FPGA that packets to be sent to this device
             should be sent down, or `None` if no outgoing traffic is expected
             to be sent to the device.
-        :type outgoing_fpga_connection: FPGAConnection or None
+        :type outgoing_fpga_connection:
+            ~pacman.model.graphs.application.FPGAConnection or None
         :param str label: The optional name of the vertex.
         :param int n_machine_vertices_per_link:
             The optional number of machine vertices to create for each FPGA
@@ -81,11 +83,11 @@ class ApplicationFPGAVertex(ApplicationVirtualVertex):
         """
         Get the slice to be given to the connection from the given link.
 
-        :param FPGAConnection link: The FPGA connection to get the slice for
+        :param ~pacman.model.graphs.application.FPGAConnection link:
+            The FPGA connection to get the slice for
         :param int index:
             The index of the connection on the FGPA link, for when
             n_machine_vertices_per_link > 1
-
         :rtype: ~pacman.model.graphs.common.Slice
         """
         # pylint: disable=unused-argument
@@ -109,7 +111,7 @@ class ApplicationFPGAVertex(ApplicationVirtualVertex):
         The connections from one or more FPGAs that packets are expected
         to be received from for this device.
 
-        :rtype: iter(FPGAConnection)
+        :rtype: iterable(~pacman.model.graphs.application.FPGAConnection)
         """
         if self._incoming_fpga_connections:
             for conn in self._incoming_fpga_connections:
@@ -121,7 +123,7 @@ class ApplicationFPGAVertex(ApplicationVirtualVertex):
         The connection to one FPGA via one link to which packets are sent
         to this device.
 
-        :rtype: FPGAConnection or None
+        :rtype: ~pacman.model.graphs.application.FPGAConnection or None
         """
         return self._outgoing_fpga_connection
 

--- a/pacman/model/graphs/application/application_graph.py
+++ b/pacman/model/graphs/application/application_graph.py
@@ -47,7 +47,8 @@ class ApplicationGraph(object):
         """
         Add a vertex to the graph.
 
-        :param ApplicationVertex vertex: The vertex to add
+        :param ~pacman.model.graphs.application.ApplicationVertex vertex:
+            The vertex to add
         :raises PacmanInvalidParameterException:
             If the vertex is not of a valid type
         :raises PacmanConfigurationException:
@@ -72,7 +73,7 @@ class ApplicationGraph(object):
         """
         The vertices in the graph.
 
-        :rtype: iterable(AbstractVertex)
+        :rtype: iterable(~pacman.model.graphs.AbstractVertex)
         """
         return self._vertex_by_label.values()
 
@@ -94,13 +95,13 @@ class ApplicationGraph(object):
 
         If required and possible will create a new partition in the graph
 
-        Returns the partition the edge was added to
-
-        :param ApplicationEdge edge: The edge to add
+        :param ~pacman.model.graphs.application.ApplicationEdge edge:
+            The edge to add
         :param str outgoing_edge_partition_name:
             The name of the edge partition to add the edge to; each edge
             partition is the partition of edges that start at the same vertex
-        :rtype: AbstractEdgePartition
+        :return: The partition the edge was added to.
+        :rtype: ~pacman.model.graphs.AbstractEdgePartition
         :raises PacmanInvalidParameterException:
             If the edge is not of a valid type or if edges have already been
             added to this partition that start at a different vertex to this
@@ -122,7 +123,8 @@ class ApplicationGraph(object):
         """
         Add an edge to the graph.
 
-        :param ApplicationEdge edge: The edge to add
+        :param ~pacman.model.graphs.application.ApplicationEdge edge:
+            The edge to add
         :raises PacmanInvalidParameterException:
             If the edge is not of a valid type or if edges have already been
             added to this partition that start at a different vertex to this
@@ -150,7 +152,7 @@ class ApplicationGraph(object):
         """
         The edges in the graph.
 
-        :rtype: iterable(AbstractEdge)
+        :rtype: iterable(~pacman.model.graphs.AbstractEdge)
         """
         return [
             edge
@@ -163,7 +165,9 @@ class ApplicationGraph(object):
 
         Will also add any edges already in the partition as well
 
-        :param ApplicationEdgePartition edge_partition:
+        :param edge_partition:
+        :type edge_partition:
+            ~pacman.model.graphs.application.ApplicationEdgePartition
         """
         self._outgoing_edge_partitions_by_pre_vertex[
             edge_partition.pre_vertex].add(edge_partition)
@@ -174,7 +178,7 @@ class ApplicationGraph(object):
         """
         The edge partitions in the graph.
 
-        :rtype: iterable(AbstractEdgePartition)
+        :rtype: iterable(~pacman.model.graphs.AbstractEdgePartition)
         """
         for partitions in \
                 self._outgoing_edge_partitions_by_pre_vertex.values():
@@ -194,9 +198,9 @@ class ApplicationGraph(object):
         """
         Get all the edge partitions that start at the given vertex.
 
-        :param AbstractVertex vertex:
+        :param ~pacman.model.graphs.AbstractVertex vertex:
             The vertex at which the edge partitions to find starts
-        :rtype: iterable(AbstractEdgePartition)
+        :rtype: iterable(~pacman.model.graphs.AbstractEdgePartition)
         """
         return self._outgoing_edge_partitions_by_pre_vertex[vertex]
 
@@ -206,13 +210,13 @@ class ApplicationGraph(object):
         Get the given outgoing edge partition that starts at the
         given vertex, or `None` if no such edge partition exists.
 
-        :param AbstractVertex vertex:
+        :param ~pacman.model.graphs.AbstractVertex vertex:
             The vertex at the start of the edges in the partition
         :param str outgoing_edge_partition_name:
             The name of the edge partition
         :return:
             The named edge partition, or `None` if no such partition exists
-        :rtype: AbstractEdgePartition or None
+        :rtype: ~pacman.model.graphs.AbstractEdgePartition or None
         """
         # In general, very few partitions start at a given vertex, so iteration
         # isn't going to be as onerous as it looks

--- a/pacman/model/graphs/application/application_vertex.py
+++ b/pacman/model/graphs/application/application_vertex.py
@@ -110,7 +110,8 @@ class ApplicationVertex(AbstractVertex, metaclass=AbstractBase):
         """
         Adds the machine vertex to the iterable returned by machine_vertices
 
-        :param MachineVertex machine_vertex: A pointer to a machine_vertex
+        :param ~pacman.model.graphs.machine.MachineVertex machine_vertex:
+            A pointer to a machine_vertex
         """
         machine_vertex.index = len(self._machine_vertices)
         self._machine_vertices.add(machine_vertex)
@@ -137,9 +138,10 @@ class ApplicationVertex(AbstractVertex, metaclass=AbstractBase):
 
     def round_n_atoms(self, n_atoms, label="n_atoms"):
         """
-        Utility function to allow suoer-classes to make sure n_atom is an int.
+        Utility function to allow suoer-classes to make sure `n_atoms` is an
+        integer.
 
-        :param n_atoms: Value convertible to int to be used for n_atoms
+        :param n_atoms: Value convertible to int to be used for `n_atoms`
         :type n_atoms: int or float or numpy.
         :return: Number of atoms.
         :rtype: int
@@ -163,7 +165,7 @@ class ApplicationVertex(AbstractVertex, metaclass=AbstractBase):
         """
         The machine vertices that this application vertex maps to.
 
-        :rtype: iterable(MachineVertex)
+        :rtype: iterable(~pacman.model.graphs.machine.MachineVertex)
         """
         return self._machine_vertices
 
@@ -233,11 +235,11 @@ class ApplicationVertex(AbstractVertex, metaclass=AbstractBase):
         this to return `None` and get_fixed_key_and_mask to return not `None`
         iff there is only one machine vertex.
 
-        :param MachineVertex machine_vertex:
+        :param ~pacman.model.graphs.machine.MachineVertex machine_vertex:
             A source machine vertex of this application vertex
         :param str partition_id:
             The identifier of the partition to get the key for
-        :rtype: BaseKeyAndMask or None
+        :rtype: ~pacman.model.routing_info.BaseKeyAndMask or None
         """
         # pylint: disable=unused-argument
         return None
@@ -250,7 +252,7 @@ class ApplicationVertex(AbstractVertex, metaclass=AbstractBase):
 
         :param str partition_id:
             The identifier of the partition to get the key for
-        :rtype: BaseKeyAndMask or None
+        :rtype: ~pacman.model.routing_info.BaseKeyAndMask or None
         """
         # pylint: disable=unused-argument
         return None
@@ -260,6 +262,9 @@ class ApplicationVertex(AbstractVertex, metaclass=AbstractBase):
         Add an edge incoming to this vertex.  This is ignored by default,
         but could be used to track incoming edges, and/or report faults.
 
-        :param ApplicationEdge edge:
-        :param ApplicationEdgePartition partition:
+        :param ~pacman.model.graphs.application.ApplicationEdge edge:
+            The edge to add.
+        :param partition: The partition to add the edge to.
+        :type partition:
+            ~pacman.model.graphs.application.ApplicationEdgePartition
         """

--- a/pacman/model/graphs/machine/abstract_sdram_partition.py
+++ b/pacman/model/graphs/machine/abstract_sdram_partition.py
@@ -33,7 +33,8 @@ class AbstractSDRAMPartition(object, metaclass=AbstractBase):
         Get the SDRAM base address for a edge given which side
         the vertex is on.
 
-        :param MachineVertex vertex: the vertex to find SDRAM base address of
+        :param ~pacman.model.graphs.machine.MachineVertex vertex:
+            the vertex to find SDRAM base address of
         :return: the SDRAM address for this vertex
         :rtype: int
         """
@@ -43,7 +44,8 @@ class AbstractSDRAMPartition(object, metaclass=AbstractBase):
         """
         Get the size of the region for a vertex given a edge.
 
-        :param MachineVertex vertex: the vertex to find SDRAM size of
+        :param ~pacman.model.graphs.machine.MachineVertex vertex:
+            the vertex to find SDRAM size of
         :return: the SDRAM size for this vertex
         :rtype: int
         """

--- a/pacman/model/graphs/machine/machine_edge.py
+++ b/pacman/model/graphs/machine/machine_edge.py
@@ -34,8 +34,10 @@ class MachineEdge(AbstractEdge):
 
     def __init__(self, pre_vertex, post_vertex, label=None):
         """
-        :param MachineVertex pre_vertex: The vertex at the start of the edge.
-        :param MachineVertex post_vertex: The vertex at the end of the edge.
+        :param ~pacman.model.graphs.machine.MachineVertex pre_vertex:
+            The vertex at the start of the edge.
+        :param ~pacman.model.graphs.machine.MachineVertex post_vertex:
+            The vertex at the end of the edge.
         :param label: The name of the edge.
         :type label: str or None
         """

--- a/pacman/model/graphs/machine/machine_vertex.py
+++ b/pacman/model/graphs/machine/machine_vertex.py
@@ -34,14 +34,15 @@ class MachineVertex(AbstractVertex, metaclass=AbstractBase):
         :param app_vertex:
             The application vertex that caused this machine vertex to be
             created. If `None`, there is no such application vertex.
-        :type app_vertex: ApplicationVertex or None
+        :type app_vertex:
+            ~pacman.model.graphs.application.ApplicationVertex or None
         :param vertex_slice:
             The slice of the application vertex that this machine vertex
             implements.
-        :type vertex_slice: Slice or None
+        :type vertex_slice: ~pacman.model.graphs.common.Slice or None
         :raises PacmanValueError: If the slice of the machine_vertex is too big
         :raise AttributeError:
-            If a not None app_vertex is not an ApplicationVertex
+            If a not-`None` app_vertex is not an ApplicationVertex
         """
         if label is None:
             label = str(type(self))
@@ -60,7 +61,7 @@ class MachineVertex(AbstractVertex, metaclass=AbstractBase):
         The application vertex that caused this machine vertex to be
         created. If `None`, there is no such application vertex.
 
-        :rtype: ApplicationVertex or None
+        :rtype: ~pacman.model.graphs.application.ApplicationVertex or None
         """
         return self._app_vertex
 
@@ -70,7 +71,7 @@ class MachineVertex(AbstractVertex, metaclass=AbstractBase):
         The slice of the application vertex that this machine vertex
         implements.
 
-        :rtype: Slice
+        :rtype: ~pacman.model.graphs.common.Slice
         """
         return self._vertex_slice
 
@@ -78,8 +79,8 @@ class MachineVertex(AbstractVertex, metaclass=AbstractBase):
         """
         Get the number of keys required by the given partition of edges.
 
-        :param str partition_id: The identifier of the partition
-            partition_id param is only used by some MachineVertex clases
+        :param str partition_id: The identifier of the partition; the
+            partition_id param is only used by some MachineVertex subclasses
         :return: The number of keys required
         :rtype: int
         """
@@ -128,7 +129,7 @@ class MachineVertex(AbstractVertex, metaclass=AbstractBase):
         """
         The IPtags used by this vertex if any.
 
-        :rtype: iterable(IPtagResource)
+        :rtype: iterable(~pacman.model.resources.IPtagResource)
         """
         return []
 
@@ -137,7 +138,7 @@ class MachineVertex(AbstractVertex, metaclass=AbstractBase):
         """
         The reverse IPtags used by this vertex if any.
 
-        :rtype: iterable(ReverseIPtagResource)
+        :rtype: iterable(~pacman.model.resources.ReverseIPtagResource)
         """
         return []
 
@@ -145,9 +146,9 @@ class MachineVertex(AbstractVertex, metaclass=AbstractBase):
     def get_fixed_location(self):
         """
         .. note::
-            If the Machine vertex has no fixed_location
-            but does have an app_vertex, app_vertex.fixed_location is used.
-            If both have a fixed_location the app level is ignored!
+            If the Machine vertex has no `fixed_location`
+            but does have an `app_vertex`, `app_vertex.fixed_location` is used.
+            If both have a `fixed_location` the app level is ignored!
         """
         if self._fixed_location:
             return self._fixed_location

--- a/pacman/model/graphs/machine/multicast_edge_partition.py
+++ b/pacman/model/graphs/machine/multicast_edge_partition.py
@@ -26,7 +26,8 @@ class MulticastEdgePartition(AbstractSingleSourcePartition):
 
     def __init__(self, pre_vertex, identifier):
         """
-        :param pre_vertex: the pre vertex of this partition.
+        :param ~pacman.model.graphs.machine.MachineVertex pre_vertex:
+            the pre vertex of this partition.
         :param str identifier: The identifier of the partition
         """
         super().__init__(

--- a/pacman/model/graphs/machine/source_segmented_sdram_machine_partition.py
+++ b/pacman/model/graphs/machine/source_segmented_sdram_machine_partition.py
@@ -33,7 +33,7 @@ class SourceSegmentedSDRAMMachinePartition(
         """
         :param str identifier: The identifier of the partition
         :param str label: A label of the partition
-        :param iterable(AbstractVertex) pre_vertices:
+        :param iterable(~pacman.model.graphs.AbstractVertex) pre_vertices:
             The vertices that an edge in this partition may originate at
         """
         super().__init__(

--- a/pacman/model/partitioner_splitters/abstract_splitters/abstract_splitter_common.py
+++ b/pacman/model/partitioner_splitters/abstract_splitters/abstract_splitter_common.py
@@ -56,7 +56,7 @@ class AbstractSplitterCommon(object, metaclass=AbstractBase):
         The app vertex to be governed by this splitter object.
         If `None`, not yet set.
 
-        :rtype: ApplicationVertex
+        :rtype: ~pacman.model.graphs.application.ApplicationVertex
         """
         return self._governed_app_vertex
 
@@ -65,7 +65,8 @@ class AbstractSplitterCommon(object, metaclass=AbstractBase):
         Sets a app vertex to be governed by this splitter object.
         Once set it can't be reset.
 
-        :param ApplicationVertex app_vertex: the app vertex to govern
+        :param ~pacman.model.graphs.application.ApplicationVertex app_vertex:
+            the app vertex to govern
         :raises PacmanConfigurationException:
             if the app vertex has already been set.
         """
@@ -83,7 +84,8 @@ class AbstractSplitterCommon(object, metaclass=AbstractBase):
         """
         Method for specific splitter objects to override.
 
-        :param ChipCounter chip_counter: counter of used chips
+        :param ~pacman.utilities.utility_objs.ChipCounter chip_counter:
+            counter of used chips
         """
 
     @abstractmethod
@@ -113,7 +115,7 @@ class AbstractSplitterCommon(object, metaclass=AbstractBase):
         for external edges.
 
         :param str partition_id: The identifier of the outgoing partition
-        :rtype: list(MachineVertex)
+        :rtype: list(~pacman.model.graphs.machine.MachineVertex)
         """
 
     @abstractmethod
@@ -129,7 +131,7 @@ class AbstractSplitterCommon(object, metaclass=AbstractBase):
             for any source machine vertex in the given partition.
 
         :param str partition_id: The identifier of the incoming partition
-        :rtype: list(MachineVertex)
+        :rtype: list(~pacman.model.graphs.machine.MachineVertex)
         """
 
     def get_source_specific_in_coming_vertices(
@@ -148,13 +150,14 @@ class AbstractSplitterCommon(object, metaclass=AbstractBase):
         This should be overridden if there are specific machine vertices for
         any given source vertex.
 
-        :param ApplicationVertex source_vertex:
-            The source to get incoming vertices for
+        :param source_vertex: The source to get incoming vertices for
+        :type source_vertex: ~pacman.model.graphs.application.ApplicationVertex
         :param str partition_id: The identifier of the incoming partition
         :return: A list of tuples of (target machine vertex, list of source
             machine or application vertices that should hit the target)
-        :rtype: list(tuple(MachineVertex,
-                     list(MachineVertex or ApplicationVertex)))
+        :rtype: list(tuple(~pacman.model.graphs.machine.MachineVertex,
+            list(~pacman.model.graphs.machine.MachineVertex or
+            ~pacman.model.graphs.application.ApplicationVertex)))
         """
         return [(m_vertex, [source_vertex])
                 for m_vertex in self.get_in_coming_vertices(partition_id)]
@@ -182,7 +185,8 @@ class AbstractSplitterCommon(object, metaclass=AbstractBase):
         machine vertex and its SDRAM; override if there are groups of
         machine vertices on the same chip.
 
-        :rtype: list(list(MachineVertex), AbstractSDRAM)
+        :rtype: list(list(~pacman.model.graphs.machine.MachineVertex),
+            ~pacman.model.resources.AbstractSDRAM)
         """
         return [([v], v.sdram_required)
                 for v in self._governed_app_vertex.machine_vertices]
@@ -193,7 +197,7 @@ class AbstractSplitterCommon(object, metaclass=AbstractBase):
         handled by Multicast.  Returns empty by default, override if there
         are Multicast connections between internal vertices
 
-        :rtype: list(MulticastEdgePartition)
+        :rtype: list(~pacman.model.graphs.machine.MulticastEdgePartition)
         """
         return []
 
@@ -203,6 +207,6 @@ class AbstractSplitterCommon(object, metaclass=AbstractBase):
         handled by SDRAM.  Returns empty by default, override if there
         are SDRAM connections between internal vertices
 
-        :rtype: list(AbstractSDRAMPartition)
+        :rtype: list(~pacman.model.graphs.machine.AbstractSDRAMPartition)
         """
         return []

--- a/pacman/model/partitioner_splitters/splitter_external_device.py
+++ b/pacman/model/partitioner_splitters/splitter_external_device.py
@@ -24,6 +24,9 @@ from pacman.exceptions import (
 
 
 class SplitterExternalDevice(AbstractSplitterCommon):
+    """
+    A splitter for handling external devices.
+    """
 
     __slots__ = [
         # Machine vertices that will send packets into the network
@@ -35,6 +38,13 @@ class SplitterExternalDevice(AbstractSplitterCommon):
         # Slice of outgoing vertex (which really doesn't matter here)
         "__outgoing_slice"
     ]
+
+    def __init__(self):
+        super().__init__()
+        self.__incoming_vertices = list()
+        self.__incoming_slices = list()
+        self.__outgoing_vertex = None
+        self.__outgoing_slice = None
 
     @overrides(AbstractSplitterCommon.set_governed_app_vertex)
     def set_governed_app_vertex(self, app_vertex):


### PR DESCRIPTION
It's important because inherited docs in FEC and sPyNNaker don't otherwise know which types to link to.

(Forgot to do this in #496)