### PR TITLE
Shared sdram

### DIFF
--- a/pacman/data/pacman_data_view.py
+++ b/pacman/data/pacman_data_view.py
@@ -562,7 +562,7 @@ class PacmanDataView(MachineDataView):
         """
         # Note the sdram can not be calculated in advance as some Vertices
         # require the hardware time step not available until simulator run
-        sdram = ConstantSDRAM(0)
+        sdram: AbstractSDRAM = ConstantSDRAM(0)
         for vertex in cls.__pacman_data._all_monitor_vertices:
             sdram += vertex.sdram_required
         return sdram
@@ -580,7 +580,7 @@ class PacmanDataView(MachineDataView):
 
         :rtype: AbstractSDRAM
         """
-        sdram = ConstantSDRAM(0)
+        sdram: AbstractSDRAM = ConstantSDRAM(0)
         for vertex in cls.__pacman_data._ethernet_monitor_vertices:
             sdram += vertex.sdram_required
         return sdram

--- a/pacman/model/resources/__init__.py
+++ b/pacman/model/resources/__init__.py
@@ -17,8 +17,9 @@ from .constant_sdram import ConstantSDRAM
 from .iptag_resource import IPtagResource
 from .multi_region_sdram import MultiRegionSDRAM
 from .reverse_iptag_resource import ReverseIPtagResource
+from .shared_sdram import SharedSDRAM
 from .variable_sdram import VariableSDRAM
 
 __all__ = ["AbstractSDRAM", "ConstantSDRAM",
            "IPtagResource", "MultiRegionSDRAM",
-           "ReverseIPtagResource", "VariableSDRAM"]
+           "ReverseIPtagResource", "SharedSDRAM", "VariableSDRAM"]

--- a/pacman/model/resources/abstract_sdram.py
+++ b/pacman/model/resources/abstract_sdram.py
@@ -80,3 +80,16 @@ class AbstractSDRAM(object, metaclass=AbstractBase):
             ``None`` is standard print
         """
         raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def _str(self) -> str:
+        """
+        A short string representation of this SDRAM.
+
+        To be used within main str methods
+        """
+        raise NotImplementedError
+
+    def __str__(self):
+        return f"SDRAM:{self._str}"

--- a/pacman/model/resources/abstract_sdram.py
+++ b/pacman/model/resources/abstract_sdram.py
@@ -43,28 +43,6 @@ class AbstractSDRAM(object, metaclass=AbstractBase):
         """
         raise NotImplementedError
 
-    @abstractmethod
-    def __sub__(self, other: AbstractSDRAM) -> AbstractSDRAM:
-        """
-        Creates a new SDRAM which is this one less the other.
-
-        :param AbstractSDRAM other: another SDRAM resource
-        :return: a New AbstractSDRAM
-        :rtype: AbstractSDRAM
-        """
-        raise NotImplementedError
-
-    @abstractmethod
-    def sub_from(self, other: AbstractSDRAM) -> AbstractSDRAM:
-        """
-        Creates a new SDRAM which is the other less this one.
-
-        :param AbstractSDRAM other: another SDRAM resource
-        :return: a New AbstractSDRAM
-        :rtype: AbstractSDRAM
-        """
-        raise NotImplementedError
-
     @property
     @abstractmethod
     def fixed(self) -> int:

--- a/pacman/model/resources/abstract_sdram.py
+++ b/pacman/model/resources/abstract_sdram.py
@@ -83,7 +83,7 @@ class AbstractSDRAM(object, metaclass=AbstractBase):
 
     @property
     @abstractmethod
-    def _str(self) -> str:
+    def short_str(self) -> str:
         """
         A short string representation of this SDRAM.
 
@@ -92,4 +92,4 @@ class AbstractSDRAM(object, metaclass=AbstractBase):
         raise NotImplementedError
 
     def __str__(self):
-        return f"SDRAM:{self._str}"
+        return f"SDRAM:{self.short_str}"

--- a/pacman/model/resources/abstract_sdram.py
+++ b/pacman/model/resources/abstract_sdram.py
@@ -84,12 +84,9 @@ class AbstractSDRAM(object, metaclass=AbstractBase):
         """
         raise NotImplementedError
 
+    @abstractmethod
     def __eq__(self, other: Any) -> bool:
