### PR TITLE
Check fixed key and masks don't overlap

### DIFF
--- a/unittests/operations_tests/routing_info_algorithms_tests/test_zoned_routing_allocator.py
+++ b/unittests/operations_tests/routing_info_algorithms_tests/test_zoned_routing_allocator.py
@@ -172,12 +172,12 @@ def create_graphs_only_fixed(overlap: bool):
         fixed_keys_by_partition = {
             "Part0": BaseKeyAndMask(0x0, 0xffff0000),
             "Part1": BaseKeyAndMask(0x1000, 0xfffff800)
-    }
+        }
     else:
         fixed_keys_by_partition = {
             "Part0": BaseKeyAndMask(0x0, 0xFFFFFFFE),
             "Part1": BaseKeyAndMask(0x4c00000, 0xFFFFFFFF)
-    }
+        }
     app_vertex = MockAppVertex(
         splitter=MockSplitter(),
         fixed_keys_by_partition=fixed_keys_by_partition)


### PR DESCRIPTION
While working on validate_routes Pr found an error in a test which had two vertices with the same fixed key:

This adds a check that fixed keys and masks don't overlap.

Fixed a test where they dod to be one with and one wiithout overlap

Pr to fix the test is:
https://github.com/SpiNNakerManchester/sPyNNaker/pull/1418

tested by:
https://github.com/SpiNNakerManchester/IntegrationTests/pull/251

fixes: https://github.com/SpiNNakerManchester/PACMAN/issues/473