### PR TITLE
Fix internal multicast partitions

### DIFF
--- a/pacman/operations/router_algorithms/application_router.py
+++ b/pacman/operations/router_algorithms/application_router.py
@@ -234,7 +234,8 @@ def route_application_graph() -> MulticastRoutingTableByPartition:
                 _route_source_to_source(source, partition, targets, self_xys)
 
         # Deal with internal multicast partitions
-        internal = source.splitter.get_internal_multicast_partitions()
+        internal = _get_filtered_internal_partitions(
+            source, partition.identifier)
         if internal:
             self_connected = True
             _route_internal(internal, targets, self_xys)
@@ -256,6 +257,12 @@ def route_application_graph() -> MulticastRoutingTableByPartition:
 
     # Return the routing tables
     return routing_tables
+
+
+def _get_filtered_internal_partitions(vertex, identifier):
+    for partition in vertex.splitter.get_internal_multicast_partitions():
+        if partition.identifier == identifier:
+            yield partition
 
 
 def _route_source_to_target(
@@ -628,7 +635,7 @@ def _get_outgoing_mapping(
     for m_vertex in app_vertex.splitter.get_out_going_vertices(partition_id):
         xy, route = vertex_xy_and_route(m_vertex)
         outgoing_mapping[xy].append(route)
-    for in_part in app_vertex.splitter.get_internal_multicast_partitions():
+    for in_part in _get_filtered_internal_partitions(app_vertex, partition_id):
         if in_part.identifier == partition_id:
             xy, route = vertex_xy_and_route(in_part.pre_vertex)
             outgoing_mapping[xy].append(route)

--- a/pacman/operations/routing_info_allocator_algorithms/zoned_routing_info_allocator.py
+++ b/pacman/operations/routing_info_allocator_algorithms/zoned_routing_info_allocator.py
@@ -17,7 +17,6 @@ from typing import Dict, FrozenSet, Iterable, Set, Tuple, cast
 from spinn_utilities.log import FormatAdapter
 from spinn_utilities.progress_bar import ProgressBar
 from spinn_utilities.ordered_set import OrderedSet
-from pacman.data import PacmanDataView
 from pacman.model.routing_info import (
     RoutingInfo, MachineVertexRoutingInfo, BaseKeyAndMask,
     AppVertexRoutingInfo)
@@ -28,6 +27,8 @@ from pacman.utilities.utility_calls import (
     get_key_ranges, allocator_bits_needed)
 from pacman.exceptions import PacmanRouteInfoAllocationException
 from pacman.utilities.constants import BITS_IN_KEY, FULL_MASK
+from pacman.utilities.algorithm_utilities.routing_algorithm_utilities import (
+    get_app_partitions)
 _XAlloc = Iterable[Tuple[ApplicationVertex, str]]
 logger = FormatAdapter(logging.getLogger(__name__))
 
@@ -137,13 +138,8 @@ class ZonedRoutingInfoAllocator(object):
         """
         self.__vertex_partitions = OrderedSet(
             (p.pre_vertex, p.identifier)
-            for p in PacmanDataView.iterate_partitions())
+            for p in get_app_partitions())
         self.__vertex_partitions.update(extra_allocations)
-        self.__vertex_partitions.update(
-            (v, p.identifier)
-            for v in PacmanDataView.iterate_vertices()
-            if isinstance(v, ApplicationVertex)
-            for p in v.splitter.get_internal_multicast_partitions())
 
         self.__find_fixed()
         self.__calculate_zones()

--- a/pacman/utilities/algorithm_utilities/routing_algorithm_utilities.py
+++ b/pacman/utilities/algorithm_utilities/routing_algorithm_utilities.py
@@ -47,19 +47,18 @@ def get_app_partitions() -> List[ApplicationEdgePartition]:
     # Find all partitions that need to be dealt with
     # Make a copy which we can edit
     partitions = list(PacmanDataView.iterate_partitions())
-    sources = frozenset(p.pre_vertex for p in partitions)
+    sources = set((p.pre_vertex, p.identifier) for p in partitions)
 
     # Convert internal partitions to self-connected partitions
     for v in PacmanDataView.iterate_vertices():
         if not isinstance(v, ApplicationVertex) or not v.splitter:
             continue
         internal_partitions = v.splitter.get_internal_multicast_partitions()
-        if v not in sources and internal_partitions:
-            # guarantee order
-            for identifier in dict.fromkeys(
-                    p.identifier for p in internal_partitions):
+        for p in internal_partitions:
+            if (v, p.identifier) not in sources:
                 # Add a partition with no edges to identify this as internal
-                partitions.append(ApplicationEdgePartition(identifier, v))
+                partitions.append(ApplicationEdgePartition(p.identifier, v))
+                sources.add((v, p.identifier))
     return partitions
 
 


### PR DESCRIPTION
Fix some issues in using internal multicast partitions.  Mostly this makes sure that they are only applied when the partition id matches the partition being dealt with.  Changes here avoid changes elsewhere.

Tested by:
 - SpiNNakerManchester/IntegrationTests#287