### PR TITLE
github action fixes

### DIFF
--- a/.github/workflows/python_actions.yml
+++ b/.github/workflows/python_actions.yml
@@ -24,7 +24,7 @@ jobs:
       dependencies: SpiNNUtils SpiNNMachine
       test_directories: unittests
       coverage-package: pacman
-      flake8-packages: pacman unittests
-      pylint-packages: pacman
+      flake8-packages: pacman unittests pacman_test_objects
+      pylint-packages: pacman pacman_test_objects
       mypy-packages: pacman pacman_test_objects
     secrets: inherit

--- a/.github/workflows/python_actions.yml
+++ b/.github/workflows/python_actions.yml
@@ -26,5 +26,5 @@ jobs:
       coverage-package: pacman
       flake8-packages: pacman unittests pacman_test_objects
       pylint-packages: pacman pacman_test_objects
-      mypy-packages: pacman pacman_test_objects
+      mypy-packages: pacman unittests pacman_test_objects
     secrets: inherit

--- a/.github/workflows/python_actions.yml
+++ b/.github/workflows/python_actions.yml
@@ -26,5 +26,5 @@ jobs:
       coverage-package: pacman
       flake8-packages: pacman unittests
       pylint-packages: pacman
-      mypy-packages: pacman
+      mypy-packages: pacman pacman_test_objects
     secrets: inherit

--- a/.github/workflows/python_actions.yml
+++ b/.github/workflows/python_actions.yml
@@ -27,5 +27,4 @@ jobs:
       flake8-packages: pacman unittests
       pylint-packages: pacman
       mypy-packages: pacman
-      check_prereleases: false
     secrets: inherit

--- a/pacman/operations/placer_algorithms/_spinner_api.py
+++ b/pacman/operations/placer_algorithms/_spinner_api.py
@@ -32,7 +32,7 @@ class Spinner:
     Typed version of the API from SpiNNer that we actually use.
     """
     #: Open a drawing surface as a context
-    png_context_manager: Callable[[str, int, int], AbstractContextManager[
+    png_context_manager: Callable[[str, int, int], ContextManager[
         _Context]]
     aspect_ratio: Callable[[int, int], float]
     draw: Callable[

--- a/pacman/operations/placer_algorithms/_spinner_api.py
+++ b/pacman/operations/placer_algorithms/_spinner_api.py
@@ -20,10 +20,10 @@ import sys
 from spinn_utilities.typing.coords import XY
 
 if sys.version_info.minor > 8:
-    # pylint: disable = ungrouped-imports
+    # pylint: disable=ungrouped-imports
     from contextlib import AbstractContextManager
 else:
-    # pylint: disable = ungrouped-imports
+    # pylint: disable=ungrouped-imports
     from typing import ContextManager as AbstractContextManager
 
     # Don't know or care what these next two types are; they're SpiNNer's

--- a/pacman/operations/placer_algorithms/_spinner_api.py
+++ b/pacman/operations/placer_algorithms/_spinner_api.py
@@ -14,16 +14,10 @@
 
 from dataclasses import dataclass
 import platform
+# pylint: disable=no-name-in-module
 from typing import (
-    Any, Callable, Dict, List, NewType, Union, Tuple)
-import sys
+    Any, Callable, ContextManager, Dict, List, NewType, Union, Tuple)
 from spinn_utilities.typing.coords import XY
-
-# pylint: disable=ungrouped-imports, no-name-in-module
-if sys.version_info.minor > 8:
-    from contextlib import AbstractContextManager
-else:
-    from typing import ContextManager as AbstractContextManager
 
 # Don't know or care what these next two types are; they're SpiNNer's
 _Boards = NewType("_Boards", list)

--- a/pacman/operations/placer_algorithms/_spinner_api.py
+++ b/pacman/operations/placer_algorithms/_spinner_api.py
@@ -19,14 +19,13 @@ from typing import (
 import sys
 from spinn_utilities.typing.coords import XY
 
+# pylint: disable=ungrouped-imports
 if sys.version_info.minor > 8:
-    # pylint: disable=ungrouped-imports
     from contextlib import AbstractContextManager
 else:
-    # pylint: disable=ungrouped-imports
     from typing import ContextManager as AbstractContextManager
 
-    # Don't know or care what these next two types are; they're SpiNNer's
+# Don't know or care what these next two types are; they're SpiNNer's
 _Boards = NewType("_Boards", list)
 _Context = NewType("_Context", int)
 #: The type of colours. RGBA

--- a/pacman/operations/placer_algorithms/_spinner_api.py
+++ b/pacman/operations/placer_algorithms/_spinner_api.py
@@ -19,7 +19,7 @@ from typing import (
 import sys
 from spinn_utilities.typing.coords import XY
 
-if sys.version_info > (3, 8):
+if sys.version_info.minor > 8:
     from contextlib import AbstractContextManager
 else:
     from typing import ContextManager as AbstractContextManager

--- a/pacman/operations/placer_algorithms/_spinner_api.py
+++ b/pacman/operations/placer_algorithms/_spinner_api.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from contextlib import AbstractContextManager
 from dataclasses import dataclass
 import platform
 from typing import (
-    Any, Callable, ContextManager, Dict, List, NewType, Union, Tuple)
+    Any, Callable, Dict, List, NewType, Union, Tuple)
 from spinn_utilities.typing.coords import XY
 
 # Don't know or care what these next two types are; they're SpiNNer's
@@ -31,7 +32,8 @@ class Spinner:
     Typed version of the API from SpiNNer that we actually use.
     """
     #: Open a drawing surface as a context
