### PR TITLE
pylint disable cleanup

### DIFF
--- a/pacman/model/graphs/application/application_fpga_vertex.py
+++ b/pacman/model/graphs/application/application_fpga_vertex.py
@@ -90,7 +90,8 @@ class ApplicationFPGAVertex(ApplicationVirtualVertex):
             n_machine_vertices_per_link > 1
         :rtype: ~pacman.model.graphs.common.Slice
         """
-        # pylint: disable=unused-argument
+        # link used in subclasses but not here
+        _ = link
         atoms_per_slice = self.n_atoms // self._n_machine_vertices_per_link
         low_atom = atoms_per_slice * index
         hi_atom = (atoms_per_slice * (index + 1)) - 1

--- a/pacman/model/graphs/application/application_graph.py
+++ b/pacman/model/graphs/application/application_graph.py
@@ -159,8 +159,6 @@ class ApplicationGraph(object):
 
     @property
     def edges(self) -> Sequence[ApplicationEdge]:
-        # pylint: disable=not-an-iterable
-        # https://github.com/PyCQA/pylint/issues/3105
         """
         The edges in the graph.
 

--- a/pacman/model/graphs/application/application_vertex.py
+++ b/pacman/model/graphs/application/application_vertex.py
@@ -322,7 +322,7 @@ class ApplicationVertex(AbstractVertex, Generic[MV], metaclass=AbstractBase):
             The identifier of the partition to get the key for
         :rtype: ~pacman.model.routing_info.BaseKeyAndMask or None
         """
-        # pylint: disable=unused-argument
+        _ = (machine_vertex, partition_id)
         return None
 
     def get_fixed_key_and_mask(
@@ -336,7 +336,7 @@ class ApplicationVertex(AbstractVertex, Generic[MV], metaclass=AbstractBase):
             The identifier of the partition to get the key for
         :rtype: ~pacman.model.routing_info.BaseKeyAndMask or None
         """
-        # pylint: disable=unused-argument
+        _ = (partition_id)
         return None
 
     def add_incoming_edge(self, edge: ApplicationEdge,

--- a/pacman/model/graphs/machine/machine_vertex.py
+++ b/pacman/model/graphs/machine/machine_vertex.py
@@ -95,7 +95,7 @@ class MachineVertex(AbstractVertex, metaclass=AbstractBase):
         :return: The number of keys required
         :rtype: int
         """
-        # pylint: disable=unused-argument
+        _ = partition_id
         return 1 << get_n_bits(self.__vertex_slice.n_atoms)
 
     @property

--- a/pacman/model/resources/iptag_resource.py
+++ b/pacman/model/resources/iptag_resource.py
@@ -52,7 +52,6 @@ class IPtagResource(object):
             traffic with the same traffic_identifier can be sent using
             the same tag
         """
-        # pylint: disable=too-many-arguments
         self._ip_address = ip_address
         self._port = port
         self._strip_sdp = strip_sdp

--- a/pacman/operations/placer_algorithms/_spinner_api.py
+++ b/pacman/operations/placer_algorithms/_spinner_api.py
@@ -14,7 +14,7 @@
 
 from dataclasses import dataclass
 import platform
-# pylint: disable=no-name-in-module
+
 from typing import (
     Any, Callable, ContextManager, Dict, List, NewType, Union, Tuple)
 from spinn_utilities.typing.coords import XY

--- a/pacman/operations/placer_algorithms/application_placer.py
+++ b/pacman/operations/placer_algorithms/application_placer.py
@@ -428,6 +428,7 @@ class ApplicationPlacer(object):
                     self.__placements.add_placement(
                         Placement(vertex, x, y, next(next_cores)))
                 except StopIteration:
+                    # pylint: disable=raise-missing-from
                     raise PacmanConfigurationException(
                         f"No more cores available on {x}, {y}: {on_chip}")
 

--- a/pacman/operations/placer_algorithms/application_placer.py
+++ b/pacman/operations/placer_algorithms/application_placer.py
@@ -428,7 +428,6 @@ class ApplicationPlacer(object):
                     self.__placements.add_placement(
                         Placement(vertex, x, y, next(next_cores)))
                 except StopIteration:
-                    # pylint: disable=raise-missing-from
                     raise PacmanConfigurationException(
                         f"No more cores available on {x}, {y}: {on_chip}")
 

--- a/pacman/operations/placer_algorithms/application_placer.py
+++ b/pacman/operations/placer_algorithms/application_placer.py
@@ -29,6 +29,7 @@ from pacman.model.graphs.application import ApplicationVertex
 from pacman.model.resources import AbstractSDRAM, ConstantSDRAM
 from pacman.exceptions import (
     PacmanPlaceException, PacmanConfigurationException, PacmanTooBigToPlace)
+from .draw_placements import draw_placements as dp
 
 logger = FormatAdapter(logging.getLogger(__name__))
 
@@ -169,8 +170,6 @@ class ApplicationPlacer(object):
             raise self._place_error(system_placements, e) from e
 
         if get_config_bool("Reports", "draw_placements"):
-            # pylint: disable=import-outside-toplevel
-            from .draw_placements import draw_placements as dp
             report_file = get_report_path("path_placements")
             dp(self.__placements, system_placements, report_file)
 
@@ -358,8 +357,6 @@ class ApplicationPlacer(object):
                             " free cores)\n")
 
         if get_config_bool("Reports", "draw_placements_on_error"):
