### PR TITLE
fix max_number_of_entries

### DIFF
--- a/pacman/model/routing_tables/multicast_routing_tables.py
+++ b/pacman/model/routing_tables/multicast_routing_tables.py
@@ -28,8 +28,6 @@ class MulticastRoutingTables(object):
     __slots__ = [
         # dict of (x,y) -> routing table
         "_routing_tables_by_chip",
-        # maximum value for number_of_entries in all tables
-        "_max_number_of_entries"
     ]
 
     def __init__(self, routing_tables=None):
@@ -40,7 +38,6 @@ class MulticastRoutingTables(object):
             If any two routing tables are for the same chip
         """
         self._routing_tables_by_chip = dict()
-        self._max_number_of_entries = 0
 
         if routing_tables is not None:
             for routing_table in routing_tables:
@@ -62,8 +59,6 @@ class MulticastRoutingTables(object):
                 str(routing_table))
         self._routing_tables_by_chip[(routing_table.x, routing_table.y)] = \
             routing_table
-        self._max_number_of_entries = max(
-            self._max_number_of_entries, routing_table.number_of_entries)
 
     @property
     def routing_tables(self):
@@ -75,8 +70,7 @@ class MulticastRoutingTables(object):
         """
         return self._routing_tables_by_chip.values()
 
-    @property
-    def max_number_of_entries(self):
+    def get_max_number_of_entries(self):
         """
         The maximum number of multicast routing entries there are in any
         multicast routing table.
@@ -85,7 +79,26 @@ class MulticastRoutingTables(object):
 
         :rtype: int
         """
-        return self._max_number_of_entries
+        if self._routing_tables_by_chip:
+            return max(map((lambda x: x.number_of_entries),
+                           self._routing_tables_by_chip.values()))
+        else:
+            return 0
+
+    def get_total_number_of_entries(self):
+        """
+        The total number of multicast routing entries there are in all
+        multicast routing table.
+
+        Will return zero if there are no routing tables
+
+        :rtype: int
+        """
+        if self._routing_tables_by_chip:
+            return sum(map((lambda x: x.number_of_entries),
+                           self._routing_tables_by_chip.values()))
+        else:
+            return 0
 
     def get_routing_table_for_chip(self, x, y):
         """

--- a/pacman/operations/router_compressors/ranged_compressor.py
+++ b/pacman/operations/router_compressors/ranged_compressor.py
@@ -53,7 +53,7 @@ def range_compressor(accept_overflow=True):
                 f"still has {new_table.number_of_entries} so will not fit")
         compressed_tables.add_routing_table(new_table)
     logger.info(f"Ranged compressor resulted with the largest table of size "
-                f"{compressed_tables.max_number_of_entries}")
+                f"{compressed_tables.get_max_number_of_entries()}")
     return compressed_tables
 
 

--- a/unittests/operations_tests/routing_table_generator_tests/test_basic.py
+++ b/unittests/operations_tests/routing_table_generator_tests/test_basic.py
@@ -70,7 +70,7 @@ class TestBasic(unittest.TestCase):
         writer = PacmanDataWriter.mock()
         self.make_infos(writer)
         data = basic_routing_table_generator()
-        self.assertEqual(0, data.max_number_of_entries)
+        self.assertEqual(0, data.get_max_number_of_entries())
         self.assertEqual(0, len(list(data.routing_tables)))
 
     def test_graph3_with_system(self):
@@ -81,5 +81,6 @@ class TestBasic(unittest.TestCase):
         system_plaements.add_placement(Placement(mv, 1, 2, 3))
         self.make_infos(writer, system_plaements)
         data = basic_routing_table_generator()
-        self.assertEqual(34, data.max_number_of_entries)
+        self.assertEqual(34, data.get_max_number_of_entries())
+        self.assertEqual(114, data.get_total_number_of_entries())
         self.assertEqual(4, len(list(data.routing_tables)))

--- a/unittests/operations_tests/routing_table_generator_tests/test_merged.py
+++ b/unittests/operations_tests/routing_table_generator_tests/test_merged.py
@@ -98,7 +98,7 @@ class TestMerged(unittest.TestCase):
         writer = PacmanDataWriter.mock()
         self.make_infos(writer)
         data = merged_routing_table_generator()
-        self.assertEqual(0, data.max_number_of_entries)
+        self.assertEqual(0, data.get_max_number_of_entries())
         self.assertEqual(0, len(list(data.routing_tables)))
 
     def test_graph1(self):
@@ -106,7 +106,7 @@ class TestMerged(unittest.TestCase):
         self.create_graphs1(writer)
         self.make_infos(writer)
         data = merged_routing_table_generator()
-        self.assertEqual(1, data.max_number_of_entries)
+        self.assertEqual(1, data.get_max_number_of_entries())
         self.assertEqual(1, len(list(data.routing_tables)))
 
     def test_graph2(self):
@@ -114,7 +114,7 @@ class TestMerged(unittest.TestCase):
         self.create_graphs3(writer)
         self.make_infos(writer)
         data = merged_routing_table_generator()
-        self.assertEqual(10, data.max_number_of_entries)
+        self.assertEqual(10, data.get_max_number_of_entries())
         self.assertEqual(4, len(list(data.routing_tables)))
 
     def test_graph3_with_system(self):
@@ -125,7 +125,7 @@ class TestMerged(unittest.TestCase):
         system_plaements.add_placement(Placement(mv, 1, 2, 3))
         self.make_infos(writer, system_plaements)
         data = merged_routing_table_generator()
-        self.assertEqual(10, data.max_number_of_entries)
+        self.assertEqual(10, data.get_max_number_of_entries())
         self.assertEqual(4, len(list(data.routing_tables)))
 
     def test_bad_infos(self):


### PR DESCRIPTION
This fixes the max routing entries.

The previous way did not work as entries are added to tables after the tables are added to the dict.

Also adds a total for debugging

Must be done at the same time as.
