### PR TITLE
Defaults from cfg

### DIFF
--- a/pacman/config_setup.py
+++ b/pacman/config_setup.py
@@ -14,29 +14,42 @@
 
 import os
 from spinn_utilities.config_holder import (
-    add_default_cfg, clear_cfg_files)
+    add_default_cfg, clear_cfg_files, get_config_str)
 from spinn_machine.config_setup import add_spinn_machine_cfg
 from pacman.data.pacman_data_writer import PacmanDataWriter
 
 BASE_CONFIG_FILE = "pacman.cfg"
 
 
-def unittest_setup():
+def unittest_setup(board_type=None):
     """
     Resets the configurations so only the local default configuration is
     included.
 
     .. note::
         This file should only be called from `PACMAN/unittests`
+
+    :param board_type: Value to say how to confuire the system.
+        This includes defining what a VirtualMachine would be
+        Can be 1 for Spin1 boards, 2 for Spin2 boards or
+        None if the test do not depend on knowing the board type.
+    :type board_type: None or int
     """
     clear_cfg_files(True)
-    add_pacman_cfg()
     PacmanDataWriter.mock()
+    add_pacman_cfg(board_type)
+    get_config_str("Mapping", "placer_start_chip")
 
 
-def add_pacman_cfg():
+def add_pacman_cfg(board_type):
     """
     Add the local configuration and all dependent configuration files.
+
+    :param board_type: Value to say how to confuire the system.
+        This includes defining what a VirtualMachine would be
+        Can be 1 for Spin1 boards, 2 for Spin2 boards or
+        None if the test do not depend on knowing the board type.
+    :type board_type: None or int
     """
-    add_spinn_machine_cfg()  # This add its dependencies too
     add_default_cfg(os.path.join(os.path.dirname(__file__), BASE_CONFIG_FILE))
+    add_spinn_machine_cfg(board_type)  # This add its dependencies too

--- a/pacman/config_setup.py
+++ b/pacman/config_setup.py
@@ -13,8 +13,7 @@
 # limitations under the License.
 
 import os
-from spinn_utilities.config_holder import (
-    add_default_cfg, clear_cfg_files, get_config_str)
+from spinn_utilities.config_holder import add_default_cfg, clear_cfg_files
 from spinn_machine.config_setup import add_spinn_machine_cfg
 from pacman.data.pacman_data_writer import PacmanDataWriter
 

--- a/pacman/config_setup.py
+++ b/pacman/config_setup.py
@@ -21,7 +21,7 @@ from pacman.data.pacman_data_writer import PacmanDataWriter
 BASE_CONFIG_FILE = "pacman.cfg"
 
 
-def unittest_setup(board_type=None):
+def unittest_setup(*, board_type=None):
     """
     Resets the configurations so only the local default configuration is
     included.
@@ -38,7 +38,6 @@ def unittest_setup(board_type=None):
     clear_cfg_files(True)
     PacmanDataWriter.mock()
     add_pacman_cfg(board_type)
-    get_config_str("Mapping", "placer_start_chip")
 
 
 def add_pacman_cfg(board_type):

--- a/pacman/operations/placer_algorithms/application_placer.py
+++ b/pacman/operations/placer_algorithms/application_placer.py
@@ -18,7 +18,8 @@ import math
 import os
 import numpy
 
-from spinn_utilities.config_holder import get_config_bool, get_config_str
+from spinn_utilities.config_holder import (
+    get_config_bool, get_config_int, get_config_str)
 from spinn_utilities.log import FormatAdapter
 from spinn_utilities.ordered_set import OrderedSet
 from spinn_utilities.progress_bar import ProgressBar
@@ -224,8 +225,8 @@ def _check_could_fit(app_vertex, vertices_to_place, sdram):
     :param int sdram:
     :raises PacmanTooBigToPlace:
     """
