### PR TITLE
fixes for FrontEndCommon typing

### DIFF
--- a/pacman/model/graphs/abstract_vertex.py
+++ b/pacman/model/graphs/abstract_vertex.py
@@ -62,7 +62,7 @@ class AbstractVertex(object):
                 "As Labels are also IDs they can not be changed.")
         self._label = label
 
-    def addedToGraph(self) -> None:
+    def setAddedToGraph(self) -> None:
         """
         Records that the vertex has been added to a graph.
 
@@ -70,6 +70,13 @@ class AbstractVertex(object):
             If there is an attempt to add the same vertex more than once
         """
         self._added_to_graph = True
+
+    def has_been_added_to_graph(self) -> bool:
+        """
+        State if the vertex has been added to the graph or not
+
+        """
+        return self._added_to_graph
 
     def get_fixed_location(self) -> Optional[ChipAndCore]:
         """

--- a/pacman/model/graphs/application/application_graph.py
+++ b/pacman/model/graphs/application/application_graph.py
@@ -67,7 +67,7 @@ class ApplicationGraph(object):
             if self._vertex_by_label[vertex.label] == vertex:
                 raise PacmanAlreadyExistsException("vertex", vertex.label)
             vertex.set_label(vertex.label + self._label_postfix())
-        vertex.addedToGraph()
+        vertex.setAddedToGraph()
         self._vertex_by_label[cast(str, vertex.label)] = vertex
 
     @property

--- a/pacman/model/routing_tables/abstract_multicast_routing_table.py
+++ b/pacman/model/routing_tables/abstract_multicast_routing_table.py
@@ -64,6 +64,20 @@ class AbstractMulticastRoutingTable(object, metaclass=AbstractBase):
         """
         raise NotImplementedError
 
+    @abstractmethod
+    def add_multicast_routing_entry(
+            self, multicast_routing_entry: MulticastRoutingEntry):
+        """
+        Adds a routing entry to this table.
+
+        :param ~spinn_machine.MulticastRoutingEntry multicast_routing_entry:
+            The route to add
+        :raise PacmanAlreadyExistsException:
+            If a routing entry with the same key-mask combination already
+            exists
+        """
+        raise NotImplementedError
+
     @property
     @abstractmethod
     def number_of_entries(self) -> int:

--- a/pacman/model/routing_tables/compressed_multicast_routing_table.py
+++ b/pacman/model/routing_tables/compressed_multicast_routing_table.py
@@ -58,16 +58,9 @@ class CompressedMulticastRoutingTable(AbstractMulticastRoutingTable):
         for multicast_routing_entry in multicast_routing_entries:
             self.add_multicast_routing_entry(multicast_routing_entry)
 
+    @overrides(AbstractMulticastRoutingTable.add_multicast_routing_entry)
     def add_multicast_routing_entry(
             self, multicast_routing_entry: MulticastRoutingEntry):
-        """
-        Adds a routing entry to this table.
-
-        :param ~spinn_machine.MulticastRoutingEntry multicast_routing_entry:
-            The route to add
-        :raise pacman.exceptions.PacmanAlreadyExistsException: If a routing
-            entry with the same key-mask combination already exists
-        """
         self._multicast_routing_entries.append(multicast_routing_entry)
 
         # update default routed counter if required

--- a/pacman/model/routing_tables/uncompressed_multicast_routing_table.py
+++ b/pacman/model/routing_tables/uncompressed_multicast_routing_table.py
@@ -67,17 +67,9 @@ class UnCompressedMulticastRoutingTable(AbstractMulticastRoutingTable):
         for multicast_routing_entry in multicast_routing_entries:
             self.add_multicast_routing_entry(multicast_routing_entry)
 
+    @overrides(AbstractMulticastRoutingTable.add_multicast_routing_entry)
     def add_multicast_routing_entry(
             self, multicast_routing_entry: MulticastRoutingEntry):
-        """
-        Adds a routing entry to this table.
-
-        :param ~spinn_machine.MulticastRoutingEntry multicast_routing_entry:
-            The route to add
-        :raise PacmanAlreadyExistsException:
-            If a routing entry with the same key-mask combination already
-            exists
-        """
         routing_entry_key = multicast_routing_entry.routing_entry_key
         mask = multicast_routing_entry.mask
 

--- a/pacman/operations/fixed_route_router/fixed_route_router.py
+++ b/pacman/operations/fixed_route_router/fixed_route_router.py
@@ -21,14 +21,15 @@ from pacman.exceptions import (
     PacmanRoutingException)
 
 
-def fixed_route_router(destination_class):
+def fixed_route_router(
+        destination_class) -> Dict[Tuple[int, int], FixedRouteEntry]:
     """
     Runs the fixed route generator for all boards on machine.
 
     :param destination_class: the destination class to route packets to
     :type destination_class: type or tuple(type,...)
     :return: router tables for fixed route paths
-    :rtype: dict(~spinn_machine.Chip, ~spinn_machine.FixedRouteEntry)
+    :rtype: dict((int, int)), ~spinn_machine.FixedRouteEntry)
     :raises PacmanConfigurationException: if no placement processor found
     :raises PacmanRoutingException:
     :raises PacmanAlreadyExistsException:

--- a/unittests/model_tests/application_graph_tests/test_application_vertex.py
+++ b/unittests/model_tests/application_graph_tests/test_application_vertex.py
@@ -120,6 +120,8 @@ class TestApplicationGraphModel(unittest.TestCase):
         vert = SimpleTestVertex(5)
         vert.set_label("test 1")
         self.assertEqual("test 1", vert.label)
-        vert.addedToGraph()
+        self.assertFalse(vert.has_been_added_to_graph())
+        vert.setAddedToGraph()
         with self.assertRaises(PacmanConfigurationException):
             vert.set_label("test 2")
+        self.assertTrue(vert.has_been_added_to_graph())


### PR DESCRIPTION
For a Vextex
rename addedToGraph to setAddedToGraph - to show it is a setter not a getter
add has_been_added_to_graph which is the gtter for above

make add_multicast_routing_entry abstract in abstract routing table
-all implement it
-avoid needing to cast

needed for https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/pull/1141
