### PR TITLE
Allow different partitions

### DIFF
--- a/pacman/model/routing_info/routing_info.py
+++ b/pacman/model/routing_info/routing_info.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 from __future__ import annotations
 from collections import defaultdict
-from typing import Dict, Iterator, Optional, Iterable, TYPE_CHECKING
+from typing import Dict, Iterator, Optional, Iterable, Set, TYPE_CHECKING
 from deprecated import deprecated
 from pacman.exceptions import PacmanAlreadyExistsException
 if TYPE_CHECKING:
@@ -161,6 +161,24 @@ class RoutingInfo(object):
             return False
         info = self._info[vertex]
         return partition_id in info
+
+    def test_pre_vertex_partition_ids(
+            self, vertex: AbstractVertex,
+            allowed_partition_ids: Set[str]):
+        """
+        Check that the partition ids for a vertex are in the allowed set.
+
+        :param AbstractVertex vertex: The vertex to search for
+        :param set[str] allowed_partition_ids: The allowed partition ids
+        :raise KeyError: If the vertex has an unknown partition ID
+        """
+        if vertex not in self._info:
+            return
+        info = self._info[vertex]
+        for partition_id in info:
+            if partition_id not in allowed_partition_ids:
+                raise KeyError(
+                    f"Vertex {vertex} has unknown partition ID {partition_id}")
 
     def get_single_routing_info_from_pre_vertex(
             self, vertex: AbstractVertex) -> Optional[VertexRoutingInfo]:

--- a/pacman/model/routing_info/routing_info.py
+++ b/pacman/model/routing_info/routing_info.py
@@ -57,6 +57,7 @@ class RoutingInfo(object):
                        "Use a combination of "
                        "get_safe_routing_info_from_pre_vertex, "
                        "get_partitions_outgoing_from_vertex, "
+                       "has_routing_info_from_pre_vertex, "
                        "or get_single_routing_info_from_pre_vertex")
     def get_routing_info_from_pre_vertex(
             self, vertex: AbstractVertex,
@@ -97,6 +98,7 @@ class RoutingInfo(object):
                        "Use a combination of "
                        "get_safe_first_key_from_pre_vertex, "
                        "get_partitions_outgoing_from_vertex, "
+                       "has_routing_info_from_pre_vertex, "
                        "or get_single_first_key_from_pre_vertex")
     def get_first_key_from_pre_vertex(
             self, vertex: AbstractVertex, partition_id: str) -> Optional[int]:
@@ -144,6 +146,21 @@ class RoutingInfo(object):
         :param AbstractVertex vertex: The vertex to search for
         """
         return self._info[vertex].keys()
+
+    def has_routing_info_from_pre_vertex(
+            self, vertex: AbstractVertex, partition_id: str) -> bool:
+        """
+        Check if there is routing information for a given vertex.
+
+        :param AbstractVertex vertex: The vertex to search for
+        :param str partition_id:
+            The ID of the partition for which to get the routing information
+        :rtype: bool
+        """
+        if vertex not in self._info:
+            return False
+        info = self._info[vertex]
+        return partition_id in info
 
     def get_single_routing_info_from_pre_vertex(
             self, vertex: AbstractVertex) -> Optional[VertexRoutingInfo]:

--- a/pacman/model/routing_info/routing_info.py
+++ b/pacman/model/routing_info/routing_info.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 from __future__ import annotations
 from collections import defaultdict
-from deprecated import deprecated
 from typing import Dict, Iterator, Optional, Iterable, TYPE_CHECKING
+from deprecated import deprecated
 from pacman.exceptions import PacmanAlreadyExistsException
 if TYPE_CHECKING:
     from .vertex_routing_info import VertexRoutingInfo

--- a/pacman/model/routing_info/routing_info.py
+++ b/pacman/model/routing_info/routing_info.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from __future__ import annotations
-from typing import Dict, Iterator, Optional, Tuple, TYPE_CHECKING
+from collections import defaultdict
+from deprecated import deprecated
+from typing import Dict, Iterator, Optional, Iterable, TYPE_CHECKING
 from pacman.exceptions import PacmanAlreadyExistsException
 if TYPE_CHECKING:
     from .vertex_routing_info import VertexRoutingInfo
@@ -29,8 +31,8 @@ class RoutingInfo(object):
     def __init__(self) -> None:
         # Partition information indexed by edge pre-vertex and partition ID
         # name
-        self._info: Dict[
-            Tuple[AbstractVertex, str], VertexRoutingInfo] = dict()
+        self._info: Dict[AbstractVertex,
+                         Dict[str, VertexRoutingInfo]] = defaultdict(dict)
 
     def add_routing_info(self, info: VertexRoutingInfo):
         """
@@ -41,13 +43,21 @@ class RoutingInfo(object):
         :raise PacmanAlreadyExistsException:
             If the partition is already in the set of edges
         """
-        key = (info.vertex, info.partition_id)
-        if key in self._info:
+        if (info.vertex in self._info and
+                info.partition_id in self._info[info.vertex]):
             raise PacmanAlreadyExistsException(
                 "Routing information", str(info))
 
-        self._info[key] = info
+        self._info[info.vertex][info.partition_id] = info
 
+    @deprecated(reason="This method is unsafe, since it doesn't determine "
+                       "whether the info is missing because there is no "
+                       "outgoing edge, or if the outgoing edge is in another "
+                       "partition and the name is wrong. "
+                       "Use a combination of "
+                       "get_safe_routing_info_from_pre_vertex, "
+                       "get_partitions_outgoing_from_vertex, "
+                       "or get_single_routing_info_from_pre_vertex")
     def get_routing_info_from_pre_vertex(
             self, vertex: AbstractVertex,
             partition_id: str) -> Optional[VertexRoutingInfo]:
@@ -57,10 +67,34 @@ class RoutingInfo(object):
         :param AbstractVertex vertex: The vertex to search for
         :param str partition_id:
             The ID of the partition for which to get the routing information
-        :rtype: VertexRoutingInfo
+        :rtype: VertexRoutingInfo or None
         """