-    max_sdram = (
-            Machine.DEFAULT_SDRAM_BYTES - PacmanDataView.get_monitor_sdram())
+    machine_sdram = get_config_int("Machine", "max_sdram_allowed_per_chip")
+    max_sdram = machine_sdram - PacmanDataView.get_monitor_sdram()
     max_cores = (
             Machine.DEFAULT_MAX_CORES_PER_CHIP - Machine.NON_USER_CORES -
             PacmanDataView.get_monitor_cores())
@@ -238,8 +239,8 @@ def _check_could_fit(app_vertex, vertices_to_place, sdram):
         f"the reason is that {vertices_to_place} ")
     if sdram > max_sdram:
         message += f"requires {sdram} bytes but "
-        if sdram > Machine.DEFAULT_SDRAM_BYTES:
-            message += f"a Chip only has {Machine.DEFAULT_SDRAM_BYTES} bytes "
+        if sdram > machine_sdram:
+            message += f"a Chip only has {machine_sdram} bytes "
         else:
             message += f"after monitors only {max_sdram} bytes are available "
         message += "Lowering max_core_per_chip may resolve this."

--- a/pacman/utilities/utility_objs/chip_counter.py
+++ b/pacman/utilities/utility_objs/chip_counter.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from spinn_utilities.config_holder import get_config_int
 from pacman.data import PacmanDataView
 
 
@@ -39,9 +40,10 @@ class ChipCounter(object):
         # The number of chips used, including the current one
         "__n_chips"]
 
-    def __init__(self, n_cores_per_chip=15, sdram_per_chip=100 * 1024 * 1024):
+    def __init__(self, n_cores_per_chip=15):
         self.__n_cores_per_chip = n_cores_per_chip
-        self.__sdram_per_chip = sdram_per_chip
+        self.__sdram_per_chip = get_config_int(
+            "Machine", "max_sdram_allowed_per_chip")
         self.__cores_free = 0
         self.__sdram_free = 0
         self.__n_chips = 0

--- a/unittests/operations_tests/placer_algorithms_tests/test_application_placer.py
+++ b/unittests/operations_tests/placer_algorithms_tests/test_application_placer.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import unittest
 
