### PR TITLE
use AbstractVertex rather than Union

### DIFF
--- a/pacman/model/partitioner_splitters/abstract_splitter_common.py
+++ b/pacman/model/partitioner_splitters/abstract_splitter_common.py
@@ -15,6 +15,7 @@ from typing import (
     Iterable, Generic, Optional, Sequence, Tuple, TypeVar, Union)
 from spinn_utilities.abstract_base import AbstractBase, abstractmethod
 from pacman.exceptions import PacmanConfigurationException
+from pacman.model.graphs import AbstractVertex
 from pacman.model.graphs.application import ApplicationVertex
 from pacman.utilities.utility_objs import ChipCounter
 from pacman.model.graphs.common import Slice
@@ -150,8 +151,7 @@ class AbstractSplitterCommon(Generic[V], metaclass=AbstractBase):
     def get_source_specific_in_coming_vertices(
             self, source_vertex: ApplicationVertex,
             partition_id: str) -> Sequence[Tuple[
-                MachineVertex, Sequence[
-                    Union[MachineVertex, ApplicationVertex]]]]:
+                MachineVertex, Sequence[AbstractVertex]]]:
         """
         Get machine post-vertices for a given source.
 
@@ -171,9 +171,6 @@ class AbstractSplitterCommon(Generic[V], metaclass=AbstractBase):
         :param str partition_id: The identifier of the incoming partition
         :return: A list of tuples of (target machine vertex, list of source
             machine or application vertices that should hit the target)
-        :rtype: list(tuple(~pacman.model.graphs.machine.MachineVertex,
-            list(~pacman.model.graphs.machine.MachineVertex or
-            ~pacman.model.graphs.application.ApplicationVertex)))
         """
         return [(m_vertex, [source_vertex])
                 for m_vertex in self.get_in_coming_vertices(partition_id)]

--- a/pacman/model/partitioner_splitters/abstract_splitter_common.py
+++ b/pacman/model/partitioner_splitters/abstract_splitter_common.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from typing import (
-    Iterable, Generic, Optional, Sequence, Tuple, TypeVar, Union)
+    Iterable, Generic, Optional, Sequence, Tuple, TypeVar)
 from spinn_utilities.abstract_base import AbstractBase, abstractmethod
 from pacman.exceptions import PacmanConfigurationException
 from pacman.model.graphs import AbstractVertex

--- a/pacman/model/routing_info/vertex_routing_info.py
+++ b/pacman/model/routing_info/vertex_routing_info.py
@@ -17,6 +17,7 @@ import numpy
 from spinn_utilities.abstract_base import abstractmethod, AbstractBase
 
 from pacman.exceptions import PacmanConfigurationException
+from pacman.model.graphs import AbstractVertex
 from pacman.model.graphs.application import ApplicationVertex
 from pacman.model.graphs.machine import MachineVertex
 
@@ -106,7 +107,7 @@ class VertexRoutingInfo(object, metaclass=AbstractBase):
 
     @property
     @abstractmethod
-    def vertex(self) -> Union[ApplicationVertex, MachineVertex]:
+    def vertex(self) -> AbstractVertex:
         """
         The vertex of the information.
 

--- a/pacman/model/routing_info/vertex_routing_info.py
+++ b/pacman/model/routing_info/vertex_routing_info.py
@@ -11,15 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Optional, Union
+from typing import Optional
 import numpy
 
 from spinn_utilities.abstract_base import abstractmethod, AbstractBase
 
 from pacman.exceptions import PacmanConfigurationException
 from pacman.model.graphs import AbstractVertex
-from pacman.model.graphs.application import ApplicationVertex
-from pacman.model.graphs.machine import MachineVertex
 
 from .base_key_and_mask import BaseKeyAndMask
 

--- a/pacman/operations/router_algorithms/application_router.py
+++ b/pacman/operations/router_algorithms/application_router.py
@@ -14,7 +14,7 @@
 
 from collections import deque, defaultdict
 from typing import (
-    Deque, Dict, Iterable, Iterator, List, Optional, Set, Tuple, Union)
+    Deque, Dict, Iterable, Iterator, List, Optional, Set, Tuple)
 from typing_extensions import TypeAlias
 from spinn_utilities.progress_bar import ProgressBar
 from spinn_utilities.typing.coords import XY
@@ -150,8 +150,8 @@ class _Targets(object):
         for vtx in vertex.splitter.get_out_going_vertices(partition_id):
             self.__add_source(vtx, core, link)
 
-    def __add_source(
-            self, source: AbstractVertex, core: _OptInt, link: _OptInt) -> None:
+    def __add_source(self, source: AbstractVertex, core: _OptInt,
+                     link: _OptInt) -> None:
         """
         :param source:
         :param core:


### PR DESCRIPTION
Replacing the uses of type
Union[MachineVertex, ApplicationVertex]
with AbstractVertex

mypy correctly does not handle a mix of the two 

includes:
https://github.com/SpiNNakerManchester/sPyNNaker/pull/1524
https://github.com/SpiNNakerManchester/BitBrainDemo/pull/68
https://github.com/SpiNNakerManchester/TSPonSpiNNaker/pull/53