-        return self._info.get((vertex, partition_id))
+        return self._info[vertex].get(partition_id)
 
+    def get_safe_routing_info_from_pre_vertex(
+            self, vertex: AbstractVertex,
+            partition_id: str) -> VertexRoutingInfo:
+        """
+        Get routing information for a given partition_id from a vertex.
+
+        :param AbstractVertex vertex: The vertex to search for
+        :param str partition_id:
+            The ID of the partition for which to get the routing information
+        :rtype: VertexRoutingInfo
+        :raise KeyError:
+            If the vertex/partition_id combination is not in the routing
+            information
+        """
+        return self._info[vertex][partition_id]
+
+    @deprecated(reason="This method is unsafe, since it doesn't determine "
+                       "whether the info is missing because there is no "
+                       "outgoing edge, or if the outgoing edge is in another "
+                       "partition and the name is wrong. "
+                       "Use a combination of "
+                       "get_safe_first_key_from_pre_vertex, "
+                       "get_partitions_outgoing_from_vertex, "
+                       "or get_single_first_key_from_pre_vertex")
     def get_first_key_from_pre_vertex(
             self, vertex: AbstractVertex, partition_id: str) -> Optional[int]:
         """
@@ -70,12 +104,72 @@ class RoutingInfo(object):
         :param str partition_id:
             The ID of the partition for which to get the routing information
         :return: The routing key of the partition
-        :rtype: int
+        :rtype: int or None
         """
-        key = (vertex, partition_id)
-        if key in self._info:
-            return self._info[key].key
-        return None
+        if vertex not in self._info:
+            return None
+        info = self._info[vertex]
+        if partition_id not in info:
+            return None
+        return info[partition_id].key
+
+    def get_safe_first_key_from_pre_vertex(
+            self, vertex: AbstractVertex, partition_id: str) -> int:
+        """
+        Get the first key for the partition starting at a vertex.
+
+        :param AbstractVertex vertex: The vertex which the partition starts at
+        :param str partition_id:
+            The ID of the partition for which to get the routing information
+        :return: The routing key of the partition
+        :rtype: int
+        :raise KeyError:
+            If the vertex/partition_id combination is not in the routing
+            information
+        """
+        return self._info[vertex][partition_id].key
+
+    def get_partitions_outgoing_from_vertex(
+            self, vertex: AbstractVertex) -> Iterable[str]:
+        """
+        Get the outgoing partitions from a vertex.
+
+        :param AbstractVertex vertex: The vertex to search for
+        """
+        return self._info[vertex].keys()
+
+    def get_single_routing_info_from_pre_vertex(
+            self, vertex: AbstractVertex) -> Optional[VertexRoutingInfo]:
+        """
+        Get routing information for a given vertex.  Fails if the vertex has
+        more than one outgoing partition.
+
+        :param AbstractVertex vertex: The vertex to search for
+        :rtype: VertexRoutingInfo or None
+        :raise KeyError: If the vertex has more than one outgoing partition
+        """
+        if vertex not in self._info:
+            return None
+        info = self._info[vertex]
+        if len(info) != 1:
+            raise KeyError(
+                f"Vertex {vertex} has more than one outgoing partition")
+        return next(iter(info.values()))
+
+    def get_single_first_key_from_pre_vertex(
+            self, vertex: AbstractVertex) -> int:
+        """
+        Get the first key for the partition starting at a vertex.  Fails if
+        the vertex has more than one outgoing partition.
+
+        :param AbstractVertex vertex: The vertex which the partition starts at
+        :rtype: int
+        :raise KeyError: If the vertex has more than one outgoing partition
+        """
+        info = self.get_single_routing_info_from_pre_vertex(vertex)
+        if info is None:
+            return None
+        return info.key
 
     def __iter__(self) -> Iterator[VertexRoutingInfo]:
         """

--- a/pacman/model/routing_info/routing_info.py
+++ b/pacman/model/routing_info/routing_info.py
@@ -177,4 +177,6 @@ class RoutingInfo(object):
 
         :return: a iterator of routing information
         """
-        return iter(self._info.values())
+        for vertex_info in self._info.values():
+            for info in vertex_info.values():
+                yield info

--- a/pacman/model/routing_info/routing_info.py
+++ b/pacman/model/routing_info/routing_info.py
@@ -55,10 +55,10 @@ class RoutingInfo(object):
                        "outgoing edge, or if the outgoing edge is in another "
                        "partition and the name is wrong. "
                        "Use a combination of "
-                       "get_safe_routing_info_from_pre_vertex, "
-                       "get_partitions_outgoing_from_vertex, "
-                       "has_routing_info_from_pre_vertex, "
-                       "or get_single_routing_info_from_pre_vertex")
+                       "get_info_from, "
+                       "get_partitions_from, "
+                       "has_info_from, "
+                       "or get_single_info_from")
     def get_routing_info_from_pre_vertex(
             self, vertex: AbstractVertex,
             partition_id: str) -> Optional[VertexRoutingInfo]:
@@ -70,12 +70,9 @@ class RoutingInfo(object):
             The ID of the partition for which to get the routing information
         :rtype: VertexRoutingInfo or None
         """
-        # TODO: Replace (currently temporarily broken to make sure we don't
-        # call it)
-        raise NotImplementedError("Deprecated - shouldn't be used")
-        # return self._info[vertex].get(partition_id)
+        return self._info[vertex].get(partition_id)
 
-    def get_safe_routing_info_from_pre_vertex(
+    def get_info_from(
             self, vertex: AbstractVertex,
             partition_id: str) -> VertexRoutingInfo:
         """
@@ -96,10 +93,10 @@ class RoutingInfo(object):
                        "outgoing edge, or if the outgoing edge is in another "
                        "partition and the name is wrong. "
                        "Use a combination of "
-                       "get_safe_first_key_from_pre_vertex, "
-                       "get_partitions_outgoing_from_vertex, "
-                       "has_routing_info_from_pre_vertex, "
-                       "or get_single_first_key_from_pre_vertex")
+                       "get_key_from, "
+                       "get_partitions_from, "
+                       "has_info_from, "
+                       "or get_single_key_from")
     def get_first_key_from_pre_vertex(
             self, vertex: AbstractVertex, partition_id: str) -> Optional[int]:
         """
@@ -111,18 +108,14 @@ class RoutingInfo(object):
         :return: The routing key of the partition
         :rtype: int or None
         """
-        # TODO: Replace (currently temporarily broken to make sure we don't
-        # call it)
-        raise NotImplementedError("Deprecated - shouldn't be used")
+        if vertex not in self._info:
+            return None
+        info = self._info[vertex]
+        if partition_id not in info:
+            return None
+        return info[partition_id].key
 