-        if not isinstance(other, AbstractSDRAM):
-            return False
-        if other.fixed != self.fixed:
-            return False
-        return other.per_timestep == self.per_timestep
+        raise NotImplementedError
 
     @abstractmethod
     def report(self, timesteps: Optional[int], indent: str = "",

--- a/pacman/model/resources/constant_sdram.py
+++ b/pacman/model/resources/constant_sdram.py
@@ -54,7 +54,7 @@ class ConstantSDRAM(AbstractSDRAM):
             return False
         return other.fixed == self.fixed
 
-    def __add__(self, other):
+    def __add__(self, other: AbstractSDRAM) -> AbstractSDRAM:
         if isinstance(other, ConstantSDRAM):
             return ConstantSDRAM(
                 self._sdram + other.fixed)

--- a/pacman/model/resources/constant_sdram.py
+++ b/pacman/model/resources/constant_sdram.py
@@ -62,23 +62,6 @@ class ConstantSDRAM(AbstractSDRAM):
             # The other is more complex so delegate to it
             return other.__add__(self)
 
-    def __sub__(self, other):
-        if isinstance(other, ConstantSDRAM):
-            return ConstantSDRAM(
-                self._sdram - other.fixed)
-        else:
-            # The other is more complex so delegate to it
-            return other.sub_from(self)
-
-    @overrides(AbstractSDRAM.sub_from)
-    def sub_from(self, other: AbstractSDRAM) -> AbstractSDRAM:
-        if isinstance(other, ConstantSDRAM):
-            return ConstantSDRAM(
-                other.fixed - self._sdram)
-        else:
-            # The other is more complex so delegate to it
-            return other - self
-
     @overrides(AbstractSDRAM.report)
     def report(self, timesteps: Optional[int], indent: str = "",
                preamble: str = "", target: Optional[TextIO] = None):

--- a/pacman/model/resources/constant_sdram.py
+++ b/pacman/model/resources/constant_sdram.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, TextIO
+from typing import Any, Optional, TextIO
 from spinn_utilities.overrides import overrides
 from .abstract_sdram import AbstractSDRAM
 
@@ -48,6 +48,11 @@ class ConstantSDRAM(AbstractSDRAM):
     @overrides(AbstractSDRAM.per_timestep)
     def per_timestep(self) -> float:
         return 0
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, ConstantSDRAM):
+            return False
+        return other.fixed == self.fixed
 
     def __add__(self, other):
         if isinstance(other, ConstantSDRAM):

--- a/pacman/model/resources/constant_sdram.py
+++ b/pacman/model/resources/constant_sdram.py
@@ -66,3 +66,8 @@ class ConstantSDRAM(AbstractSDRAM):
     def report(self, timesteps: Optional[int], indent: str = "",
                preamble: str = "", target: Optional[TextIO] = None):
         print(indent, preamble, f"Constant {self._sdram} bytes", file=target)
+
+    @property
+    @overrides(AbstractSDRAM._str)
+    def _str(self):
+        return f"fixed: {self._sdram}"

--- a/pacman/model/resources/constant_sdram.py
+++ b/pacman/model/resources/constant_sdram.py
@@ -68,6 +68,6 @@ class ConstantSDRAM(AbstractSDRAM):
         print(indent, preamble, f"Constant {self._sdram} bytes", file=target)
 
     @property
-    @overrides(AbstractSDRAM._str)
-    def _str(self):
+    @overrides(AbstractSDRAM.short_str)
+    def short_str(self):
         return f"fixed: {self._sdram}"

--- a/pacman/model/resources/constant_sdram.py
+++ b/pacman/model/resources/constant_sdram.py
@@ -69,5 +69,5 @@ class ConstantSDRAM(AbstractSDRAM):
 
     @property
     @overrides(AbstractSDRAM.short_str)
-    def short_str(self):
+    def short_str(self) -> str:
         return f"fixed: {self._sdram}"

--- a/pacman/model/resources/multi_region_sdram.py
+++ b/pacman/model/resources/multi_region_sdram.py
@@ -14,7 +14,7 @@
 from __future__ import annotations
 from enum import Enum
 import math
-from typing import Dict, Optional, TextIO, Union
+from typing import Any, Dict, Optional, TextIO, Union
 
 import numpy
 from typing_extensions import TypeAlias
@@ -144,6 +144,11 @@ class MultiRegionSDRAM(AbstractSDRAM):
         :return:
         """
         return self.__total.get_total_sdram(n_timesteps)
+
+    def __eq__(self, other: Any) -> bool:
+        if isinstance(other, MultiRegionSDRAM):
+            return self.__total == other._MultiRegionSDRAM__total
+        return self.__total == other
 
     def __add__(self, other: AbstractSDRAM) -> AbstractSDRAM:
         """

--- a/pacman/model/resources/multi_region_sdram.py
+++ b/pacman/model/resources/multi_region_sdram.py
@@ -104,7 +104,7 @@ class MultiRegionSDRAM(AbstractSDRAM):
                 if isinstance(r, MultiRegionSDRAM):
                     r.merge(other)
                 else:
-                    other.add_cost(region, r.fixed, r.per_timestep)
+                    other.nest(region, r)
                     self.__regions[region] = other
             else:
                 self.__regions[region] += other

--- a/pacman/model/resources/multi_region_sdram.py
+++ b/pacman/model/resources/multi_region_sdram.py
@@ -176,3 +176,7 @@ class MultiRegionSDRAM(AbstractSDRAM):
         """
         return self.__total.per_timestep
 
+    @property
+    @overrides(AbstractSDRAM._str)
+    def _str(self):
+        return f"Multi:{self.__total._str}"

--- a/pacman/model/resources/multi_region_sdram.py
+++ b/pacman/model/resources/multi_region_sdram.py
@@ -49,7 +49,7 @@ class MultiRegionSDRAM(AbstractSDRAM):
     __slots__ = (
         # The regions of SDRAM, each of which is an AbstractSDRAM
         "__regions",
-        # The todal cost of all the regions
+        # The total cost of all the regions
         "__total")
 
     def __init__(self) -> None:
@@ -177,6 +177,6 @@ class MultiRegionSDRAM(AbstractSDRAM):
         return self.__total.per_timestep
 
     @property
-    @overrides(AbstractSDRAM._str)
-    def _str(self):
-        return f"Multi:{self.__total._str}"
+    @overrides(AbstractSDRAM.short_str)
+    def short_str(self):
+        return f"Multi:{self.__total.short_str}"

--- a/pacman/model/resources/multi_region_sdram.py
+++ b/pacman/model/resources/multi_region_sdram.py
@@ -77,17 +77,11 @@ class MultiRegionSDRAM(AbstractSDRAM):
         :param per_timestep_sdram: The variable cost for this region is any
         :type per_timestep_sdram: int or numpy.integer
         """