-    png_context_manager: Callable[[str, int, int], ContextManager[_Context]]
+    png_context_manager: Callable[[str, int, int],
+        AbstractContextManager[_Context]]
     aspect_ratio: Callable[[int, int], float]
     draw: Callable[
         [_Context, int, int, int, int, _Boards, Dict[Any, Any],

--- a/pacman/operations/placer_algorithms/_spinner_api.py
+++ b/pacman/operations/placer_algorithms/_spinner_api.py
@@ -12,14 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from contextlib import AbstractContextManager
 from dataclasses import dataclass
 import platform
 from typing import (
     Any, Callable, Dict, List, NewType, Union, Tuple)
+import sys
 from spinn_utilities.typing.coords import XY
 
-# Don't know or care what these next two types are; they're SpiNNer's
+if sys.version_info > (3, 8):
+    from contextlib import AbstractContextManager
+else:
+    from typing import ContextManager as AbstractContextManager
+
+    # Don't know or care what these next two types are; they're SpiNNer's
 _Boards = NewType("_Boards", list)
 _Context = NewType("_Context", int)
 #: The type of colours. RGBA
@@ -32,8 +37,8 @@ class Spinner:
     Typed version of the API from SpiNNer that we actually use.
     """
     #: Open a drawing surface as a context
-    png_context_manager: Callable[[str, int, int],
-        AbstractContextManager[_Context]]
+    png_context_manager: Callable[[str, int, int], AbstractContextManager[
+        _Context]]
     aspect_ratio: Callable[[int, int], float]
     draw: Callable[
         [_Context, int, int, int, int, _Boards, Dict[Any, Any],

--- a/pacman/operations/placer_algorithms/_spinner_api.py
+++ b/pacman/operations/placer_algorithms/_spinner_api.py
@@ -19,7 +19,7 @@ from typing import (
 import sys
 from spinn_utilities.typing.coords import XY
 
-# pylint: disable=ungrouped-imports
+# pylint: disable=ungrouped-imports, no-name-in-module
 if sys.version_info.minor > 8:
     from contextlib import AbstractContextManager
 else:

--- a/pacman/operations/placer_algorithms/_spinner_api.py
+++ b/pacman/operations/placer_algorithms/_spinner_api.py
@@ -20,8 +20,10 @@ import sys
 from spinn_utilities.typing.coords import XY
 
 if sys.version_info.minor > 8:
+    # pylint: disable = ungrouped-imports
     from contextlib import AbstractContextManager
 else:
+    # pylint: disable = ungrouped-imports
     from typing import ContextManager as AbstractContextManager
 
     # Don't know or care what these next two types are; they're SpiNNer's

--- a/pacman_test_objects/non_legacy_app_vertex.py
+++ b/pacman_test_objects/non_legacy_app_vertex.py
@@ -20,4 +20,3 @@ class NonLegacyApplicationVertex(ApplicationVertex):
 
     def n_atoms(self):
         pass
-

--- a/pacman_test_objects/non_legacy_app_vertex.py
+++ b/pacman_test_objects/non_legacy_app_vertex.py
@@ -15,8 +15,12 @@ from pacman.model.graphs.application import ApplicationVertex
 
 
 class NonLegacyApplicationVertex(ApplicationVertex):
+    """
+    Test vertex
+    """
     def __init__(self, label="test"):
         super().__init__(label=label)
 
+    @property
     def n_atoms(self):
-        pass
+        return 256

--- a/pacman_test_objects/placer_test_support.py
+++ b/pacman_test_objects/placer_test_support.py
@@ -18,6 +18,9 @@ from pacman.model.resources import ConstantSDRAM
 
 
 def get_resourced_machine_vertex(lo_atom, hi_atom, label=None):
+    """
+    A test vertex with sdram set
+    """
     sdram_requirement = 4000 + 50 * (hi_atom - lo_atom)
     sdram = ConstantSDRAM(sdram_requirement)
     return SimpleMachineVertex(

--- a/pacman_test_objects/py.typed
+++ b/pacman_test_objects/py.typed
@@ -1,0 +1,13 @@
+# Copyright (c) 2023 The University of Manchester
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/pacman_test_objects/simple_test_vertex.py
+++ b/pacman_test_objects/simple_test_vertex.py
@@ -14,7 +14,7 @@
 
 """ test vertex used in many unit tests
 """
-from  typing import Optional
+from typing import Optional
 from spinn_utilities.overrides import overrides
 from pacman.model.partitioner_interfaces.legacy_partitioner_api import (
     LegacyPartitionerAPI)

--- a/unittests/model_tests/partitioner_splitters_tests/splitter_slice_legacy_test.py
+++ b/unittests/model_tests/partitioner_splitters_tests/splitter_slice_legacy_test.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import unittest
-from testfixtures import LogCapture
+from testfixtures import LogCapture  # type: ignore[import]
 from pacman.config_setup import unittest_setup
 from pacman.exceptions import PacmanConfigurationException
 from pacman.model.partitioner_splitters import SplitterFixedLegacy


### PR DESCRIPTION
This and related Ps do more to unify the way we test.

All are independent but tested together.
Except the FEC one depends on this one.

General changes in several Repositories

1. mypy unittests
1. We still do not pylint unitests
1. install types-PyYAML so import yaml does not need a type: ignore 
1. minor changes to get tests to pass
1. Do not mypy matplot lib as the typed versions of matplotlib are python 3.9 and above
1. pylint: disable=no-name-in-module when using typing context Manager
  - test show pylint is wrong in python 3.13