-        # if vertex not in self._info:
-        #     return None
-        # info = self._info[vertex]
-        # if partition_id not in info:
-        #     return None
-        # return info[partition_id].key
-
-    def get_safe_first_key_from_pre_vertex(
+    def get_key_from(
             self, vertex: AbstractVertex, partition_id: str) -> int:
         """
         Get the first key for the partition starting at a vertex.
@@ -138,7 +131,7 @@ class RoutingInfo(object):
         """
         return self._info[vertex][partition_id].key
 
-    def get_partitions_outgoing_from_vertex(
+    def get_partitions_from(
             self, vertex: AbstractVertex) -> Iterable[str]:
         """
         Get the outgoing partitions from a vertex.
@@ -147,7 +140,7 @@ class RoutingInfo(object):
         """
         return self._info[vertex].keys()
 
-    def has_routing_info_from_pre_vertex(
+    def has_info_from(
             self, vertex: AbstractVertex, partition_id: str) -> bool:
         """
         Check if there is routing information for a given vertex.
@@ -162,7 +155,7 @@ class RoutingInfo(object):
         info = self._info[vertex]
         return partition_id in info
 
-    def test_pre_vertex_partition_ids(
+    def check_info_from(
             self, vertex: AbstractVertex,
             allowed_partition_ids: Set[str]):
         """
@@ -180,7 +173,7 @@ class RoutingInfo(object):
                 raise KeyError(
                     f"Vertex {vertex} has unknown partition ID {partition_id}")
 
-    def get_single_routing_info_from_pre_vertex(
+    def get_single_info_from(
             self, vertex: AbstractVertex) -> Optional[VertexRoutingInfo]:
         """
         Get routing information for a given vertex.  Fails if the vertex has
@@ -198,7 +191,7 @@ class RoutingInfo(object):
                 f"Vertex {vertex} has more than one outgoing partition")
         return next(iter(info.values()))
 
-    def get_single_first_key_from_pre_vertex(
+    def get_single_key_from(
             self, vertex: AbstractVertex) -> Optional[int]:
         """
         Get the first key for the partition starting at a vertex.  Fails if
@@ -208,7 +201,7 @@ class RoutingInfo(object):
         :rtype: int or None
         :raise KeyError: If the vertex has more than one outgoing partition
         """
-        info = self.get_single_routing_info_from_pre_vertex(vertex)
+        info = self.get_single_info_from(vertex)
         if info is None:
             return None
         return info.key

--- a/pacman/model/routing_info/routing_info.py
+++ b/pacman/model/routing_info/routing_info.py
@@ -157,13 +157,13 @@ class RoutingInfo(object):
         return next(iter(info.values()))
 
     def get_single_first_key_from_pre_vertex(
-            self, vertex: AbstractVertex) -> int:
+            self, vertex: AbstractVertex) -> Optional[int]:
         """
         Get the first key for the partition starting at a vertex.  Fails if
         the vertex has more than one outgoing partition.
 
         :param AbstractVertex vertex: The vertex which the partition starts at
-        :rtype: int
+        :rtype: int or None
         :raise KeyError: If the vertex has more than one outgoing partition
         """
         info = self.get_single_routing_info_from_pre_vertex(vertex)

--- a/pacman/model/routing_info/routing_info.py
+++ b/pacman/model/routing_info/routing_info.py
@@ -69,7 +69,10 @@ class RoutingInfo(object):
             The ID of the partition for which to get the routing information
         :rtype: VertexRoutingInfo or None
         """
-        return self._info[vertex].get(partition_id)
+        # TODO: Replace (currently temporarily broken to make sure we don't
+        # call it)
+        raise NotImplementedError("Deprecated - shouldn't be used")
+        # return self._info[vertex].get(partition_id)
 
     def get_safe_routing_info_from_pre_vertex(
             self, vertex: AbstractVertex,
@@ -106,12 +109,16 @@ class RoutingInfo(object):
         :return: The routing key of the partition
         :rtype: int or None
         """
-        if vertex not in self._info:
-            return None
-        info = self._info[vertex]
-        if partition_id not in info:
-            return None
-        return info[partition_id].key
+        # TODO: Replace (currently temporarily broken to make sure we don't
+        # call it)
+        raise NotImplementedError("Deprecated - shouldn't be used")
+
+        # if vertex not in self._info:
+        #     return None
+        # info = self._info[vertex]
+        # if partition_id not in info:
+        #     return None
+        # return info[partition_id].key
 
     def get_safe_first_key_from_pre_vertex(
             self, vertex: AbstractVertex, partition_id: str) -> int:

--- a/pacman/operations/multi_cast_router_check_functionality/valid_routes_checker.py
+++ b/pacman/operations/multi_cast_router_check_functionality/valid_routes_checker.py
@@ -118,14 +118,13 @@ def validate_routes(routing_tables: MulticastRoutingTables):
             if isinstance(m_vertex, AbstractVirtual):
                 continue
             placement = PacmanDataView.get_placement_of_vertex(m_vertex)
-            r_info = routing_infos.get_routing_info_from_pre_vertex(
+            r_info = routing_infos.get_safe_routing_info_from_pre_vertex(
                 m_vertex, partition.identifier)
 
             # search for these destinations
-            if r_info:
-                _search_route(
-                    placement, destinations[m_vertex], r_info.key_and_mask,
-                    routing_tables, m_vertex.vertex_slice.n_atoms)
+            _search_route(
+                placement, destinations[m_vertex], r_info.key_and_mask,
+                routing_tables, m_vertex.vertex_slice.n_atoms)
 
 
 def _search_route(

--- a/pacman/operations/multi_cast_router_check_functionality/valid_routes_checker.py
+++ b/pacman/operations/multi_cast_router_check_functionality/valid_routes_checker.py
@@ -118,7 +118,7 @@ def validate_routes(routing_tables: MulticastRoutingTables):
             if isinstance(m_vertex, AbstractVirtual):
                 continue
             placement = PacmanDataView.get_placement_of_vertex(m_vertex)
-            r_info = routing_infos.get_safe_routing_info_from_pre_vertex(
+            r_info = routing_infos.get_info_from(
                 m_vertex, partition.identifier)
 
             # search for these destinations

--- a/pacman/operations/routing_table_generators/basic_routing_table_generator.py
+++ b/pacman/operations/routing_table_generators/basic_routing_table_generator.py
@@ -63,11 +63,8 @@ def __create_routing_table(
     sources_by_key_mask: Dict[BaseKeyAndMask,
                               Tuple[AbstractVertex, str]] = dict()
     for source_vertex, partition_id in partitions_in_table:
-        r_info = routing_infos.get_routing_info_from_pre_vertex(
+        r_info = routing_infos.get_safe_routing_info_from_pre_vertex(
             source_vertex, partition_id)
-        # Should be there; skip if not
-        if r_info is None:
-            continue
         entry = partitions_in_table[source_vertex, partition_id]
         if r_info.key_and_mask in sources_by_key_mask:
             if (sources_by_key_mask[r_info.key_and_mask]

--- a/pacman/operations/routing_table_generators/basic_routing_table_generator.py
+++ b/pacman/operations/routing_table_generators/basic_routing_table_generator.py
@@ -63,7 +63,7 @@ def __create_routing_table(
     sources_by_key_mask: Dict[BaseKeyAndMask,
                               Tuple[AbstractVertex, str]] = dict()
     for source_vertex, partition_id in partitions_in_table:
-        r_info = routing_infos.get_safe_routing_info_from_pre_vertex(
+        r_info = routing_infos.get_info_from(
             source_vertex, partition_id)
         entry = partitions_in_table[source_vertex, partition_id]
         if r_info.key_and_mask in sources_by_key_mask:

--- a/pacman/operations/routing_table_generators/merged_routing_table_generator.py
+++ b/pacman/operations/routing_table_generators/merged_routing_table_generator.py
@@ -70,10 +70,8 @@ def __create_routing_table(
     iterator = _IteratorWithNext(partitions_in_table.items())
     while iterator.has_next:
         (vertex, part_id), entry = iterator.pop()
-        r_info = routing_info.get_routing_info_from_pre_vertex(vertex, part_id)
-        if r_info is None:
-            raise PacmanRoutingException(
-                f"Missing Routing information for {vertex}, {part_id}")
+        r_info = routing_info.get_safe_routing_info_from_pre_vertex(
+            vertex, part_id)
 
         if r_info.key_and_mask in sources_by_key_mask:
             if (sources_by_key_mask[r_info.key_and_mask] != (vertex, part_id)):
@@ -102,7 +100,7 @@ def __create_routing_table(
             continue
 
         # This has to be AppVertexRoutingInfo!
-        app_r_info = routing_info.get_routing_info_from_pre_vertex(
+        app_r_info = routing_info.get_safe_routing_info_from_pre_vertex(
             vertex.app_vertex, part_id)
         assert isinstance(app_r_info, AppVertexRoutingInfo)
 
@@ -112,7 +110,7 @@ def __create_routing_table(
         while __match(iterator, vertex, part_id, r_info, entry, routing_info,
                       app_r_info):
             (vertex, part_id), entry = iterator.pop()
-            r_info = routing_info.get_routing_info_from_pre_vertex(
+            r_info = routing_info.get_safe_routing_info_from_pre_vertex(
                 vertex, part_id)
             if r_info is not None:
                 assert isinstance(r_info, MachineVertexRoutingInfo)
@@ -139,11 +137,8 @@ def __match(
         return False
     if __mask_has_holes(r_info.mask):
         return False
-    next_r_info = routing_info.get_routing_info_from_pre_vertex(
+    next_r_info = routing_info.get_safe_routing_info_from_pre_vertex(
         next_vertex, next_part_id)
-    if next_r_info is None:
-        raise KeyError(
-            f"No routing info found for {next_vertex}, {next_part_id}")
     if next_r_info.index != r_info.index + 1:
         return False
     app_src = vertex.app_vertex

--- a/pacman/operations/routing_table_generators/merged_routing_table_generator.py
+++ b/pacman/operations/routing_table_generators/merged_routing_table_generator.py
@@ -69,7 +69,7 @@ def __create_routing_table(
     iterator = _IteratorWithNext(partitions_in_table.items())
     while iterator.has_next:
         (vertex, part_id), entry = iterator.pop()
-        r_info = routing_info.get_safe_routing_info_from_pre_vertex(
+        r_info = routing_info.get_info_from(
             vertex, part_id)
 
         if r_info.key_and_mask in sources_by_key_mask:
@@ -99,7 +99,7 @@ def __create_routing_table(
             continue
 
         # This has to be AppVertexRoutingInfo!
-        app_r_info = routing_info.get_safe_routing_info_from_pre_vertex(
+        app_r_info = routing_info.get_info_from(
             vertex.app_vertex, part_id)
         assert isinstance(app_r_info, AppVertexRoutingInfo)
 
@@ -109,7 +109,7 @@ def __create_routing_table(
         while __match(iterator, vertex, part_id, r_info, entry, routing_info,
                       app_r_info):
             (vertex, part_id), entry = iterator.pop()
-            r_info = routing_info.get_safe_routing_info_from_pre_vertex(
+            r_info = routing_info.get_info_from(
                 vertex, part_id)
             if r_info is not None:
                 assert isinstance(r_info, MachineVertexRoutingInfo)
@@ -136,7 +136,7 @@ def __match(
         return False
     if __mask_has_holes(r_info.mask):
         return False
-    next_r_info = routing_info.get_safe_routing_info_from_pre_vertex(
+    next_r_info = routing_info.get_info_from(
         next_vertex, next_part_id)
     if next_r_info.index != r_info.index + 1:
         return False

--- a/pacman/operations/routing_table_generators/merged_routing_table_generator.py
+++ b/pacman/operations/routing_table_generators/merged_routing_table_generator.py
@@ -16,7 +16,6 @@ from typing import (
 from spinn_utilities.progress_bar import ProgressBar
 from spinn_machine import MulticastRoutingEntry, RoutingEntry
 from pacman.data import PacmanDataView
-from pacman.exceptions import PacmanRoutingException
 from pacman.model.routing_tables import (
     UnCompressedMulticastRoutingTable, MulticastRoutingTables)
 from pacman.model.graphs.application import ApplicationVertex

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,6 +50,7 @@ include_package_data = True
 install_requires =
         jsonschema
         typing_extensions
+        deprecated
         SpiNNUtilities == 1!7.3.1
         SpiNNMachine == 1!7.3.1
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,6 +74,7 @@ test =
         pylint
         testfixtures
         types-jsonschema
+        types-Deprecated
 # How to make
 #    [Reports]
 #    draw_placements=True

--- a/unittests/model_tests/routing_info_tests/test_routing_info.py
+++ b/unittests/model_tests/routing_info_tests/test_routing_info.py
@@ -28,7 +28,7 @@ class TestRoutingInfo(unittest.TestCase):
     def setUp(self):
         unittest_setup()
 
-    def test_routing_info(self):
+    def test_routing_info_deprecated(self):
         pre_vertex = SimpleMachineVertex(ConstantSDRAM(0))
         key = 12345
         info = MachineVertexRoutingInfo(
@@ -72,6 +72,61 @@ class TestRoutingInfo(unittest.TestCase):
                 pre_vertex, "Test")
         assert routing_info.get_routing_info_from_pre_vertex(
             pre_vertex, "Test2").get_keys().tolist() == [key]
+
+    def test_routing_info(self):
+        pre_vertex = SimpleMachineVertex(ConstantSDRAM(0))
+        key = 12345
+        info = MachineVertexRoutingInfo(
+            BaseKeyAndMask(key, FULL_MASK), "Test", pre_vertex, 0)
+        routing_info = RoutingInfo()
+        routing_info.add_routing_info(info)
+
+        with self.assertRaises(PacmanAlreadyExistsException):
+            routing_info.add_routing_info(info)
+
+        assert routing_info.get_safe_routing_info_from_pre_vertex(
+            pre_vertex, "Test") == info
+        with self.assertRaises(KeyError):
+            routing_info.get_safe_routing_info_from_pre_vertex(
+                None, "Test")
+        with self.assertRaises(KeyError):
+            routing_info.get_safe_routing_info_from_pre_vertex(
+                pre_vertex, "None")
+
+        assert routing_info.get_safe_first_key_from_pre_vertex(
+            pre_vertex, "Test") == key
+        with self.assertRaises(KeyError):
+            routing_info.get_safe_first_key_from_pre_vertex(
+                None, "Test")
+        with self.assertRaises(KeyError):
+            routing_info.get_safe_first_key_from_pre_vertex(
+                pre_vertex, "None")
+
+        assert list(routing_info.get_partitions_outgoing_from_vertex(
+            pre_vertex)) == ["Test"]
+        assert list(routing_info.get_partitions_outgoing_from_vertex(
+            None)) == []
+
+        assert next(iter(routing_info)) == info
+
+        info2 = MachineVertexRoutingInfo(
+            BaseKeyAndMask(key, FULL_MASK), "Test", pre_vertex, 0)
+
+        with self.assertRaises(PacmanAlreadyExistsException):
+            routing_info.add_routing_info(info2)
+        assert info != info2
+
+        info3 = MachineVertexRoutingInfo(
+            BaseKeyAndMask(key, FULL_MASK), "Test2", pre_vertex, 0)
+        routing_info.add_routing_info(info3)
+        assert info != info3
+        assert routing_info.get_safe_routing_info_from_pre_vertex(
+                pre_vertex, "Test2") !=\
+            routing_info.get_safe_routing_info_from_pre_vertex(
+                pre_vertex, "Test")
+        assert routing_info.get_safe_routing_info_from_pre_vertex(
+            pre_vertex, "Test2").get_keys().tolist() == [key]
+
 
     def test_base_key_and_mask(self):
         with self.assertRaises(PacmanConfigurationException):

--- a/unittests/model_tests/routing_info_tests/test_routing_info.py
+++ b/unittests/model_tests/routing_info_tests/test_routing_info.py
@@ -109,6 +109,17 @@ class TestRoutingInfo(unittest.TestCase):
         assert list(routing_info.get_partitions_outgoing_from_vertex(
             None)) == []
 
+        # This should work as can be either partition
+        routing_info.test_pre_vertex_partition_ids(
+            pre_vertex, {"Test", "Test2"})
+
+        # Works because None has no partitions!
+        routing_info.test_pre_vertex_partition_ids(None, {"Test"})
+
+        # This should not work
+        with self.assertRaises(KeyError):
+            routing_info.test_pre_vertex_partition_ids(pre_vertex, {"Test2"})
+
         assert routing_info.has_routing_info_from_pre_vertex(
             pre_vertex, "Test")
         assert not routing_info.has_routing_info_from_pre_vertex(

--- a/unittests/model_tests/routing_info_tests/test_routing_info.py
+++ b/unittests/model_tests/routing_info_tests/test_routing_info.py
@@ -109,6 +109,13 @@ class TestRoutingInfo(unittest.TestCase):
         assert list(routing_info.get_partitions_outgoing_from_vertex(
             None)) == []
 
+        assert routing_info.has_routing_info_from_pre_vertex(
+            pre_vertex, "Test")
+        assert not routing_info.has_routing_info_from_pre_vertex(
+            None, "Test")
+        assert not routing_info.has_routing_info_from_pre_vertex(
+            pre_vertex, "None")
+
         assert next(iter(routing_info)) == info
 
         info2 = MachineVertexRoutingInfo(

--- a/unittests/model_tests/routing_info_tests/test_routing_info.py
+++ b/unittests/model_tests/routing_info_tests/test_routing_info.py
@@ -127,7 +127,6 @@ class TestRoutingInfo(unittest.TestCase):
         assert routing_info.get_safe_routing_info_from_pre_vertex(
             pre_vertex, "Test2").get_keys().tolist() == [key]
 
-
     def test_base_key_and_mask(self):
         with self.assertRaises(PacmanConfigurationException):
             BaseKeyAndMask(0xF0, 0x40)

--- a/unittests/model_tests/routing_info_tests/test_routing_info.py
+++ b/unittests/model_tests/routing_info_tests/test_routing_info.py
@@ -86,45 +86,45 @@ class TestRoutingInfo(unittest.TestCase):
         with self.assertRaises(PacmanAlreadyExistsException):
             routing_info.add_routing_info(info)
 
-        assert routing_info.get_safe_routing_info_from_pre_vertex(
+        assert routing_info.get_info_from(
             pre_vertex, "Test") == info
         with self.assertRaises(KeyError):
-            routing_info.get_safe_routing_info_from_pre_vertex(
+            routing_info.get_info_from(
                 None, "Test")
         with self.assertRaises(KeyError):
-            routing_info.get_safe_routing_info_from_pre_vertex(
+            routing_info.get_info_from(
                 pre_vertex, "None")
 
-        assert routing_info.get_safe_first_key_from_pre_vertex(
+        assert routing_info.get_key_from(
             pre_vertex, "Test") == key
         with self.assertRaises(KeyError):
-            routing_info.get_safe_first_key_from_pre_vertex(
+            routing_info.get_key_from(
                 None, "Test")
         with self.assertRaises(KeyError):
-            routing_info.get_safe_first_key_from_pre_vertex(
+            routing_info.get_key_from(
                 pre_vertex, "None")
 
-        assert list(routing_info.get_partitions_outgoing_from_vertex(
+        assert list(routing_info.get_partitions_from(
             pre_vertex)) == ["Test"]
-        assert list(routing_info.get_partitions_outgoing_from_vertex(
+        assert list(routing_info.get_partitions_from(
             None)) == []
 
         # This should work as can be either partition
-        routing_info.test_pre_vertex_partition_ids(
+        routing_info.check_info_from(
             pre_vertex, {"Test", "Test2"})
 
         # Works because None has no partitions!
-        routing_info.test_pre_vertex_partition_ids(None, {"Test"})
+        routing_info.check_info_from(None, {"Test"})
 
         # This should not work
         with self.assertRaises(KeyError):
-            routing_info.test_pre_vertex_partition_ids(pre_vertex, {"Test2"})
+            routing_info.check_info_from(pre_vertex, {"Test2"})
 
-        assert routing_info.has_routing_info_from_pre_vertex(
+        assert routing_info.has_info_from(
             pre_vertex, "Test")
-        assert not routing_info.has_routing_info_from_pre_vertex(
+        assert not routing_info.has_info_from(
             None, "Test")
-        assert not routing_info.has_routing_info_from_pre_vertex(
+        assert not routing_info.has_info_from(
             pre_vertex, "None")
 
         assert next(iter(routing_info)) == info
@@ -140,17 +140,17 @@ class TestRoutingInfo(unittest.TestCase):
             BaseKeyAndMask(key, FULL_MASK), "Test2", pre_vertex, 0)
         routing_info.add_routing_info(info3)
         assert info != info3
-        assert routing_info.get_safe_routing_info_from_pre_vertex(
+        assert routing_info.get_info_from(
                 pre_vertex, "Test2") !=\
-            routing_info.get_safe_routing_info_from_pre_vertex(
+            routing_info.get_info_from(
                 pre_vertex, "Test")
-        assert routing_info.get_safe_routing_info_from_pre_vertex(
+        assert routing_info.get_info_from(
             pre_vertex, "Test2").get_keys().tolist() == [key]
         with self.assertRaises(KeyError):
-            routing_info.get_single_routing_info_from_pre_vertex(
+            routing_info.get_single_info_from(
                 pre_vertex)
         with self.assertRaises(KeyError):
-            routing_info.get_single_first_key_from_pre_vertex(pre_vertex)
+            routing_info.get_single_key_from(pre_vertex)
 
     def test_base_key_and_mask(self):
         with self.assertRaises(PacmanConfigurationException):

--- a/unittests/model_tests/routing_info_tests/test_routing_info.py
+++ b/unittests/model_tests/routing_info_tests/test_routing_info.py
@@ -146,6 +146,11 @@ class TestRoutingInfo(unittest.TestCase):
                 pre_vertex, "Test")
         assert routing_info.get_safe_routing_info_from_pre_vertex(
             pre_vertex, "Test2").get_keys().tolist() == [key]
+        with self.assertRaises(KeyError):
+            routing_info.get_single_routing_info_from_pre_vertex(
+                pre_vertex)
+        with self.assertRaises(KeyError):
+            routing_info.get_single_first_key_from_pre_vertex(pre_vertex)
 
     def test_base_key_and_mask(self):
         with self.assertRaises(PacmanConfigurationException):

--- a/unittests/model_tests/routing_info_tests/test_routing_info.py
+++ b/unittests/model_tests/routing_info_tests/test_routing_info.py
@@ -28,50 +28,52 @@ class TestRoutingInfo(unittest.TestCase):
     def setUp(self):
         unittest_setup()
 
-    def test_routing_info_deprecated(self):
-        pre_vertex = SimpleMachineVertex(ConstantSDRAM(0))
-        key = 12345
-        info = MachineVertexRoutingInfo(
-            BaseKeyAndMask(key, FULL_MASK), "Test", pre_vertex, 0)
-        routing_info = RoutingInfo()
-        routing_info.add_routing_info(info)
-
-        with self.assertRaises(PacmanAlreadyExistsException):
-            routing_info.add_routing_info(info)
-
-        assert routing_info.get_routing_info_from_pre_vertex(
-            pre_vertex, "Test") == info
-        assert routing_info.get_routing_info_from_pre_vertex(
-            None, "Test") is None
-        assert routing_info.get_routing_info_from_pre_vertex(
-            pre_vertex, "None") is None
-
-        assert routing_info.get_first_key_from_pre_vertex(
-            pre_vertex, "Test") == key
-        assert routing_info.get_first_key_from_pre_vertex(
-            None, "Test") is None
-        assert routing_info.get_first_key_from_pre_vertex(
-            pre_vertex, "None") is None
-
-        assert next(iter(routing_info)) == info
-
-        info2 = MachineVertexRoutingInfo(
-            BaseKeyAndMask(key, FULL_MASK), "Test", pre_vertex, 0)
-
-        with self.assertRaises(PacmanAlreadyExistsException):
-            routing_info.add_routing_info(info2)
-        assert info != info2
-
-        info3 = MachineVertexRoutingInfo(
-            BaseKeyAndMask(key, FULL_MASK), "Test2", pre_vertex, 0)
-        routing_info.add_routing_info(info3)
-        assert info != info3
-        assert routing_info.get_routing_info_from_pre_vertex(
-                pre_vertex, "Test2") !=\
-            routing_info.get_routing_info_from_pre_vertex(
-                pre_vertex, "Test")
-        assert routing_info.get_routing_info_from_pre_vertex(
-            pre_vertex, "Test2").get_keys().tolist() == [key]
+    # TODO: Replace (currently temporarily broken to make sure we don't
+    # call it)
+    # def test_routing_info_deprecated(self):
+    #     pre_vertex = SimpleMachineVertex(ConstantSDRAM(0))
+    #     key = 12345
+    #     info = MachineVertexRoutingInfo(
+    #         BaseKeyAndMask(key, FULL_MASK), "Test", pre_vertex, 0)
+    #     routing_info = RoutingInfo()
+    #     routing_info.add_routing_info(info)
+    #
+    #     with self.assertRaises(PacmanAlreadyExistsException):
+    #         routing_info.add_routing_info(info)
+    #
+    #     assert routing_info.get_routing_info_from_pre_vertex(
+    #         pre_vertex, "Test") == info
+    #     assert routing_info.get_routing_info_from_pre_vertex(
+    #         None, "Test") is None
+    #     assert routing_info.get_routing_info_from_pre_vertex(
+    #         pre_vertex, "None") is None
+    #
+    #     assert routing_info.get_first_key_from_pre_vertex(
+    #         pre_vertex, "Test") == key
+    #     assert routing_info.get_first_key_from_pre_vertex(
+    #         None, "Test") is None
+    #     assert routing_info.get_first_key_from_pre_vertex(
+    #         pre_vertex, "None") is None
+    #
+    #     assert next(iter(routing_info)) == info
+    #
+    #     info2 = MachineVertexRoutingInfo(
+    #         BaseKeyAndMask(key, FULL_MASK), "Test", pre_vertex, 0)
+    #
+    #     with self.assertRaises(PacmanAlreadyExistsException):
+    #         routing_info.add_routing_info(info2)
+    #     assert info != info2
+    #
+    #     info3 = MachineVertexRoutingInfo(
+    #         BaseKeyAndMask(key, FULL_MASK), "Test2", pre_vertex, 0)
+    #     routing_info.add_routing_info(info3)
+    #     assert info != info3
+    #     assert routing_info.get_routing_info_from_pre_vertex(
+    #             pre_vertex, "Test2") !=\
+    #         routing_info.get_routing_info_from_pre_vertex(
+    #             pre_vertex, "Test")
+    #     assert routing_info.get_routing_info_from_pre_vertex(
+    #         pre_vertex, "Test2").get_keys().tolist() == [key]
 
     def test_routing_info(self):
         pre_vertex = SimpleMachineVertex(ConstantSDRAM(0))

--- a/unittests/operations_tests/routing_info_algorithms_tests/test_zoned_routing_allocator.py
+++ b/unittests/operations_tests/routing_info_algorithms_tests/test_zoned_routing_allocator.py
@@ -244,7 +244,7 @@ def check_keys_for_application_partition_pairs(routing_info, app_mask):
         mapped_key = None
         for m_vertex in part.pre_vertex.splitter.get_out_going_vertices(
                 part.identifier):
-            key = routing_info.get_first_key_from_pre_vertex(
+            key = routing_info.get_safe_first_key_from_pre_vertex(
                 m_vertex, part.identifier)
             if check_fixed(m_vertex, part.identifier, key):
                 continue

--- a/unittests/operations_tests/routing_info_algorithms_tests/test_zoned_routing_allocator.py
+++ b/unittests/operations_tests/routing_info_algorithms_tests/test_zoned_routing_allocator.py
@@ -244,7 +244,7 @@ def check_keys_for_application_partition_pairs(routing_info, app_mask):
         mapped_key = None
         for m_vertex in part.pre_vertex.splitter.get_out_going_vertices(
                 part.identifier):
-            key = routing_info.get_safe_first_key_from_pre_vertex(
+            key = routing_info.get_key_from(
                 m_vertex, part.identifier)
             if check_fixed(m_vertex, part.identifier, key):
                 continue

--- a/unittests/operations_tests/routing_table_generator_tests/test_merged.py
+++ b/unittests/operations_tests/routing_table_generator_tests/test_merged.py
@@ -141,7 +141,7 @@ class TestMerged(unittest.TestCase):
         try:
             merged_routing_table_generator()
             raise PacmanRoutingException("Should not get here")
-        except PacmanRoutingException as ex:
+        except KeyError as ex:
             self.assertIn("Missing Routing information", str(ex))
 
     def test_iterator_with_next(self):

--- a/unittests/operations_tests/routing_table_generator_tests/test_merged.py
+++ b/unittests/operations_tests/routing_table_generator_tests/test_merged.py
@@ -142,7 +142,7 @@ class TestMerged(unittest.TestCase):
             merged_routing_table_generator()
             raise PacmanRoutingException("Should not get here")
         except KeyError as ex:
-            self.assertIn("Missing Routing information", str(ex))
+            self.assertIn("foo", str(ex))
 
     def test_iterator_with_next(self):
         empty = _IteratorWithNext([])


### PR DESCRIPTION
Work to make sure partitions that vertices send using, and the partitions actually connected agree!

As the method is deprecated, the other PRs are not strictly necessary, but should avoid deprecation warnings:
 - SpiNNakerManchester/SpiNNakerGraphFrontEnd#286
 - SpiNNakerManchester/SpiNNFrontEndCommon#1219
 - SpiNNakerManchester/sPyNNaker#1496
 - SpiNNakerManchester/SpiNNGym#96
 - SpiNNakerManchester/MarkovChainMonteCarlo#72
 - SpiNNakerManchester/SpiNNaker_PDP2#89
 - SpiNNakerManchester/TSPOnSpiNNaker#48

Tested by:
 - SpiNNakerManchester/IntegrationTests#294