-            # pylint: disable=import-outside-toplevel
-            from .draw_placements import draw_placements as dp
             report_file = get_report_path("path_placements_on_error")
             dp(self.__placements, system_placements, report_file)
 

--- a/pacman/operations/router_compressors/ordered_covering_router_compressor/ordered_covering.py
+++ b/pacman/operations/router_compressors/ordered_covering_router_compressor/ordered_covering.py
@@ -41,7 +41,6 @@ _Aliases: TypeAlias = Dict[_KeyMask, FrozenSet[_KeyMask]]
 _ROAliases: TypeAlias = Mapping[_KeyMask, FrozenSet[_KeyMask]]
 #: Sequence of all bit positions in a 32-bit word
 _all_bits = tuple(1 << i for i in range(32))
-# pylint: disable=wrong-spelling-in-comment
 
 
 def ordered_covering_compressor() -> MulticastRoutingTables:

--- a/pacman/operations/router_compressors/ordered_covering_router_compressor/ordered_covering.py
+++ b/pacman/operations/router_compressors/ordered_covering_router_compressor/ordered_covering.py
@@ -41,6 +41,7 @@ _Aliases: TypeAlias = Dict[_KeyMask, FrozenSet[_KeyMask]]
 _ROAliases: TypeAlias = Mapping[_KeyMask, FrozenSet[_KeyMask]]
 #: Sequence of all bit positions in a 32-bit word
 _all_bits = tuple(1 << i for i in range(32))
+# pylint: disable=wrong-spelling-in-comment
 
 
 def ordered_covering_compressor() -> MulticastRoutingTables:

--- a/pacman/operations/router_compressors/ranged_compressor.py
+++ b/pacman/operations/router_compressors/ranged_compressor.py
@@ -65,7 +65,6 @@ class RangeCompressor(object):
     A compressor based on ranges.
     Use via :py:func:`range_compressor`.
     """
-    # pylint: disable=attribute-defined-outside-init
     __slots__ = (
         # Router table to add merged routes into
         "_compressed",

--- a/pacman/operations/router_compressors/ranged_compressor.py
+++ b/pacman/operations/router_compressors/ranged_compressor.py
@@ -71,7 +71,7 @@ class RangeCompressor(object):
         # List of entries to be merged
         "_entries")
 
-    def __init__(self):
+    def __init__(self) -> None:
         # temp values to avoid Optional
         self._entries: List[MulticastRoutingEntry] = []
         self._compressed = CompressedMulticastRoutingTable(0, 0)

--- a/pacman/operations/router_compressors/ranged_compressor.py
+++ b/pacman/operations/router_compressors/ranged_compressor.py
@@ -14,7 +14,7 @@
 
 import logging
 import sys
-from typing import cast
+from typing import cast, List
 from spinn_utilities.config_holder import get_config_bool
 from spinn_utilities.log import FormatAdapter
 from spinn_utilities.progress_bar import ProgressBar
@@ -70,6 +70,11 @@ class RangeCompressor(object):
         "_compressed",
         # List of entries to be merged
         "_entries")
+
+    def __init__(self):
+        # temp values to avoid Optional
+        self._entries: List[MulticastRoutingEntry] = []
+        self._compressed = CompressedMulticastRoutingTable(0, 0)
 
     def compress_table(
             self, uncompressed: UnCompressedMulticastRoutingTable

--- a/unittests/operations_tests/partition_algorithms_tests/test_basic_partitioner.py
+++ b/unittests/operations_tests/partition_algorithms_tests/test_basic_partitioner.py
@@ -32,7 +32,6 @@ class TestBasicPartitioner(unittest.TestCase):
     """
     test for basic partitioning algorithm
     """
-    # pylint: disable=attribute-defined-outside-init
 
     TheTestAddress = "192.162.240.253"
 


### PR DESCRIPTION
similar to https://github.com/SpiNNakerManchester/SpiNNUtils/pull/302

disables not removed 

data
- protected-access
  -  hide data in the model
 
model/graphs/application/application_vertex.py
- import-outside-toplevel
  - PacmanDataView ->ApplicationGraph -> ApplicationFPGAVertex -> ApplicationVertex -> PacmanDataView

operations/placer_algorithms/_spinner_api.py
- import-error,import-outside-toplevel
  - Don't require spinner

operations/placer_algorithms/application_placer.py
- raise-missing-from
   - original was StopIteration so not needed as a with

operations/router_compressors/ordered_covering_router_compressor/ordered_covering.py
- wrong-spelling-in-comment
  - Lost of abbreviations and Xs and Os in Mundy's docs

utilities/json_utils.py
- broad-except
   - json used for debug info so better broken json with the exception in it.