### PR TITLE
skip  prereleases

### DIFF
--- a/.github/workflows/python_actions.yml
+++ b/.github/workflows/python_actions.yml
@@ -25,4 +25,5 @@ jobs:
       dependencies: SpiNNUtils SpiNNMachine
       test_directories: unittests
       flake8-packages: pacman unittests
+      check_prereleases: false
     secrets: inherit


### PR DESCRIPTION
required for https://github.com/SpiNNakerManchester/PACMAN/issues/561

As you can not access matrix.python-version at the steps level higher than the steps 
https://github.com/SpiNNakerManchester/SupportScripts/commit/09acde67d8af65b260a8e544714e2e31807f5e3e
does an if in each step

this pr adds the flag check_prereleases: false