-from spinn_machine import Machine
+from spinn_utilities.config_holder import get_config_int
 from spinn_machine.virtual_machine import virtual_machine
 from pacman.data.pacman_data_writer import PacmanDataWriter
 from pacman.exceptions import (
@@ -95,7 +95,7 @@ def _make_vertices(
 
 
 def test_application_placer():
-    unittest_setup()
+    unittest_setup(board_type=1)
     writer = PacmanDataWriter.mock()
     # fixed early works as this vertex is looked at first
     fixed = SimpleTestVertex(10, "FIXED", max_atoms_per_core=1)
@@ -110,7 +110,7 @@ def test_application_placer():
 
 
 def test_application_placer_late_fixed():
-    unittest_setup()
+    unittest_setup(board_type=1)
     writer = PacmanDataWriter.mock()
     for i in range(56):
         _make_vertices(writer, 1000, 14, 5, f"app_vertex_{i}")
@@ -130,10 +130,11 @@ def test_application_placer_late_fixed():
 
 
 def test_sdram_bigger_than_chip():
-    unittest_setup()
+    unittest_setup(board_type=1)
     writer = PacmanDataWriter.mock()
+    chip_sdram = get_config_int("Machine", "max_sdram_allowed_per_chip")
     _make_vertices(writer, 1, 1, 5, "big_app_vertex",
-                   sdram=Machine.DEFAULT_SDRAM_BYTES + 24)
+                   sdram=chip_sdram  + 24)
     try:
         place_application_graph(Placements())
         raise AssertionError("Error not raise")
@@ -142,22 +143,21 @@ def test_sdram_bigger_than_chip():
 
 
 def test_sdram_bigger_monitors():
-    unittest_setup()
+    unittest_setup(board_type=1)
     writer = PacmanDataWriter.mock()
-    monitor = SimpleMachineVertex(
-                    ConstantSDRAM(Machine.DEFAULT_SDRAM_BYTES // 2))
+    sdram = get_config_int("Machine", "max_sdram_allowed_per_chip")
+    monitor = SimpleMachineVertex(ConstantSDRAM(sdram // 2))
     # This is purely an info call so test check directly
     writer.add_monitor_all_chips(monitor)
     try:
-        _check_could_fit("app_test", ["m_vertex]"],
-                         sdram=Machine.DEFAULT_SDRAM_BYTES // 2 + 5)
+        _check_could_fit("app_test", ["m_vertex]"], sdram=sdram // 2 + 5)
         raise AssertionError("Error not raise")
     except PacmanTooBigToPlace as ex:
         assert ("after monitors only" in str(ex))
 
 
 def test_more_cores_than_chip():
-    unittest_setup()
+    unittest_setup(board_type=1)
     writer = PacmanDataWriter.mock()
     _make_vertices(writer, 1, 1, 19, "big_app_vertex")
     try:
@@ -168,7 +168,7 @@ def test_more_cores_than_chip():
 
 
 def test_more_cores_than_user():
-    unittest_setup()
+    unittest_setup(board_type=1)
     writer = PacmanDataWriter.mock()
     _make_vertices(writer, 1, 1, 18, "big_app_vertex")
     try:
@@ -179,7 +179,7 @@ def test_more_cores_than_user():
 
 
 def test_more_cores_with_monitor():
-    unittest_setup()
+    unittest_setup(board_type=1)
     writer = PacmanDataWriter.mock()
     monitor = SimpleMachineVertex(ConstantSDRAM(4000))
     # This is purely an info call so test check directly
@@ -193,7 +193,7 @@ def test_more_cores_with_monitor():
 
 
 def test_could_fit():
-    unittest_setup()
+    unittest_setup(board_type=1)
     writer = PacmanDataWriter.mock()
     monitor = SimpleMachineVertex(ConstantSDRAM(0))
     writer.add_monitor_all_chips(monitor)

--- a/unittests/operations_tests/placer_algorithms_tests/test_application_placer.py
+++ b/unittests/operations_tests/placer_algorithms_tests/test_application_placer.py
@@ -134,7 +134,7 @@ def test_sdram_bigger_than_chip():
     writer = PacmanDataWriter.mock()
     chip_sdram = get_config_int("Machine", "max_sdram_allowed_per_chip")
     _make_vertices(writer, 1, 1, 5, "big_app_vertex",
-                   sdram=chip_sdram  + 24)
+                   sdram=chip_sdram + 24)
     try:
         place_application_graph(Placements())
         raise AssertionError("Error not raise")

--- a/unittests/operations_tests/router_algorithms_tests/test_routers.py
+++ b/unittests/operations_tests/router_algorithms_tests/test_routers.py
@@ -440,7 +440,7 @@ def _route_and_time(algorithm):
 
 def test_simple(params):
     algorithm, _n_vertices, n_m_vertices = params
-    unittest_setup()
+    unittest_setup(board_type=1)
     writer = PacmanDataWriter.mock()
     source_vertex = _make_vertices(writer, 1000, n_m_vertices, "source")
     target_vertex = _make_vertices(writer, 1000, n_m_vertices, "target")
@@ -453,7 +453,7 @@ def test_simple(params):
 
 def test_self(params):
     algorithm, _n_vertices, n_m_vertices = params
-    unittest_setup()
+    unittest_setup(board_type=1)
     writer = PacmanDataWriter.mock()
     source_vertex = _make_vertices(writer, 1000, n_m_vertices, "self")
     writer.add_edge(ApplicationEdge(source_vertex, source_vertex), "Test")
@@ -465,7 +465,7 @@ def test_self(params):
 
 def test_simple_self(params):
     algorithm, _n_vertices, n_m_vertices = params
-    unittest_setup()
+    unittest_setup(board_type=1)
     writer = PacmanDataWriter.mock()
     source_vertex = _make_vertices(writer, 1000, n_m_vertices, "source")
     target_vertex = _make_vertices(writer, 1000, n_m_vertices, "target")
@@ -480,7 +480,7 @@ def test_simple_self(params):
 
 def test_multi(params):
     algorithm, n_vertices, n_m_vertices = params
-    unittest_setup()
+    unittest_setup(board_type=1)
     writer = PacmanDataWriter.mock()
     for i in range(n_vertices):
         _make_vertices(writer, 1000, n_m_vertices, f"app_vertex_{i}")
@@ -496,7 +496,7 @@ def test_multi(params):
 
 def test_multi_self(params):
     algorithm, n_vertices, n_m_vertices = params
-    unittest_setup()
+    unittest_setup(board_type=1)
     writer = PacmanDataWriter.mock()
     for i in range(n_vertices):
         _make_vertices(writer, 1000, n_m_vertices, f"app_vertex_{i}")
@@ -511,7 +511,7 @@ def test_multi_self(params):
 
 def test_multi_split(params):
     algorithm, n_vertices, n_m_vertices = params
-    unittest_setup()
+    unittest_setup(board_type=1)
     writer = PacmanDataWriter.mock()
     for i in range(n_vertices):
         _make_vertices_split(writer, 1000, 3, 2, n_m_vertices,
@@ -529,7 +529,7 @@ def test_multi_split(params):
 
 def test_multi_self_split(params):
     algorithm, n_vertices, n_m_vertices = params
-    unittest_setup()
+    unittest_setup(board_type=1)
     writer = PacmanDataWriter.mock()
     for i in range(n_vertices):
         _make_vertices_split(writer, 1000, 3, 2, n_m_vertices,
@@ -546,7 +546,7 @@ def test_multi_self_split(params):
 
 def test_multi_down_chips_and_links(params):
     algorithm, n_vertices, n_m_vertices = params
-    unittest_setup()
+    unittest_setup(board_type=1)
     writer = PacmanDataWriter.mock()
     for i in range(n_vertices):
         _make_vertices(writer, 1000, n_m_vertices, f"app_vertex_{i}")
@@ -601,7 +601,7 @@ def test_multi_down_chips_and_links(params):
 
 def test_internal_only(params):
     algorithm, _n_vertices, _n_m_vertices = params
-    unittest_setup()
+    unittest_setup(board_type=1)
     writer = PacmanDataWriter.mock()
     _make_vertices_split(
         writer, 1000, 3, 2, 2, "app_vertex",
@@ -615,7 +615,7 @@ def test_internal_only(params):
 
 def test_internal_and_split(params):
     algorithm, n_vertices, n_m_vertices = params
-    unittest_setup()
+    unittest_setup(board_type=1)
     writer = PacmanDataWriter.mock()
     for i in range(n_vertices):
         _make_vertices_split(
@@ -634,7 +634,7 @@ def test_internal_and_split(params):
 
 def test_spinnaker_link(params):
     algorithm, n_vertices, n_m_vertices = params
-    unittest_setup()
+    unittest_setup(board_type=1)
     writer = PacmanDataWriter.mock()
     in_device = ApplicationSpiNNakerLinkVertex(100, 0)
     in_device.splitter = SplitterExternalDevice()
@@ -657,7 +657,7 @@ def test_spinnaker_link(params):
 
 def test_fpga_link(params):
     algorithm, n_vertices, n_m_vertices = params
-    unittest_setup()
+    unittest_setup(board_type=1)
     writer = PacmanDataWriter.mock()
     in_device = ApplicationFPGAVertex(
         100, [FPGAConnection(0, 0, None, None)], None)
@@ -683,7 +683,7 @@ def test_fpga_link(params):
 
 def test_fpga_link_overlap(params):
     algorithm, _n_vertices, _n_m_vertices = params
-    unittest_setup()
+    unittest_setup(board_type=1)
     writer = PacmanDataWriter.mock()
     set_config("Machine", "down_chips", "6,1")
     writer.set_machine(virtual_machine(12, 12))
@@ -704,7 +704,7 @@ def test_fpga_link_overlap(params):
 
 def test_odd_case(params):
     algorithm, _n_vertices, _n_m_vertices = params
-    unittest_setup()
+    unittest_setup(board_type=1)
     writer = PacmanDataWriter.mock()
     target_vertex = _make_vertices(writer, 200, 20, "app_vertex")
     delay_vertex = _make_one_to_one_vertices(writer, 200, 20, "delay_vtx")
@@ -739,7 +739,7 @@ def test_with_ethernet_system_placements(params):
     # is placed on multiple ethernet chips, but the source is only connected
     # to one of them
     algorithm, _n_vertices, _n_m_vertices = params
-    unittest_setup()
+    unittest_setup(board_type=1)
     writer = PacmanDataWriter.mock()
     writer.set_machine(virtual_machine(16, 16))
     source_vertex = _make_vertices(writer, 200, 3, "app_vertex")
@@ -781,7 +781,7 @@ def _check_path(source, nodes_fixed, machine, target):
 
 
 def test_route_around():
-    unittest_setup()
+    unittest_setup(board_type=1)
     # Take out all the chips around 3,3 except one then make a path that goes
     # through it
     #      3,4 4,4

--- a/unittests/operations_tests/routing_table_generator_tests/test_basic.py
+++ b/unittests/operations_tests/routing_table_generator_tests/test_basic.py
@@ -34,7 +34,7 @@ from pacman_test_objects import SimpleTestVertex
 class TestBasic(unittest.TestCase):
 
     def setUp(self):
-        unittest_setup()
+        unittest_setup(board_type=1)
 
     def create_graphs3(self, writer):
         v1 = SimpleTestVertex(

--- a/unittests/operations_tests/routing_table_generator_tests/test_merged.py
+++ b/unittests/operations_tests/routing_table_generator_tests/test_merged.py
@@ -36,7 +36,7 @@ from pacman_test_objects import SimpleTestVertex
 class TestMerged(unittest.TestCase):
 
     def setUp(self):
-        unittest_setup()
+        unittest_setup(board_type=1)
 
     def create_graphs1(self, writer):
         v1 = SimpleTestVertex(

--- a/unittests/operations_tests/tag_allocator_tests/test_tags_board_addresses.py
+++ b/unittests/operations_tests/tag_allocator_tests/test_tags_board_addresses.py
@@ -29,7 +29,7 @@ class TestTagsBoardAddresses(unittest.TestCase):
     """ Tests for ip tags on different boards
     """
     def setUp(self):
-        unittest_setup()
+        unittest_setup(board_type=1)
 
     def test_ip_tags(self):
         writer = PacmanDataWriter.mock()

--- a/unittests/test_fixed_route_router.py
+++ b/unittests/test_fixed_route_router.py
@@ -79,7 +79,7 @@ def _check_setup(width, height):
      (False, True),
      (True, True)])
 def test_all_working(width, height,  with_down_links, with_down_chips):
-    unittest_setup()
+    unittest_setup(board_type=1)
     temp_machine = virtual_machine(width=width, height=height)
     down_links = None
     if with_down_links:
@@ -100,7 +100,7 @@ def test_all_working(width, height,  with_down_links, with_down_chips):
 
 
 def test_unreachable():
-    unittest_setup()
+    unittest_setup(board_type=1)
     set_config("Machine", "down_chips", "0,2:1,3:1,4")
     with pytest.raises(PacmanRoutingException):
         _check_setup(8, 8)


### PR DESCRIPTION
Part of https://github.com/SpiNNakerManchester/SpiNNMachine/pull/215

The ApplicationPlacer uses the cfg Value even once ChipInfo has been read 
This is to decide if it has run out of sdram because the actual machine is too small or because it would be impossible with any machine of this board type.

Highly unlikely with sdram but could happen with n_cores which will use the same pattern.