-        sdram: AbstractSDRAM
         if per_timestep_sdram:
-            sdram = VariableSDRAM(
-                _ceil(fixed_sdram), _ceil(per_timestep_sdram))
+            self.nest(region, VariableSDRAM(
+                _ceil(fixed_sdram), _ceil(per_timestep_sdram)))
         else:
-            sdram = ConstantSDRAM(_ceil(fixed_sdram))
-        self.__total += sdram
-        if region in self.__regions:
-            self.__regions[region] += sdram
-        else:
-            self.__regions[region] = sdram
+            self.nest(region, ConstantSDRAM(_ceil(fixed_sdram)))
 
     def nest(self, region: _RegionKey, other: AbstractSDRAM):
         """

--- a/pacman/model/resources/multi_region_sdram.py
+++ b/pacman/model/resources/multi_region_sdram.py
@@ -159,25 +159,6 @@ class MultiRegionSDRAM(AbstractSDRAM):
         """
         return self.__total + other
 
-    def __sub__(self, other: AbstractSDRAM) -> AbstractSDRAM:
-        """
-        Creates a new SDRAM which is this one less the other.
-
-        :param other: another SDRAM resource
-        :return: a New AbstractSDRAM
-        """
-        return self.__total - other
-
-    def sub_from(self, other: AbstractSDRAM) -> AbstractSDRAM:
-        """
-        Creates a new SDRAM which is the other less this one.
-
-        :param AbstractSDRAM other: another SDRAM resource
-        :return: a New AbstractSDRAM
-        :rtype: AbstractSDRAM
-        """
-        return self.__total.sub_from(other)
-
     @property
     def fixed(self) -> int:
         """

--- a/pacman/model/resources/multi_region_sdram.py
+++ b/pacman/model/resources/multi_region_sdram.py
@@ -178,5 +178,5 @@ class MultiRegionSDRAM(AbstractSDRAM):
 
     @property
     @overrides(AbstractSDRAM.short_str)
-    def short_str(self):
+    def short_str(self) -> str:
         return f"Multi:{self.__total.short_str}"

--- a/pacman/model/resources/multi_region_sdram.py
+++ b/pacman/model/resources/multi_region_sdram.py
@@ -50,11 +50,11 @@ class MultiRegionSDRAM(AbstractSDRAM):
         # The regions of SDRAM, each of which is an AbstractSDRAM
         "__regions",
         # The total cost of all the regions
-        "__total")
+        "_total")
 
     def __init__(self) -> None:
         self.__regions: Dict[_RegionKey, AbstractSDRAM] = {}
-        self.__total: AbstractSDRAM = ConstantSDRAM(0)
+        self._total: AbstractSDRAM = ConstantSDRAM(0)
 
     @property
     def regions(self):
@@ -97,7 +97,7 @@ class MultiRegionSDRAM(AbstractSDRAM):
         :param AbstractSDRAM other:
             Another SDRAM model to make combine by nesting
         """
-        self.__total += other
+        self._total += other
         if region in self.__regions:
             if isinstance(other, MultiRegionSDRAM):
                 r = self.__regions[region]
@@ -121,7 +121,7 @@ class MultiRegionSDRAM(AbstractSDRAM):
 
         :param MultiRegionSDRAM other: Another mapping of costs by region
         """
-        self.__total += other
+        self._total += other
         for region in other.regions:
             if region in self.regions:
                 self.__regions[region] += other.regions[region]
@@ -131,7 +131,7 @@ class MultiRegionSDRAM(AbstractSDRAM):
     @overrides(AbstractSDRAM.report)
     def report(self, timesteps: Optional[int], indent: str = "",
                preamble: str = "", target: Optional[TextIO] = None):
-        self.__total.report(timesteps, indent, preamble, target)
+        self._total.report(timesteps, indent, preamble, target)
         for region in self.__regions:
             self.__regions[region].report(
                 timesteps, indent+"    ", str(region)+":", target)
@@ -143,12 +143,12 @@ class MultiRegionSDRAM(AbstractSDRAM):
         :param int n_timesteps: number of timesteps to cost for
         :return:
         """
-        return self.__total.get_total_sdram(n_timesteps)
+        return self._total.get_total_sdram(n_timesteps)
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, MultiRegionSDRAM):
-            return self.__total == other._MultiRegionSDRAM__total
-        return self.__total == other
+            return self._total == other._total
+        return self._total == other
 
     def __add__(self, other: AbstractSDRAM) -> AbstractSDRAM:
         """
@@ -157,14 +157,14 @@ class MultiRegionSDRAM(AbstractSDRAM):
         :param other: another SDRAM resource
         :return: a New AbstractSDRAM
         """
-        return self.__total + other
+        return self._total + other
 
     @property
     def fixed(self) -> int:
         """
         The fixed SDRAM cost.
         """
-        return self.__total.fixed
+        return self._total.fixed
 
     @property
     def per_timestep(self) -> float:
@@ -174,9 +174,9 @@ class MultiRegionSDRAM(AbstractSDRAM):
         .. warning::
             May well be zero.
         """
-        return self.__total.per_timestep
+        return self._total.per_timestep
 
     @property
     @overrides(AbstractSDRAM.short_str)
     def short_str(self) -> str:
-        return f"Multi:{self.__total.short_str}"
+        return f"Multi:{self._total.short_str}"

--- a/pacman/model/resources/shared_sdram.py
+++ b/pacman/model/resources/shared_sdram.py
@@ -1,0 +1,132 @@
+# Copyright (c) 2017 The University of Manchester
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from copy import deepcopy
+import math
+from typing import Any, Dict, Optional, Self, TextIO, Union
+
+import numpy
+
+from spinn_utilities.overrides import overrides
+from pacman.exceptions import PacmanConfigurationException
+from .abstract_sdram import AbstractSDRAM
+from .constant_sdram import ConstantSDRAM
+from .variable_sdram import VariableSDRAM
+
+
+def _ceil(value: Union[int, float, numpy.integer, numpy.floating]) -> int:
+    return math.ceil(value)
+
+
+class SharedSDRAM(AbstractSDRAM):
+    """
+    Represents an amount of SDRAM used on a chip in the machine.
+
+    This is split into cost for each core and ones for each chip
+    """
+
+    __slots__ = (
+        # The amount of SDRAM per core
+        "_per_core",
+        # Map of extra shared SDRAM per Chip
+        "_shared"
+        )
+
+    def __init__(self, shared: Dict[str,AbstractSDRAM],
+                 per_core: Optional[AbstractSDRAM] = None) -> None:
+        """
+        Creates an SDRAM of both per_core and shared requirements.
+
+        .. note::
+            Each key must map GLOBALLY to the same SDRAM (or an equal one)
+            It is recommended that a vertex use its label at the start the key
+
+        :param shared:
+            The sdram that will be allocated ONCE per Chip
+            This is a dict of keys to sdram
+        :param per_core:
+            The amount of SDRAM that will be needed on every core.
+        """
+        # create a shallow copy
+        self._shared = shared.copy()
+        if per_core is None:
+            self._per_core = ConstantSDRAM(0)
+        else:
+            self._per_core = per_core
+
+
+    @overrides(AbstractSDRAM.get_total_sdram)
+    def get_total_sdram(self, n_timesteps: Optional[int]) -> int:
+        running = self._per_core.get_total_sdram(n_timesteps)
+        for sdram in self._shared.values():
+            running += sdram.get_total_sdram(n_timesteps)
+        return running
+
+    @property
+    @overrides(AbstractSDRAM.fixed)
+    def fixed(self) -> int:
+        running = self._per_core.fixed
+        for sdram in self._shared.values():
+            running += sdram.fixed
+        return running
+
+    @property
+    @overrides(AbstractSDRAM.per_timestep)
+    def per_timestep(self) -> float:
+        running = self._per_core.per_timestep
+        for sdram in self._shared.values():
+            running += sdram.per_timestep
+        return running
+
+    @overrides(AbstractSDRAM.__eq__)
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, SharedSDRAM):
+            return False
+        if self._per_core != other._per_core:
+            return False
+        return self._shared == other._shared
+
+    @overrides(AbstractSDRAM.__add__)
+    def __add__(self, other: AbstractSDRAM) -> Self:
+        if isinstance(other, (ConstantSDRAM, VariableSDRAM)):
+            return SharedSDRAM(self._shared, self._per_core + other)
+        elif isinstance(other, SharedSDRAM):
+            shared = self._shared.copy()
+            for key, value in other._shared.items():
+                if key in shared:
+                    if value != shared[key]:
+                        raise PacmanConfigurationException(
+                            f"Shared {key} has different values")
+                else:
+                    shared[key] = value
+            return SharedSDRAM(shared, self._per_core)
+        else:
+            # MultiRegionSDRAM
+            return other + self
+
+    @overrides(AbstractSDRAM.__sub__)
+    def __sub__(self, other: AbstractSDRAM) -> 'VariableSDRAM':
+        raise NotImplementedError
+
+    @overrides(AbstractSDRAM.sub_from)
+    def sub_from(self, other: AbstractSDRAM) -> 'VariableSDRAM':
+        raise NotImplementedError
+
+    @overrides(AbstractSDRAM.report)
+    def report(self, timesteps: Optional[int], indent: str = "",
+               preamble: str = "", target: Optional[TextIO] = None):
+        print(indent, preamble,
+              f"Fixed {self._fixed_sdram} bytes "
+              f"Per_timestep {self._per_timestep_sdram} bytes "
+              f"for a total of {self.get_total_sdram(timesteps)}", file=target)

--- a/pacman/model/resources/shared_sdram.py
+++ b/pacman/model/resources/shared_sdram.py
@@ -121,16 +121,16 @@ class SharedSDRAM(AbstractSDRAM):
             sdram.report(timesteps, indent+"    ", key+":", target)
 
     @property
-    @overrides(AbstractSDRAM._str)
-    def _str(self):
+    @overrides(AbstractSDRAM.short_str)
+    def short_str(self):
         if self._per_core.fixed > 0 or self._per_core.per_timestep > 0:
-            per_core = f"per-core: {self._per_core._str} "
+            per_core = f"per-core: {self._per_core.short_str} "
         else:
             per_core = ""
         shared: Optional[str] = None
         for key, sdram in self._shared.items():
             if shared is None:
-                shared = f"shared:{key}: {sdram._str}"
+                shared = f"shared:{key}: {sdram.short_str}"
             else:
-                shared = f" {key}: {sdram._str}"
+                shared = f" {key}: {sdram.short_str}"
         return per_core + shared

--- a/pacman/model/resources/shared_sdram.py
+++ b/pacman/model/resources/shared_sdram.py
@@ -115,14 +115,6 @@ class SharedSDRAM(AbstractSDRAM):
             # MultiRegionSDRAM
             return other + self
 
-    @overrides(AbstractSDRAM.__sub__)
-    def __sub__(self, other: AbstractSDRAM) -> 'VariableSDRAM':
-        raise NotImplementedError
-
-    @overrides(AbstractSDRAM.sub_from)
-    def sub_from(self, other: AbstractSDRAM) -> 'VariableSDRAM':
-        raise NotImplementedError
-
     @overrides(AbstractSDRAM.report)
     def report(self, timesteps: Optional[int], indent: str = "",
                preamble: str = "", target: Optional[TextIO] = None):

--- a/pacman/model/resources/shared_sdram.py
+++ b/pacman/model/resources/shared_sdram.py
@@ -121,3 +121,18 @@ class SharedSDRAM(AbstractSDRAM):
         self._per_core.report(timesteps, indent, preamble, target)
         for key, sdram in self._shared.items():
             sdram.report(timesteps, indent+"    ", key+":", target)
+
+    @property
+    @overrides(AbstractSDRAM._str)
+    def _str(self):
+        if self._per_core.fixed > 0 or self._per_core.per_timestep > 0:
+            per_core = f"per-core: {self._per_core._str} "
+        else:
+            per_core = ""
+        shared: Optional[str] = None
+        for key, sdram in self._shared.items():
+            if shared is None:
+                shared = f"shared:{key}: {sdram._str}"
+            else:
+                shared = f" {key}: {sdram._str}"
+        return per_core + shared

--- a/pacman/model/resources/shared_sdram.py
+++ b/pacman/model/resources/shared_sdram.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from copy import deepcopy
 import math
 from typing import Any, Dict, Optional, Self, TextIO, Union
 
@@ -43,7 +42,7 @@ class SharedSDRAM(AbstractSDRAM):
         "_shared"
         )
 
-    def __init__(self, shared: Dict[str,AbstractSDRAM],
+    def __init__(self, shared: Dict[str, AbstractSDRAM],
                  per_core: Optional[AbstractSDRAM] = None) -> None:
         """
         Creates an SDRAM of both per_core and shared requirements.
@@ -64,7 +63,6 @@ class SharedSDRAM(AbstractSDRAM):
             self._per_core = ConstantSDRAM(0)
         else:
             self._per_core = per_core
-
 
     @overrides(AbstractSDRAM.get_total_sdram)
     def get_total_sdram(self, n_timesteps: Optional[int]) -> int:

--- a/pacman/model/resources/shared_sdram.py
+++ b/pacman/model/resources/shared_sdram.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import math
-from typing import Any, Dict, Optional, Self, TextIO, Union
+from typing import Any, Dict, Optional, TextIO, Union
 
 import numpy
 
@@ -96,7 +96,7 @@ class SharedSDRAM(AbstractSDRAM):
         return self._shared == other._shared
 
     @overrides(AbstractSDRAM.__add__)
-    def __add__(self, other: AbstractSDRAM) -> Self:
+    def __add__(self, other: AbstractSDRAM) -> AbstractSDRAM:
         if isinstance(other, (ConstantSDRAM, VariableSDRAM)):
             return SharedSDRAM(self._shared, self._per_core + other)
         elif isinstance(other, SharedSDRAM):

--- a/pacman/model/resources/shared_sdram.py
+++ b/pacman/model/resources/shared_sdram.py
@@ -60,7 +60,7 @@ class SharedSDRAM(AbstractSDRAM):
         # create a shallow copy
         self._shared = shared.copy()
         if per_core is None:
-            self._per_core = ConstantSDRAM(0)
+            self._per_core: AbstractSDRAM = ConstantSDRAM(0)
         else:
             self._per_core = per_core
 
@@ -122,14 +122,14 @@ class SharedSDRAM(AbstractSDRAM):
 
     @property
     @overrides(AbstractSDRAM.short_str)
-    def short_str(self):
+    def short_str(self) -> str:
         if self._per_core.fixed > 0 or self._per_core.per_timestep > 0:
             per_core = f"per-core: {self._per_core.short_str} "
         else:
             per_core = ""
-        shared: Optional[str] = None
+        shared = ""
         for key, sdram in self._shared.items():
-            if shared is None:
+            if shared == "":
                 shared = f"shared:{key}: {sdram.short_str}"
             else:
                 shared = f" {key}: {sdram.short_str}"

--- a/pacman/model/resources/shared_sdram.py
+++ b/pacman/model/resources/shared_sdram.py
@@ -118,7 +118,6 @@ class SharedSDRAM(AbstractSDRAM):
     @overrides(AbstractSDRAM.report)
     def report(self, timesteps: Optional[int], indent: str = "",
                preamble: str = "", target: Optional[TextIO] = None):
-        print(indent, preamble,
-              f"Fixed {self._fixed_sdram} bytes "
-              f"Per_timestep {self._per_timestep_sdram} bytes "
-              f"for a total of {self.get_total_sdram(timesteps)}", file=target)
+        self._per_core.report(timesteps, indent, preamble, target)
+        for key, sdram in self._shared.items():
+            sdram.report(timesteps, indent+"    ", key+":", target)

--- a/pacman/model/resources/variable_sdram.py
+++ b/pacman/model/resources/variable_sdram.py
@@ -108,7 +108,7 @@ class VariableSDRAM(AbstractSDRAM):
               f"for a total of {self.get_total_sdram(timesteps)}", file=target)
 
     @property
-    @overrides(AbstractSDRAM._str)
-    def _str(self):
+    @overrides(AbstractSDRAM.short_str)
+    def short_str(self):
         return (f"fixed:{self._fixed_sdram} "
                 f"per_timestep:{self._per_timestep_sdram}")

--- a/pacman/model/resources/variable_sdram.py
+++ b/pacman/model/resources/variable_sdram.py
@@ -22,6 +22,7 @@ from pacman.exceptions import PacmanConfigurationException
 from .abstract_sdram import AbstractSDRAM
 from .constant_sdram import ConstantSDRAM
 
+
 def _ceil(value: Union[int, float, numpy.integer, numpy.floating]) -> int:
     return math.ceil(value)
 

--- a/pacman/model/resources/variable_sdram.py
+++ b/pacman/model/resources/variable_sdram.py
@@ -98,17 +98,6 @@ class VariableSDRAM(AbstractSDRAM):
             #  SharedSDRAM, MultiRegionSDRAM
             return other + self
 
-    def __sub__(self, other: AbstractSDRAM) -> 'VariableSDRAM':
-        return VariableSDRAM(
-            self._fixed_sdram - other.fixed,
-            self._per_timestep_sdram - other.per_timestep)
-
-    @overrides(AbstractSDRAM.sub_from)
-    def sub_from(self, other: AbstractSDRAM) -> 'VariableSDRAM':
-        return VariableSDRAM(
-            other.fixed - self._fixed_sdram,
-            other.per_timestep - self._per_timestep_sdram)
-
     @overrides(AbstractSDRAM.report)
     def report(self, timesteps: Optional[int], indent: str = "",
                preamble: str = "", target: Optional[TextIO] = None):

--- a/pacman/model/resources/variable_sdram.py
+++ b/pacman/model/resources/variable_sdram.py
@@ -109,6 +109,6 @@ class VariableSDRAM(AbstractSDRAM):
 
     @property
     @overrides(AbstractSDRAM.short_str)
-    def short_str(self):
+    def short_str(self) -> str:
         return (f"fixed:{self._fixed_sdram} "
                 f"per_timestep:{self._per_timestep_sdram}")

--- a/pacman/model/resources/variable_sdram.py
+++ b/pacman/model/resources/variable_sdram.py
@@ -87,7 +87,7 @@ class VariableSDRAM(AbstractSDRAM):
         else:
             return False
 
-    def __add__(self, other: AbstractSDRAM) -> 'VariableSDRAM':
+    def __add__(self, other: AbstractSDRAM) -> AbstractSDRAM:
         if isinstance(other, ConstantSDRAM):
             return VariableSDRAM(
                 self._fixed_sdram + other.fixed,  self._per_timestep_sdram)

--- a/pacman/model/resources/variable_sdram.py
+++ b/pacman/model/resources/variable_sdram.py
@@ -87,9 +87,16 @@ class VariableSDRAM(AbstractSDRAM):
             return False
 
     def __add__(self, other: AbstractSDRAM) -> 'VariableSDRAM':
-        return VariableSDRAM(
-            self._fixed_sdram + other.fixed,
-            self._per_timestep_sdram + other.per_timestep)
+        if isinstance(other, ConstantSDRAM):
+            return VariableSDRAM(
+                self._fixed_sdram + other.fixed,  self._per_timestep_sdram)
+        elif isinstance(other, VariableSDRAM):
+            return VariableSDRAM(
+                self._fixed_sdram + other.fixed,
+                self._per_timestep_sdram + other.per_timestep)
+        else:
+            #  SharedSDRAM, MultiRegionSDRAM
+            return other + self
 
     def __sub__(self, other: AbstractSDRAM) -> 'VariableSDRAM':
         return VariableSDRAM(

--- a/pacman/model/resources/variable_sdram.py
+++ b/pacman/model/resources/variable_sdram.py
@@ -105,3 +105,9 @@ class VariableSDRAM(AbstractSDRAM):
               f"Fixed {self._fixed_sdram} bytes "
               f"Per_timestep {self._per_timestep_sdram} bytes "
               f"for a total of {self.get_total_sdram(timesteps)}", file=target)
+
+    @property
+    @overrides(AbstractSDRAM._str)
+    def _str(self):
+        return (f"fixed:{self._fixed_sdram} "
+                f"per_timestep:{self._per_timestep_sdram}")

--- a/pacman/model/resources/variable_sdram.py
+++ b/pacman/model/resources/variable_sdram.py
@@ -13,14 +13,14 @@
 # limitations under the License.
 
 import math
-from typing import Optional, TextIO, Union
+from typing import Any, Optional, TextIO, Union
 
 import numpy
 
 from spinn_utilities.overrides import overrides
 from pacman.exceptions import PacmanConfigurationException
 from .abstract_sdram import AbstractSDRAM
-
+from .constant_sdram import ConstantSDRAM
 
 def _ceil(value: Union[int, float, numpy.integer, numpy.floating]) -> int:
     return math.ceil(value)
@@ -71,6 +71,20 @@ class VariableSDRAM(AbstractSDRAM):
     @overrides(AbstractSDRAM.per_timestep)
     def per_timestep(self) -> float:
         return self._per_timestep_sdram
+
+    def __eq__(self, other: Any) -> bool:
+        if isinstance(other, VariableSDRAM):
+            if other.fixed != self.fixed:
+                return False
+            else:
+                return other.per_timestep == self.per_timestep
+        elif isinstance(other, ConstantSDRAM):
+            if self._per_timestep_sdram != 0:
+                return False
+            else:
+                return other.fixed == self.fixed
+        else:
+            return False
 
     def __add__(self, other: AbstractSDRAM) -> 'VariableSDRAM':
         return VariableSDRAM(

--- a/pacman/utilities/json_utils.py
+++ b/pacman/utilities/json_utils.py
@@ -185,47 +185,6 @@ def reverse_iptags_from_json(
     return iptags
 
 
-def vertex_to_json(vertex: MachineVertex) -> JsonObject:
-    """
-    Converts a Machine Vertex to json.
-
-    :param MachineVertex vertex:
-    :rtype: dict(str, object)
-    """
-    json_dict: JsonObject = dict()
-    try:
-        json_dict["class"] = vertex.__class__.__name__
-        json_dict["label"] = vertex.label
-        json_dict["fixed_sdram"] = int(vertex.sdram_required.fixed)
-        json_dict["per_timestep_sdram"] = int(
-            vertex.sdram_required.per_timestep)
-        json_dict["iptags"] = iptag_resources_to_json(vertex.iptags)
-        json_dict["reverse_iptags"] = reverse_iptags_to_json(
-            vertex.reverse_iptags)
-    except Exception as ex:  # pylint: disable=broad-except
-        json_dict["exception"] = str(ex)
-    return json_dict
-
-
-def vertex_from_json(json_dict: JsonObject) -> SimpleMachineVertex:
-    """
-    Creates a simple Vertex based on the json
-
-    :param dict(str, object) json_dict:
-    :rtype:  SimpleMachineVertex
-    """
-    sdram = VariableSDRAM(
-        cast(int, json_dict["fixed_sdram"]),
-        cast(float, json_dict["per_timestep_sdram"]))
-    iptags = iptag_resources_from_json(
-        cast(List[JsonObject], json_dict["iptags"]))
-    reverse_iptags = reverse_iptags_from_json(
-        cast(List[JsonObject], json_dict["reverse_iptags"]))
-    return SimpleMachineVertex(
-        sdram=sdram, label=json_dict["label"], iptags=iptags,
-        reverse_iptags=reverse_iptags)
-
-
 def placement_to_json(placement: Placement) -> JsonObject:
     """
     Converts a Placement to json

--- a/pacman/utilities/json_utils.py
+++ b/pacman/utilities/json_utils.py
@@ -22,10 +22,10 @@ from typing import cast, Iterable, List, Union
 from spinn_utilities.typing.json import JsonArray, JsonObject
 
 from pacman.data import PacmanDataView
-from pacman.model.graphs.machine import MachineVertex, SimpleMachineVertex
+from pacman.model.graphs.machine import SimpleMachineVertex
 from pacman.model.placements.placement import Placement
 from pacman.model.resources import (
-    IPtagResource, ReverseIPtagResource, VariableSDRAM)
+    IPtagResource, ReverseIPtagResource)
 from pacman.model.routing_info import BaseKeyAndMask
 
 

--- a/unittests/model_tests/resources_tests/test_resources_model.py
+++ b/unittests/model_tests/resources_tests/test_resources_model.py
@@ -48,28 +48,18 @@ class TestResourceModels(unittest.TestCase):
         const2 = ConstantSDRAM(256)
         combo = const1 + const2
         self.assertEqual(combo.get_total_sdram(None), 128+256)
-        combo = const1 - const2
-        self.assertEqual(combo.get_total_sdram(None), 128-256)
         combo = const2 + const1
         self.assertEqual(combo.get_total_sdram(None), 256+128)
-        combo = const2 - const1
-        self.assertEqual(combo.get_total_sdram(None), 256-128)
 
         var1 = VariableSDRAM(124, 8)
         self.assertEqual(var1.get_total_sdram(100), 124 + 8 * 100)
         combo = var1 + const1
         self.assertEqual(combo.get_total_sdram(100), 124 + 8 * 100 + 128)
-        combo = var1 - const1
-        self.assertEqual(combo.get_total_sdram(100), 124 + 8 * 100 - 128)
         combo = const1 + var1
         self.assertEqual(combo.get_total_sdram(100), 128 + 124 + 8 * 100)
-        combo = const1 - var1
-        self.assertEqual(combo.get_total_sdram(100), 128 - (124 + 8 * 100))
         var2 = VariableSDRAM(234, 6)
         combo = var2 + var1
         self.assertEqual(combo.get_total_sdram(150), 234 + 124 + (6 + 8) * 150)
-        combo = var2 - var1
-        self.assertEqual(combo.get_total_sdram(150), 234 - 124 + (6 - 8) * 150)
 
         multi1 = MultiRegionSDRAM()
         multi1.add_cost(1, 100, 4)
@@ -153,16 +143,6 @@ class TestResourceModels(unittest.TestCase):
         self.assertNotEqual(riptr, str(riptr))
         self.assertEqual(riptr, riptr2)
         self.assertEqual(hash(riptr), hash(riptr2))
-
-    def test_sub(self):
-        const1 = ConstantSDRAM(128)
-        const2 = ConstantSDRAM(28)
-        self.assertEqual(ConstantSDRAM(100), const1 - const2)
-        self.assertEqual(ConstantSDRAM(100), const2.sub_from(const1))
-        var1 = VariableSDRAM(100, 5)
-        self.assertEqual(VariableSDRAM(28, -5), const1 - var1)
-        self.assertEqual(VariableSDRAM(-28, 5), var1 - const1)
-        self.assertEqual(VariableSDRAM(-28, 5), const1.sub_from(var1))
 
     def test_total(self):
         var0 = VariableSDRAM(28, 0)

--- a/unittests/model_tests/resources_tests/test_resources_model.py
+++ b/unittests/model_tests/resources_tests/test_resources_model.py
@@ -220,6 +220,12 @@ class TestResourceModels(unittest.TestCase):
         with self.assertRaises(PacmanConfigurationException):
             sh1 + sh3
 
+        sh4 = SharedSDRAM({"bar": var3})
+        multi4 = MultiRegionSDRAM()
+        multi4.nest(1, sh1)
+        multi4.nest(2, sh4)
+        self.assertEqual(multi4.get_total_sdram(10), 20 + 10 + 30 + 2 * 10)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/unittests/model_tests/resources_tests/test_resources_model.py
+++ b/unittests/model_tests/resources_tests/test_resources_model.py
@@ -22,7 +22,7 @@ from pacman.config_setup import unittest_setup
 from pacman.exceptions import PacmanConfigurationException
 from pacman.model.resources import (
     ConstantSDRAM, IPtagResource, MultiRegionSDRAM, ReverseIPtagResource,
-    VariableSDRAM)
+    SharedSDRAM, VariableSDRAM)
 
 
 class MockEnum(Enum):
@@ -170,6 +170,22 @@ class TestResourceModels(unittest.TestCase):
         var4 = VariableSDRAM(28, 4)
         with self.assertRaises(PacmanConfigurationException):
             var4.get_total_sdram(None)
+
+    def test_shared(self):
+        var1 = VariableSDRAM(20, 1)
+        sh1 = SharedSDRAM({"foo": var1})
+        self.assertEqual(sh1.get_total_sdram(5), 25)
+        combo1 = sh1 + sh1
+        self.assertEqual(combo1.get_total_sdram(5), 25)
+        self.assertEqual(combo1, sh1)
+        combo2 = var1 + var1
+        self.assertEqual(combo2.get_total_sdram(5), 50)
+        con1 = ConstantSDRAM(12)
+        combo3 = sh1 + con1
+        self.assertEqual(combo3.get_total_sdram(5), 37)
+        combo4 = con1 + sh1
+        self.assertEqual(combo4.get_total_sdram(5), 37)
+        self.assertEqual(combo3, combo4)
 
 
 if __name__ == '__main__':

--- a/unittests/utilities_tests/test_json_utils.py
+++ b/unittests/utilities_tests/test_json_utils.py
@@ -18,7 +18,7 @@ from pacman.model.placements import Placement
 from pacman.model.resources import (
     ConstantSDRAM, IPtagResource, ReverseIPtagResource)
 from pacman.utilities.json_utils import (
-    placement_from_json, placement_to_json, vertex_to_json, vertex_from_json)
+    placement_from_json, placement_to_json)
 from pacman.model.graphs.machine import SimpleMachineVertex
 
 
@@ -59,13 +59,6 @@ class TestJsonUtils(unittest.TestCase):
     # Composite JSON round-trip testing schemes
     # ------------------------------------------------------------------
 
-    def vertex_there_and_back(self, there):
-        j_object = vertex_to_json(there)
-        j_str = json.dumps(j_object)
-        j_object2 = json.loads(j_str)
-        back = vertex_from_json(j_object2)
-        self._compare_vertex(there, back)
-
     def placement_there_and_back(self, there):
         j_object = placement_to_json(there)
         j_str = json.dumps(j_object)
@@ -76,14 +69,6 @@ class TestJsonUtils(unittest.TestCase):
     # ------------------------------------------------------------------
     # Test cases
     # ------------------------------------------------------------------
-
-    def test_vertex(self):
-        s1 = SimpleMachineVertex(
-            sdram=ConstantSDRAM(0),
-            iptags=[IPtagResource("127.0.0.1", port=None, strip_sdp=True)],
-            reverse_iptags=[ReverseIPtagResource(port=25, sdp_port=2, tag=5)],
-            label="Vertex")
-        self.vertex_there_and_back(s1)
 
     def test_placement(self):
         s1 = SimpleMachineVertex(


### PR DESCRIPTION
Designed to be used with https://github.com/SpiNNakerManchester/PACMAN/pull/581

Removals
1. Subtraction between sdram object
 -Unused and make even less sense with SharedSdram
2. vertet json mehtods
- Unused. Can be replaced when the use case defines what is needed.

Changes.
1. eq defintion moved to each sdram
2. MultiRegionSDRAM now holds total as another sdram object
 - Many methods delegated to that sdram object
4. MultiRegionSDRAM add_cost now uses nest method (as did the same thing)
5. add methods changed to handle the extra type

SharedSdram
-Takes a dict of keys to sdram Objects
- Optionally also a per_core sdram (mainly when summing)
