### PR TITLE
rework routing allocator and provide more data

### DIFF
--- a/pacman/model/routing_info/routing_info.py
+++ b/pacman/model/routing_info/routing_info.py
@@ -314,7 +314,7 @@ class RoutingInfo(object):
         """
         Checks if there are any atoms into machine zone overlaps
 
-        Trie if there are any fixed key mask vertexes.
+        True if there are any fixed key mask vertexes.
 
         :return: True if and only if there is at least one overlap
         """

--- a/pacman/model/routing_info/routing_info.py
+++ b/pacman/model/routing_info/routing_info.py
@@ -333,11 +333,30 @@ class RoutingInfo(object):
         self._target_machine_bits =  target_machine_bits
         self._target_atom_bits = target_atom_bits
 
-    def get_zones(self) -> Tuple[int, int, int, int, int, int, int]:
-        """
-        Get the allocator zone info
-        """
-        return [self._min_bits_atoms_and_mac,
-                self._max_bits_machine, self._max_bits_atoms,
-                self._size_app_part_bits, self._size_mac_atoms_bits,
-                self._target_machine_bits, self._target_atom_bits]
+    @property
+    def min_bits_atoms_and_mac(self) -> int:
+        return self._min_bits_atoms_and_mac
+
+    @property
+    def max_bits_machine(self) -> int:
+        return self._max_bits_machine
+
+    @property
+    def max_bits_atoms(self) -> int:
+        return self._max_bits_atoms
+
+    @property
+    def size_app_part_bits(self) -> int:
+        return self._size_app_part_bits
+
+    @property
+    def size_mac_atoms_bits(self) -> int:
+        return self._size_mac_atoms_bits
+
+    @property
+    def target_machine_bits(self) -> int:
+        return self._target_machine_bits
+
+    @property
+    def target_atom_bits(self) -> int:
+        return self._target_atom_bits

--- a/pacman/model/routing_info/routing_info.py
+++ b/pacman/model/routing_info/routing_info.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 from __future__ import annotations
 from collections import defaultdict
-from typing import Dict, Iterator, Optional, Iterable, Set, TYPE_CHECKING
+from typing import (
+    Dict, Iterator, Optional, Iterable, Set, Tuple, TYPE_CHECKING)
 from deprecated import deprecated
 from pacman.exceptions import PacmanAlreadyExistsException
 if TYPE_CHECKING:
@@ -26,13 +27,14 @@ class RoutingInfo(object):
     An association of machine vertices to a non-overlapping set of keys
     and masks.
     """
-    __slots__ = ("_info", )
+    __slots__ = ("_info", "_overlaps")
 
     def __init__(self) -> None:
         # Partition information indexed by edge pre-vertex and partition ID
         # name
         self._info: Dict[AbstractVertex,
                          Dict[str, VertexRoutingInfo]] = defaultdict(dict)
+        self._overlaps: Set[Tuple[str, AbstractVertex]] = set()
 
     def add_routing_info(self, info: VertexRoutingInfo) -> None:
         """
@@ -213,3 +215,40 @@ class RoutingInfo(object):
 
     def __len__(self) -> int:
         return sum(len(v) for v in self._info.values())
+
+    def add_overlap(self, partition_id: str, vertex: AbstractVertex):
+        """
+        Records that this vertex, partition pair overlaps top part of the key
+
+        These are the exceptions to the split between
+        the application vertex/ partition id bits and
+        the machine vertex / core parts
+
+        :param partition_id: Id of the partition
+        :param vertex: Application or Machine vertex
+        """
+        self._overlaps.add((partition_id, vertex))
+
+    def check_overlap(self, partition_id: str, vertex: AbstractVertex) -> bool:
+        """
+        Checks if this vertex, partition pair overlaps top part of the key
+
+        :param partition_id: Id of the partition
+        :param vertex: Application or Machine vertex
+        :return: True if and only if there is an overlap
+        """
+        return (partition_id, vertex) in self._overlaps
+
+    def get_overlaps(self) -> Iterator[Tuple[str, AbstractVertex]]:
+        """
+        Returns vertex, partition pairs that overlaps top part of the key
+        """
+        for pair in self._overlaps:
+            yield pair
+
+    def has_overlap(self) -> bool:
+        """
+        Checks if there are any overlaps top part of the key
+        :return: True if and only if there is at least one overlap
+        """
+        return len(self._overlaps) > 0

--- a/pacman/model/routing_info/routing_info.py
+++ b/pacman/model/routing_info/routing_info.py
@@ -321,7 +321,7 @@ class RoutingInfo(object):
         return len(self._mx_overlaps) > 0
 
     def add_zones(
-            self, min_bits_machine_and_atoms : int, max_bits_machine: int,
+            self, min_bits_machine_and_atoms: int, max_bits_machine: int,
             max_bits_atoms: int, size_app_part_bits: int,
             size_mac_atoms_bits: int, target_machine_bits: int,
             target_atom_bits: int) -> None:
@@ -389,11 +389,11 @@ class RoutingInfo(object):
     def target_machine_bits(self) -> int:
         """
         Size of the machine part for vertex.
-        
+
         It will be at least max_bits_machine,
         but will include any extra bits if not all bits are needed.
-             
-        It may however not be respected on vertices with a very large number 
+
+        It may however not be respected on vertices with a very large number
         of atoms per core.
         """
         return self._target_machine_bits

--- a/pacman/model/routing_info/routing_info.py
+++ b/pacman/model/routing_info/routing_info.py
@@ -256,7 +256,7 @@ class RoutingInfo(object):
 
     def get_ap_overlaps(self) -> Iterator[Tuple[str, AbstractVertex]]:
         """
-        Returns vertex, partition pairs that overlaps top part of the key
+        :returns:  vertex, partition pairs that overlaps top part of the key
         """
         for pair in self._ap_overlaps:
             yield pair
@@ -264,6 +264,7 @@ class RoutingInfo(object):
     def has_ap_overlap(self) -> bool:
         """
         Checks if there are any overlaps top part of the key
+
         :return: True if and only if there is at least one overlap
         """
         return len(self._ap_overlaps) > 0
@@ -299,6 +300,8 @@ class RoutingInfo(object):
         """
         Returns vertex, partition pairs whose atoms keys
         overlap into the machine zone
+
+        :returns: Partition ID, vertex pairs
         """
         for pair in self._mx_overlaps:
             yield pair
@@ -306,6 +309,7 @@ class RoutingInfo(object):
     def has_mx_overlap(self) -> bool:
         """
         Checks if there are any atoms into machine zone overlaps
+
         :return: True if and only if there is at least one overlap
         """
         return len(self._mx_overlaps) > 0

--- a/pacman/model/routing_info/routing_info.py
+++ b/pacman/model/routing_info/routing_info.py
@@ -27,14 +27,27 @@ class RoutingInfo(object):
     An association of machine vertices to a non-overlapping set of keys
     and masks.
     """
-    __slots__ = ("_info", "_overlaps")
+    __slots__ = ("_info", "_ap_overlaps", "_mx_overlaps",
+                 "_min_bits_atoms_and_mac",
+                 "_max_bits_machine", "_max_bits_atoms",
+                 "_size_app_part_bits", "_size_mac_atoms_bits",
+                 "_target_machine_bits", "_target_atom_bits")
 
     def __init__(self) -> None:
         # Partition information indexed by edge pre-vertex and partition ID
         # name
         self._info: Dict[AbstractVertex,
                          Dict[str, VertexRoutingInfo]] = defaultdict(dict)
-        self._overlaps: Set[Tuple[str, AbstractVertex]] = set()
+        self._ap_overlaps: Set[Tuple[str, AbstractVertex]] = set()
+        self._mx_overlaps: Set[Tuple[str, AbstractVertex]] = set()
+        # Temp values to avoid Optionals
+        self._min_bits_atoms_and_mac = -1000
+        self._max_bits_machine = -1000
+        self._max_bits_atoms = -1000
+        self._size_app_part_bits = -1000
+        self._size_mac_atoms_bits = -1000
+        self._target_machine_bits = -1000
+        self._target_atom_bits = -1000
 
     def add_routing_info(self, info: VertexRoutingInfo) -> None:
         """
@@ -216,7 +229,7 @@ class RoutingInfo(object):
     def __len__(self) -> int:
         return sum(len(v) for v in self._info.values())
 
-    def add_overlap(self, partition_id: str, vertex: AbstractVertex):
+    def add_ap_overlap(self, partition_id: str, vertex: AbstractVertex):
         """
         Records that this vertex, partition pair overlaps top part of the key
 
@@ -227,9 +240,10 @@ class RoutingInfo(object):
         :param partition_id: Id of the partition
         :param vertex: Application or Machine vertex
         """
-        self._overlaps.add((partition_id, vertex))
+        self._ap_overlaps.add((partition_id, vertex))
 
-    def check_overlap(self, partition_id: str, vertex: AbstractVertex) -> bool:
+    def check_ap_overlap(
+            self, partition_id: str, vertex: AbstractVertex) -> bool:
         """
         Checks if this vertex, partition pair overlaps top part of the key
 
@@ -237,18 +251,93 @@ class RoutingInfo(object):
         :param vertex: Application or Machine vertex
         :return: True if and only if there is an overlap
         """
-        return (partition_id, vertex) in self._overlaps
+        return (partition_id, vertex) in self._ap_overlaps
 
-    def get_overlaps(self) -> Iterator[Tuple[str, AbstractVertex]]:
+    def get_ap_overlaps(self) -> Iterator[Tuple[str, AbstractVertex]]:
         """
         Returns vertex, partition pairs that overlaps top part of the key
         """
-        for pair in self._overlaps:
+        for pair in self._ap_overlaps:
             yield pair
 
-    def has_overlap(self) -> bool:
+    def has_ap_overlap(self) -> bool:
         """
         Checks if there are any overlaps top part of the key
         :return: True if and only if there is at least one overlap
         """
-        return len(self._overlaps) > 0
+        return len(self._ap_overlaps) > 0
+
+    def add_mx_overlap(self, partition_id: str, vertex: AbstractVertex):
+        """
+        Records that this vertex, partition pair's atoms keys
+        overlap into the machine zone
+
+        These are the exceptions to the split between
+        the application vertex/ partition id bits and
+        the machine vertex / core parts
+
+        :param partition_id: Id of the partition
+        :param vertex: Application or Machine vertex
+        """
+        self._mx_overlaps.add((partition_id, vertex))
+
+    def check_mx_overlap(
+            self, partition_id: str, vertex: AbstractVertex) -> bool:
+        """
+        Checks if this vertex, partition pair air's atoms keys
+        overlap into the machine zone
+
+        :param partition_id: Id of the partition
+        :param vertex: Application or Machine vertex
+        :return: True if and only if there is an overlap
+        """
+        return (partition_id, vertex) in self._mx_overlaps
+
+    def get_mx_overlaps(self) -> Iterator[Tuple[str, AbstractVertex]]:
+        """
+        Returns vertex, partition pairs whose atoms keys
+        overlap into the machine zone
+        """
+        for pair in self._mx_overlaps:
+            yield pair
+
+    def has_mx_overlap(self) -> bool:
+        """
+        Checks if there are any atoms into machine zone overlaps
+        :return: True if and only if there is at least one overlap
+        """
+        return len(self._mx_overlaps) > 0
+
+    def add_zones(
+            self, min_bits_atoms_and_mac: int, max_bits_machine: int,
+            max_bits_atoms:int, size_app_part_bits: int,
+            size_mac_atoms_bits: int, target_machine_bits: int,
+            target_atom_bits: int) -> None:
+        """
+        Copy in the zone info from the allocator
+
+        :param min_bits_atoms_and_mac:
+        :param max_bits_machine:
+        :param max_bits_atoms:
+        :param size_app_part_bits:
+        :param size_mac_atoms_bits:
+        :param target_machine_bits:
+        :param target_atom_bits:
+        :return:
+        """
+        self._min_bits_atoms_and_mac = min_bits_atoms_and_mac
+        self._max_bits_machine = max_bits_machine
+        self._max_bits_atoms = max_bits_atoms
+        self._size_app_part_bits = size_app_part_bits
+        self._size_mac_atoms_bits = size_mac_atoms_bits
+        self._target_machine_bits =  target_machine_bits
+        self._target_atom_bits = target_atom_bits
+
+    def get_zones(self) -> Tuple[int, int, int, int, int, int, int]:
+        """
+        Get the allocator zone info
+        """
+        return [self._min_bits_atoms_and_mac,
+                self._max_bits_machine, self._max_bits_atoms,
+                self._size_app_part_bits, self._size_mac_atoms_bits,
+                self._target_machine_bits, self._target_atom_bits]

--- a/pacman/model/routing_info/routing_info.py
+++ b/pacman/model/routing_info/routing_info.py
@@ -229,7 +229,8 @@ class RoutingInfo(object):
     def __len__(self) -> int:
         return sum(len(v) for v in self._info.values())
 
-    def add_ap_overlap(self, partition_id: str, vertex: AbstractVertex):
+    def add_ap_overlap(
+            self, partition_id: str, vertex: AbstractVertex) -> None:
         """
         Records that this vertex, partition pair overlaps top part of the key
 
@@ -267,7 +268,8 @@ class RoutingInfo(object):
         """
         return len(self._ap_overlaps) > 0
 
-    def add_mx_overlap(self, partition_id: str, vertex: AbstractVertex):
+    def add_mx_overlap(
+            self, partition_id: str, vertex: AbstractVertex) -> None:
         """
         Records that this vertex, partition pair's atoms keys
         overlap into the machine zone

--- a/pacman/model/routing_info/routing_info.py
+++ b/pacman/model/routing_info/routing_info.py
@@ -28,7 +28,7 @@ class RoutingInfo(object):
     and masks.
     """
     __slots__ = ("_info", "_ap_overlaps", "_mx_overlaps",
-                 "_min_bits_atoms_and_mac",
+                 "_min_bits_machine_and_atoms",
                  "_max_bits_machine", "_max_bits_atoms",
                  "_size_app_part_bits", "_size_mac_atoms_bits",
                  "_target_machine_bits", "_target_atom_bits")
@@ -41,7 +41,7 @@ class RoutingInfo(object):
         self._ap_overlaps: Set[Tuple[str, AbstractVertex]] = set()
         self._mx_overlaps: Set[Tuple[str, AbstractVertex]] = set()
         # Temp values to avoid Optionals
-        self._min_bits_atoms_and_mac = -1000
+        self._min_bits_machine_and_atoms = -1000
         self._max_bits_machine = -1000
         self._max_bits_atoms = -1000
         self._size_app_part_bits = -1000
@@ -290,6 +290,8 @@ class RoutingInfo(object):
         Checks if this vertex, partition pair air's atoms keys
         overlap into the machine zone
 
+        All fixed key mask vertexes are included.
+
         :param partition_id: Id of the partition
         :param vertex: Application or Machine vertex
         :return: True if and only if there is an overlap
@@ -301,6 +303,8 @@ class RoutingInfo(object):
         Returns vertex, partition pairs whose atoms keys
         overlap into the machine zone
 
+        All fixed key mask vertexes are included.
+
         :returns: Partition ID, vertex pairs
         """
         for pair in self._mx_overlaps:
@@ -310,19 +314,21 @@ class RoutingInfo(object):
         """
         Checks if there are any atoms into machine zone overlaps
 
+        Trie if there are any fixed key mask vertexes.
+
         :return: True if and only if there is at least one overlap
         """
         return len(self._mx_overlaps) > 0
 
     def add_zones(
-            self, min_bits_atoms_and_mac: int, max_bits_machine: int,
+            self, min_bits_machine_and_atoms : int, max_bits_machine: int,
             max_bits_atoms: int, size_app_part_bits: int,
             size_mac_atoms_bits: int, target_machine_bits: int,
             target_atom_bits: int) -> None:
         """
         Copy in the zone info from the allocator
 
-        :param min_bits_atoms_and_mac:
+        :param min_bits_machine_and_atoms c:
         :param max_bits_machine:
         :param max_bits_atoms:
         :param size_app_part_bits:
@@ -331,7 +337,7 @@ class RoutingInfo(object):
         :param target_atom_bits:
         :return:
         """
-        self._min_bits_atoms_and_mac = min_bits_atoms_and_mac
+        self._min_bits_machine_and_atoms = min_bits_machine_and_atoms
         self._max_bits_machine = max_bits_machine
         self._max_bits_atoms = max_bits_atoms
         self._size_app_part_bits = size_app_part_bits
@@ -340,29 +346,65 @@ class RoutingInfo(object):
         self._target_atom_bits = target_atom_bits
 
     @property
-    def min_bits_atoms_and_mac(self) -> int:
-        return self._min_bits_atoms_and_mac
+    def min_bits_machine_and_atoms(self) -> int:
+        """
+       Minimum size needed for the combined machine and atoms zone
+
+       This is the maximum needed to represent the keys and masks
+       for a single app vertex / partition ID
+        """
+        return self._min_bits_machine_and_atoms
 
     @property
     def max_bits_machine(self) -> int:
+        """
+        Maximum number of bits to represent the machines for any vertex
+        """
         return self._max_bits_machine
 
     @property
     def max_bits_atoms(self) -> int:
+        """
+        Maximum number of bits to represent the atoms for any vertex
+        """
         return self._max_bits_atoms
 
     @property
     def size_app_part_bits(self) -> int:
+        """
+        Size of the App vertex / Partition name zone
+        """
         return self._size_app_part_bits
 
     @property
     def size_mac_atoms_bits(self) -> int:
+        """
+        Size of the machine and atoms part
+
+        This will always be 32 - size_app_part_bits
+        """
         return self._size_mac_atoms_bits
 
     @property
     def target_machine_bits(self) -> int:
+        """
+        Size of the machine part for vertex.
+        
+        It will be at least max_bits_machine,
+        but will include any extra bits if not all bits are needed.
+             
+        It may however not be respected on vertices with a very large number 
+        of atoms per core.
+        """
         return self._target_machine_bits
 
     @property
     def target_atom_bits(self) -> int:
+        """
+         Size of the atoms part for vertex that fit the normal case
+
+         Ideally this will be the max_bits_atoms but may be smaller
+         if there is a mix of application vertices with many outgoing
+         and others with atoms per core.
+         """
         return self._target_atom_bits

--- a/pacman/model/routing_info/routing_info.py
+++ b/pacman/model/routing_info/routing_info.py
@@ -328,7 +328,7 @@ class RoutingInfo(object):
         """
         Copy in the zone info from the allocator
 
-        :param min_bits_machine_and_atoms c:
+        :param min_bits_machine_and_atoms:
         :param max_bits_machine:
         :param max_bits_atoms:
         :param size_app_part_bits:

--- a/pacman/model/routing_info/routing_info.py
+++ b/pacman/model/routing_info/routing_info.py
@@ -312,7 +312,7 @@ class RoutingInfo(object):
 
     def add_zones(
             self, min_bits_atoms_and_mac: int, max_bits_machine: int,
-            max_bits_atoms:int, size_app_part_bits: int,
+            max_bits_atoms: int, size_app_part_bits: int,
             size_mac_atoms_bits: int, target_machine_bits: int,
             target_atom_bits: int) -> None:
         """
@@ -332,7 +332,7 @@ class RoutingInfo(object):
         self._max_bits_atoms = max_bits_atoms
         self._size_app_part_bits = size_app_part_bits
         self._size_mac_atoms_bits = size_mac_atoms_bits
-        self._target_machine_bits =  target_machine_bits
+        self._target_machine_bits = target_machine_bits
         self._target_atom_bits = target_atom_bits
 
     @property

--- a/pacman/operations/routing_info_allocator_algorithms/zoned_routing_info_allocator.py
+++ b/pacman/operations/routing_info_allocator_algorithms/zoned_routing_info_allocator.py
@@ -144,8 +144,9 @@ class ZonedRoutingInfoAllocator(object):
 
         routing_info = RoutingInfo()
         self.__allocate_fixed(routing_info)
-        self.__calculate_zones(routing_info)
-        self.__check_zones(routing_info)
+        self.__calculate_zone_sizes_needed(routing_info)
+        self.__set_fixed_used(routing_info)
+        self.__calculate_machine_atoms_zones(routing_info)
 
         self.__allocate(routing_info)
         return routing_info
@@ -227,7 +228,8 @@ class ZonedRoutingInfoAllocator(object):
                         "Application {pre} has fixed key {key_and_mask} for "
                         "partition {identifier} but no out_going_vertices")
 
-    def __calculate_zones(self, routing_info: RoutingInfo) -> None:
+    def __calculate_zone_sizes_needed(
+            self, routing_info: RoutingInfo) -> None:
         """
         Computes the size for the zones.
 
@@ -258,18 +260,18 @@ class ZonedRoutingInfoAllocator(object):
             else:
                 self.__atom_bits_per_app_part[pre, identifier] = 0
 
-    def __check_zones(self, routing_infos: RoutingInfo) -> None:
         # See if it could fit even before considering fixed
         if (self.__size_app_part_bits + self.__min_bits_atoms_and_mac >
                 BITS_IN_KEY):
             raise PacmanRouteInfoAllocationException(
-                "Unable to use ZonedRoutingInfoAllocator please select a "
-                f"different allocator as it needs {self.__size_app_part_bits} "
-                f"+ {self.__min_bits_atoms_and_mac} bits")
+                "Unable to use ZonedRoutingInfoAllocator as it needs "
+                "{self.__size_app_part_bits} bits for application keys + "
+                f"{self.__min_bits_atoms_and_mac} for machine and atom bits")
 
-        # Reserve fixed and check it still works
-        self.__set_fixed_used(routing_infos)
 
+    def __calculate_machine_atoms_zones(
+            self, routing_info: RoutingInfo) -> None:
+        # use all the bits not used by the application partition and overlaps
         self.__size_machine_atoms_bits = (
                 BITS_IN_KEY - self.__size_app_part_bits)
 
@@ -286,6 +288,10 @@ class ZonedRoutingInfoAllocator(object):
             self.__target_atom_bits = (
                     self.__size_machine_atoms_bits - self.__max_bits_machine)
             self.__target_machine_bits = self.__max_bits_machine
+
+        # assume all fixed (already have info) will overlap
+        for info in routing_info:
+            routing_info.add_mx_overlap(info.partition_id, info.vertex)
 
     @classmethod
     def calc_overlaps(

--- a/pacman/operations/routing_info_allocator_algorithms/zoned_routing_info_allocator.py
+++ b/pacman/operations/routing_info_allocator_algorithms/zoned_routing_info_allocator.py
@@ -104,8 +104,6 @@ class ZonedRoutingInfoAllocator(object):
         "__fixed_partitions",
         # Set of app_part indexes used by fixed
         "__fixed_used",
-        # True if all partitions are fixed
-        "__all_fixed",
         # Size of the App vertex / Partition name zone
         "__size_app_part_bits",
         # Size of the machine and atoms part
@@ -137,7 +135,6 @@ class ZonedRoutingInfoAllocator(object):
         self.__target_machine_bits = -10000
         self.__target_atom_bits = -10000
 
-        self.__all_fixed = True
 
     def allocate(self) -> RoutingInfo:
         """
@@ -156,10 +153,7 @@ class ZonedRoutingInfoAllocator(object):
         self.__calculate_zones()
         self.__check_zones(routing_infos)
 
-        if self.__all_fixed:
-            self.__allocate_all_fixed(routing_infos)
-        else:
-            self.__allocate(routing_infos)
+        self.__allocate(routing_infos)
         return routing_infos
 
     def __find_fixed(self) -> None:
@@ -168,7 +162,6 @@ class ZonedRoutingInfoAllocator(object):
 
         See :py:meth:`__add_fixed`
         """
-        self.__all_fixed = True
         for pre, identifier in self.__vertex_partitions:
             app_key_and_mask = pre.get_fixed_key_and_mask(identifier)
             is_fixed_m_key = False
@@ -202,9 +195,7 @@ class ZonedRoutingInfoAllocator(object):
                             f" but not for all machine vertices of {pre}")
                     is_unfixed_m_key = True
 
-            if app_key_and_mask is None:
-                self.__all_fixed = False
-            else:
+            if app_key_and_mask is not None:
                 if not is_fixed_m_key:
                     if len(outgoing) > 1:
                         raise PacmanRouteInfoAllocationException(
@@ -351,6 +342,8 @@ class ZonedRoutingInfoAllocator(object):
             if not machine_vertices:
                 continue
 
+            n_bits_atoms = self.__atom_bits_per_app_part[pre, identifier]
+
             id_mv =(identifier, machine_vertices[0])
             fixed = id_mv in self.__fixed_partitions
 
@@ -362,14 +355,12 @@ class ZonedRoutingInfoAllocator(object):
                     routing_infos.add_routing_info(MachineVertexRoutingInfo(
                         key_and_mask, identifier, machine_vertex,
                         machine_index))
-                continue  # for pre
 
             else:
                 while app_part_index in self.__fixed_used:
                         app_part_index += 1
 
                 machine_vertices.sort(key=lambda x: x.vertex_slice.lo_atom)
-                n_bits_atoms = self.__atom_bits_per_app_part[pre, identifier]
                 if n_bits_atoms <= self.__target_atom_bits:
                     # OK it fits use global sizes
                     n_bits_machine = self.__target_machine_bits

--- a/pacman/operations/routing_info_allocator_algorithms/zoned_routing_info_allocator.py
+++ b/pacman/operations/routing_info_allocator_algorithms/zoned_routing_info_allocator.py
@@ -104,7 +104,7 @@ class ZonedRoutingInfoAllocator(object):
         # Size of the App vertex / Partition name zone
         "__size_app_part_bits",
         # Size of the machine and atoms part
-        "__size_mac_atoms_bits",
+        "__size_machine_atoms_bits",
         # Size of the machine part for vertex that fit the normal case
         "__target_machine_bits",
         # Size of the atoms part for vertex that fit the normal case
@@ -126,7 +126,7 @@ class ZonedRoutingInfoAllocator(object):
 
         # temp values to init without optional
         self.__size_app_part_bits = -10000
-        self.__size_mac_atoms_bits = -10000
+        self.__size_machine_atoms_bits = -10000
         self.__target_machine_bits = -10000
         self.__target_atom_bits = -10000
 
@@ -270,21 +270,21 @@ class ZonedRoutingInfoAllocator(object):
         # Reserve fixed and check it still works
         self.__set_fixed_used(routing_infos)
 
-        self.__size_mac_atoms_bits = (
+        self.__size_machine_atoms_bits = (
                 BITS_IN_KEY - self.__size_app_part_bits)
 
-        if self.__size_mac_atoms_bits >= (
+        if self.__size_machine_atoms_bits >= (
                 self.__max_bits_machine + self.__max_bits_atoms):
             # Fits nicely add extra bits to the machine zone
             self.__target_atom_bits = self.__max_bits_atoms
             self.__target_machine_bits = (
-                    self.__size_mac_atoms_bits - self.__max_bits_atoms)
+                    self.__size_machine_atoms_bits - self.__max_bits_atoms)
         else:
             # Does not fit so remove bits from the atom zone
             # Likely only a few very big machine vertices will need them
             # they will then flow into the machine zone
             self.__target_atom_bits = (
-                    self.__size_mac_atoms_bits - self.__max_bits_machine)
+                    self.__size_machine_atoms_bits - self.__max_bits_machine)
             self.__target_machine_bits = self.__max_bits_machine
 
     @classmethod
@@ -382,7 +382,7 @@ class ZonedRoutingInfoAllocator(object):
                 n_bits_atoms = self.__target_atom_bits
                 overlap = False
             else:
-                n_bits_machine = self.__size_mac_atoms_bits - n_bits_atoms
+                n_bits_machine = self.__size_machine_atoms_bits - n_bits_atoms
                 needed = allocator_bits_needed(len(machine_vertices))
                 assert (n_bits_machine >= needed)
                 overlap = True
@@ -412,7 +412,7 @@ class ZonedRoutingInfoAllocator(object):
         routing_info.add_zones(
             self.__min_bits_atoms_and_mac,
             self.__max_bits_machine, self.__max_bits_atoms,
-            self.__size_app_part_bits, self.__size_mac_atoms_bits,
+            self.__size_app_part_bits, self.__size_machine_atoms_bits,
             self.__target_machine_bits, self.__target_atom_bits)
 
     @staticmethod

--- a/pacman/operations/routing_info_allocator_algorithms/zoned_routing_info_allocator.py
+++ b/pacman/operations/routing_info_allocator_algorithms/zoned_routing_info_allocator.py
@@ -130,7 +130,6 @@ class ZonedRoutingInfoAllocator(object):
         self.__target_machine_bits = -10000
         self.__target_atom_bits = -10000
 
-
     def allocate(self) -> RoutingInfo:
         """
         Perform routing information allocation.
@@ -151,7 +150,8 @@ class ZonedRoutingInfoAllocator(object):
         self.__allocate(routing_info)
         return routing_info
 
-    def __check_no_fixed(self, pre: ApplicationVertex, identifier: str) -> None:
+    def __check_no_fixed(
+            self, pre: ApplicationVertex, identifier: str) -> None:
         for vert in pre.splitter.get_out_going_vertices(identifier):
             key_and_mask = pre.get_machine_fixed_key_and_mask(
                 vert, identifier)
@@ -169,8 +169,8 @@ class ZonedRoutingInfoAllocator(object):
             if key_and_mask != app_key_and_mask:
                 raise PacmanRouteInfoAllocationException(
                     f"For partition {part_id} {pre} has fixed key "
-                    f"{app_key_and_mask} while only outgoing machine vertex has"
-                    f" {key_and_mask}")
+                    f"{app_key_and_mask} while only outgoing machine vertex"
+                    f" has {key_and_mask}")
         routing_info.add_routing_info(MachineVertexRoutingInfo(
             app_key_and_mask, part_id, m_vertex, m_vertex.index))
         n_bits_atoms = m_vertex.get_n_keys_for_partition(part_id)
@@ -224,15 +224,15 @@ class ZonedRoutingInfoAllocator(object):
                                                outgoing, routing_info)
                 else:
                     raise PacmanRouteInfoAllocationException(
-                    "Application {pre} has fixed key {key_and_mask} "
-                    "for partition {identifier} but no out_going_vertices")
+                        "Application {pre} has fixed key {key_and_mask} for "
+                        "partition {identifier} but no out_going_vertices")
 
     def __calculate_zones(self, routing_info: RoutingInfo) -> None:
         """
         Computes the size for the zones.
 
         """
-        self.__size_app_part_bits =  allocator_bits_needed(
+        self.__size_app_part_bits = allocator_bits_needed(
             len(self.__vertex_partitions))
 
         progress = ProgressBar(
@@ -338,7 +338,8 @@ class ZonedRoutingInfoAllocator(object):
             if blocked:
                 self.__ap_keys_blocked_by_fixed.update(blocked)
                 routing_info.add_ap_overlap(identifier, pre)
-                for outgoing in pre.splitter.get_out_going_vertices(identifier):
+                for outgoing in pre.splitter.get_out_going_vertices(
+                        identifier):
                     routing_info.add_ap_overlap(identifier, outgoing)
 
             ap_keys_available = 2**self.__size_app_part_bits
@@ -372,7 +373,7 @@ class ZonedRoutingInfoAllocator(object):
             n_bits_atoms = self.__atom_bits_per_app_part[pre, identifier]
 
             while app_part_index in self.__ap_keys_blocked_by_fixed:
-                    app_part_index += 1
+                app_part_index += 1
 
             machine_vertices.sort(key=lambda x: x.vertex_slice.lo_atom)
             if n_bits_atoms <= self.__target_atom_bits:

--- a/pacman/operations/routing_info_allocator_algorithms/zoned_routing_info_allocator.py
+++ b/pacman/operations/routing_info_allocator_algorithms/zoned_routing_info_allocator.py
@@ -268,7 +268,6 @@ class ZonedRoutingInfoAllocator(object):
                 "{self.__size_app_part_bits} bits for application keys + "
                 f"{self.__min_bits_atoms_and_mac} for machine and atom bits")
 
-
     def __calculate_machine_atoms_zones(
             self, routing_info: RoutingInfo) -> None:
         # use all the bits not used by the application partition and overlaps

--- a/pacman/operations/routing_info_allocator_algorithms/zoned_routing_info_allocator.py
+++ b/pacman/operations/routing_info_allocator_algorithms/zoned_routing_info_allocator.py
@@ -116,7 +116,7 @@ class ZonedRoutingInfoAllocator(object):
         self.__n_bits_machine = 0
         self.__n_bits_atoms = 0
         self.__atom_bits_per_app_part: Dict[
-            Tuple[AbstractVertex, str], int] = dict()
+            Tuple[ApplicationVertex, str], int] = dict()
         self.__flexible = flexible
         self.__fixed_partitions: Dict[
             Tuple[str, AbstractVertex], BaseKeyAndMask] = dict()

--- a/pacman/operations/routing_info_allocator_algorithms/zoned_routing_info_allocator.py
+++ b/pacman/operations/routing_info_allocator_algorithms/zoned_routing_info_allocator.py
@@ -91,10 +91,10 @@ class ZonedRoutingInfoAllocator(object):
         # For each App vertex / Partition name zone keep track of the number of
         # bites required for the mask for each machine vertex
         "__atom_bits_per_app_part",
-        # Minimun size needed for the machine and atoms zone
-        # This is the maximum represent the keys and masks
-        # for a single app vertex / partition name zone
-        "__min_bits_atoms_and_mac",
+        # Minimum size needed for the combined machine and atoms zone
+        # This is the maximum needed to represent the keys and masks
+        # for a single app vertex / partition ID
+        "__min_bits_machine_and_atoms",
         # Maximum number of bits to represent the machines for any vertex
         "__max_bits_machine",
         # Maximum number of bits to represent the atoms for any vertex
@@ -120,7 +120,7 @@ class ZonedRoutingInfoAllocator(object):
         self.__ap_keys_blocked_by_fixed: Set[int] = set()
 
         # Start at with values for an empty graph then as needed
-        self.__min_bits_atoms_and_mac = 0
+        self.__min_bits_machine_and_atoms = 0
         self.__max_bits_machine = 0
         self.__max_bits_atoms = 0
 
@@ -254,19 +254,21 @@ class ZonedRoutingInfoAllocator(object):
                 machine_bits = allocator_bits_needed(len(machine_vertices))
                 self.__max_bits_machine = max(
                     self.__max_bits_machine, machine_bits)
-                self.__min_bits_atoms_and_mac = max(
-                    self.__min_bits_atoms_and_mac, machine_bits + atom_bits)
+                self.__min_bits_machine_and_atoms = max(
+                    self.__min_bits_machine_and_atoms,
+                    machine_bits + atom_bits)
                 self.__atom_bits_per_app_part[pre, identifier] = atom_bits
             else:
                 self.__atom_bits_per_app_part[pre, identifier] = 0
 
         # See if it could fit even before considering fixed
-        if (self.__size_app_part_bits + self.__min_bits_atoms_and_mac >
+        if (self.__size_app_part_bits + self.__min_bits_machine_and_atoms >
                 BITS_IN_KEY):
             raise PacmanRouteInfoAllocationException(
                 "Unable to use ZonedRoutingInfoAllocator as it needs "
                 "{self.__size_app_part_bits} bits for application keys + "
-                f"{self.__min_bits_atoms_and_mac} for machine and atom bits")
+                f"{self.__min_bits_machine_and_atoms} "
+                f"for machine and atom bits")
 
     def __calculate_machine_atoms_zones(
             self, routing_info: RoutingInfo) -> None:
@@ -352,8 +354,8 @@ class ZonedRoutingInfoAllocator(object):
             if ap_keys_available < len(self.__vertex_partitions):
                 #  Oops need more bits
                 self.__size_app_part_bits += 1
-                if (self.__size_app_part_bits + self.__min_bits_atoms_and_mac >
-                        BITS_IN_KEY):
+                if (self.__size_app_part_bits +
+                        self.__min_bits_machine_and_atoms > BITS_IN_KEY):
                     raise PacmanRouteInfoAllocationException(
                         "Unable to allocate with fixed keys")
                 # clear used
@@ -415,7 +417,7 @@ class ZonedRoutingInfoAllocator(object):
             app_part_index += 1
 
         routing_info.add_zones(
-            self.__min_bits_atoms_and_mac,
+            self.__min_bits_machine_and_atoms,
             self.__max_bits_machine, self.__max_bits_atoms,
             self.__size_app_part_bits, self.__size_machine_atoms_bits,
             self.__target_machine_bits, self.__target_atom_bits)

--- a/pacman/operations/routing_info_allocator_algorithms/zoned_routing_info_allocator.py
+++ b/pacman/operations/routing_info_allocator_algorithms/zoned_routing_info_allocator.py
@@ -235,6 +235,7 @@ class ZonedRoutingInfoAllocator(object):
         """
         self.__size_app_part_bits =  allocator_bits_needed(
             len(self.__vertex_partitions))
+        self.__size_mac_atoms_bits = BITS_IN_KEY - self.__size_app_part_bits
 
         progress = ProgressBar(
             len(self.__vertex_partitions), "Calculating zones")
@@ -282,6 +283,28 @@ class ZonedRoutingInfoAllocator(object):
                     self.__size_mac_atoms_bits - self.__max_bits_machine)
             self.__target_machine_bits = self.__max_bits_machine
 
+    @classmethod
+    def calc_overlaps(
+            cls, key_and_mask: BaseKeyAndMask, ap_zone: int) -> Set[int]:
+        """
+        Which of the top bits could be used by this key and mask
+
+        :param key_and_mask: key and mask values (typically from fixed)
+        :param ap_zone: number of bits in the application partition zone
+        :return: Set of top zone values that need to be blocked.
+        """
+        mac_zone = BITS_IN_KEY - ap_zone
+        # Get the key and mask that overlap with the A-P key and mask
+        key = key_and_mask.key >> mac_zone
+        mask = key_and_mask.mask >> mac_zone
+        # Make the mask all 1s in the MSBs where it has been shifted
+        mask |= (((1 << mac_zone) - 1) << ap_zone)
+
+        blocked: Set[int] = set()
+        for k, n_keys in get_key_ranges(key, mask):
+            blocked.update(range(k, k + n_keys))
+        return blocked
+
     def __set_fixed_used(self, routing_info: RoutingInfo) -> None:
         """
         Block the use of ``AP`` indexes that would clash with fixed keys
@@ -303,22 +326,11 @@ class ZonedRoutingInfoAllocator(object):
             if not routing_info.has_info_from(pre, identifier):
                 continue
             key_and_mask = routing_info.get_info_from(pre, identifier)
-            # Get the key and mask that overlap with the A-P key and mask
-            key = key_and_mask.key >> self.__min_bits_atoms_and_mac
-            mask = key_and_mask.mask >> self.__min_bits_atoms_and_mac
+            blocked = self.calc_overlaps(
+                key_and_mask, self.__size_app_part_bits)
 
-            # Make the mask all 1s in the MSBs where it has been shifted
-            mask |= (((1 << self.__min_bits_atoms_and_mac) - 1) <<
-                     self.__size_app_part_bits)
-
-            # Generate all possible combinations of keys for the remaining
-            # mask
-            overlap = False
-            for k, n_keys in get_key_ranges(key, mask):
-                self.__ap_keys_blocked_by_fixed.update(range(k, k + n_keys))
-                overlap = True
-
-            if overlap:
+            if blocked:
+                self.__ap_keys_blocked_by_fixed.update(blocked)
                 routing_info.add_ap_overlap(identifier, pre)
                 for outgoing in pre.splitter.get_out_going_vertices(identifier):
                     routing_info.add_ap_overlap(identifier, outgoing)

--- a/pacman/operations/routing_info_allocator_algorithms/zoned_routing_info_allocator.py
+++ b/pacman/operations/routing_info_allocator_algorithms/zoned_routing_info_allocator.py
@@ -190,14 +190,6 @@ class ZonedRoutingInfoAllocator(object):
             key_and_mask = pre.get_machine_fixed_key_and_mask(
                 m_vertex, part_id)
 
-            if machine_mask is None:
-                machine_mask = key_and_mask.mask
-            elif machine_mask != key_and_mask.mask:
-                raise PacmanRouteInfoAllocationException(
-                    f"For partition {part_id} {pre} has different "
-                    f"machine_fixed_key_and_mask found {hex(machine_mask)} "
-                    f"and {hex(key_and_mask.mask)}")
-
             if key_and_mask is None:
                 raise PacmanRouteInfoAllocationException(
                     f"For partition {part_id} {pre} has fixed key "
@@ -210,6 +202,16 @@ class ZonedRoutingInfoAllocator(object):
                     f"{app_key_and_mask} "
                     f"while outgoing {m_vertex} has {key_and_mask}"
                     f"these do not align")
+
+            if machine_mask is None:
+                machine_mask = key_and_mask.mask
+            elif machine_mask != key_and_mask.mask:
+                raise PacmanRouteInfoAllocationException(
+                    f"For partition {part_id} {pre} has different "
+                    f"machine_fixed_key_and_mask found {hex(machine_mask)} "
+                    f"and {hex(key_and_mask.mask)}")
+
+
             routing_info.add_routing_info(MachineVertexRoutingInfo(
                 key_and_mask, part_id, m_vertex, m_vertex.index))
             n_bits_atoms = m_vertex.get_n_keys_for_partition(part_id)

--- a/pacman/operations/routing_info_allocator_algorithms/zoned_routing_info_allocator.py
+++ b/pacman/operations/routing_info_allocator_algorithms/zoned_routing_info_allocator.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import logging
-from typing import Dict, Iterable, List, Set, Tuple
+from typing import Dict, Iterable, List, Optional, Set, Tuple
 from spinn_utilities.log import FormatAdapter
 from spinn_utilities.progress_bar import ProgressBar
 from spinn_utilities.ordered_set import OrderedSet
@@ -177,7 +177,7 @@ class ZonedRoutingInfoAllocator(object):
         n_bits_atoms = m_vertex.get_n_keys_for_partition(part_id)
         routing_info.add_routing_info(AppVertexRoutingInfo(
             app_key_and_mask, part_id, pre,
-            self.__mask(n_bits_atoms), n_bits_atoms,
+            app_key_and_mask.mask, n_bits_atoms,
             len(pre.machine_vertices) - 1))
 
     def __allocate_many_fixed(
@@ -185,9 +185,19 @@ class ZonedRoutingInfoAllocator(object):
             app_key_and_mask: BaseKeyAndMask, outgoing: List[MachineVertex],
             routing_info: RoutingInfo) -> None:
         max_atom_bits = 0
+        machine_mask: Optional[int] = None
         for m_vertex in outgoing:
             key_and_mask = pre.get_machine_fixed_key_and_mask(
                 m_vertex, part_id)
+
+            if machine_mask is None:
+                machine_mask = key_and_mask.mask
+            elif machine_mask != key_and_mask.mask:
+                raise PacmanRouteInfoAllocationException(
+                    f"For partition {part_id} {pre} has different "
+                    f"machine_fixed_key_and_mask found {hex(machine_mask)} "
+                    f"and {hex(key_and_mask.mask)}")
+
             if key_and_mask is None:
                 raise PacmanRouteInfoAllocationException(
                     f"For partition {part_id} {pre} has fixed key "
@@ -204,9 +214,10 @@ class ZonedRoutingInfoAllocator(object):
                 key_and_mask, part_id, m_vertex, m_vertex.index))
             n_bits_atoms = m_vertex.get_n_keys_for_partition(part_id)
             max_atom_bits = max(max_atom_bits, n_bits_atoms)
+        assert machine_mask is not None
         routing_info.add_routing_info(AppVertexRoutingInfo(
             app_key_and_mask, part_id, pre,
-            self.__mask(n_bits_atoms), n_bits_atoms,
+            machine_mask, n_bits_atoms,
             len(pre.machine_vertices) - 1))
 
     def __allocate_fixed(self, routing_info: RoutingInfo) -> None:

--- a/pacman/operations/routing_info_allocator_algorithms/zoned_routing_info_allocator.py
+++ b/pacman/operations/routing_info_allocator_algorithms/zoned_routing_info_allocator.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import logging
-from typing import Dict, Iterable, Set, Tuple, cast
+from typing import Dict, Iterable, List, Set, Tuple
 from spinn_utilities.log import FormatAdapter
 from spinn_utilities.progress_bar import ProgressBar
 from spinn_utilities.ordered_set import OrderedSet
@@ -100,10 +100,8 @@ class ZonedRoutingInfoAllocator(object):
         "__max_bits_machine",
         # Maximum number of bits to represent the atoms for any vertex
         "__max_bits_atoms",
-        # Map of (partition identifier, machine_vertex) to fixed_key_and_mask
-        "__fixed_partitions",
         # Set of app_part indexes used by fixed
-        "__fixed_used",
+        "__ap_keys_blocked_by_fixed",
         # Size of the App vertex / Partition name zone
         "__size_app_part_bits",
         # Size of the machine and atoms part
@@ -120,9 +118,7 @@ class ZonedRoutingInfoAllocator(object):
             Tuple[ApplicationVertex, str]] = OrderedSet()
         self.__atom_bits_per_app_part: Dict[
             Tuple[ApplicationVertex, str], int] = dict()
-        self.__fixed_partitions: Dict[
-            Tuple[str, AbstractVertex], BaseKeyAndMask] = dict()
-        self.__fixed_used: Set[int] = set()
+        self.__ap_keys_blocked_by_fixed: Set[int] = set()
 
         # Start at with values for an empty graph then as needed
         self.__min_bits_atoms_and_mac = 0
@@ -148,65 +144,91 @@ class ZonedRoutingInfoAllocator(object):
             (p.pre_vertex, p.identifier)
             for p in get_app_partitions())
 
-        routing_infos = RoutingInfo()
-        self.__find_fixed()
-        self.__calculate_zones()
-        self.__check_zones(routing_infos)
+        routing_info = RoutingInfo()
+        self.__allocate_fixed(routing_info)
+        self.__calculate_zones(routing_info)
+        self.__check_zones(routing_info)
 
-        self.__allocate(routing_infos)
-        return routing_infos
+        self.__allocate(routing_info)
+        return routing_info
 
-    def __find_fixed(self) -> None:
-        """
-        Looks for FixedKeyAmdMask Constraints and keeps track of these.
+    def __check_no_fixed(self, pre: ApplicationVertex, identifier: str) -> None:
+        for vert in pre.splitter.get_out_going_vertices(identifier):
+            key_and_mask = pre.get_machine_fixed_key_and_mask(
+                vert, identifier)
+            if key_and_mask is not None:
+                raise PacmanRouteInfoAllocationException(
+                    f"For partition {identifier} {pre} has no fixed key,"
+                    f" but {vert} has fixed key {key_and_mask}")
 
-        See :py:meth:`__add_fixed`
-        """
-        for pre, identifier in self.__vertex_partitions:
-            app_key_and_mask = pre.get_fixed_key_and_mask(identifier)
-            is_fixed_m_key = False
-            is_unfixed_m_key = False
-            outgoing = list(pre.splitter.get_out_going_vertices(identifier))
-            for vert in outgoing:
-                key_and_mask = pre.get_machine_fixed_key_and_mask(
-                    vert, identifier)
-                if key_and_mask is not None:
-                    if is_unfixed_m_key:
-                        raise PacmanRouteInfoAllocationException(
-                            "A fixed key has been found for one machine vertex"
-                            f" but not for all machine vertices of {pre}")
-                    is_fixed_m_key = True
-                    if app_key_and_mask is None:
-                        raise PacmanRouteInfoAllocationException(
-                            "No application fixed key found, but machine "
-                            f"fixed key {key_and_mask} found on vertex {pre}, "
-                            f"machine vertex {vert}, partition {identifier}")
-                    if (key_and_mask.key & app_key_and_mask.mask !=
-                            app_key_and_mask.key):
-                        raise PacmanRouteInfoAllocationException(
-                            f"For application vertex {pre}, the fixed key for "
-                            f"machine vertex {vert} of {key_and_mask} does "
-                            f"not align with the app key {app_key_and_mask}")
-                    self.__fixed_partitions[identifier, vert] = key_and_mask
+    def __allocate_one_fixed(
+            self, pre: ApplicationVertex, part_id: str,
+            app_key_and_mask: BaseKeyAndMask, m_vertex: MachineVertex,
+            routing_info: RoutingInfo) -> None:
+        key_and_mask = pre.get_machine_fixed_key_and_mask(m_vertex, part_id)
+        if key_and_mask is not None:
+            if key_and_mask != app_key_and_mask:
+                raise PacmanRouteInfoAllocationException(
+                    f"For partition {part_id} {pre} has fixed key "
+                    f"{app_key_and_mask} while only outgoing machine vertex has"
+                    f" {key_and_mask}")
+        routing_info.add_routing_info(MachineVertexRoutingInfo(
+            app_key_and_mask, part_id, m_vertex, m_vertex.index))
+        n_bits_atoms = m_vertex.get_n_keys_for_partition(part_id)
+        routing_info.add_routing_info(AppVertexRoutingInfo(
+            app_key_and_mask, part_id, pre,
+            self.__mask(n_bits_atoms), n_bits_atoms,
+            len(pre.machine_vertices) - 1))
+
+    def __allocate_many_fixed(
+            self, pre: ApplicationVertex, part_id: str,
+            app_key_and_mask: BaseKeyAndMask, outgoing: List[MachineVertex],
+            routing_info: RoutingInfo) -> None:
+        max_atom_bits = 0
+        for m_vertex in outgoing:
+            key_and_mask = pre.get_machine_fixed_key_and_mask(
+                m_vertex, part_id)
+            if key_and_mask is None:
+                raise PacmanRouteInfoAllocationException(
+                    f"For partition {part_id} {pre} has fixed key "
+                    f"{app_key_and_mask} "
+                    f"while outgoing {m_vertex} has no fixed key")
+            if (key_and_mask.key & app_key_and_mask.mask !=
+                    app_key_and_mask.key):
+                raise PacmanRouteInfoAllocationException(
+                    f"For partition {part_id} {pre} has fixed key "
+                    f"{app_key_and_mask} "
+                    f"while outgoing {m_vertex} has {key_and_mask}"
+                    f"these do not align")
+            routing_info.add_routing_info(MachineVertexRoutingInfo(
+                key_and_mask, part_id, m_vertex, m_vertex.index))
+            n_bits_atoms = m_vertex.get_n_keys_for_partition(part_id)
+            max_atom_bits = max(max_atom_bits, n_bits_atoms)
+        routing_info.add_routing_info(AppVertexRoutingInfo(
+            app_key_and_mask, part_id, pre,
+            self.__mask(n_bits_atoms), n_bits_atoms,
+            len(pre.machine_vertices) - 1))
+
+    def __allocate_fixed(self, routing_info: RoutingInfo) -> None:
+        for pre, part_id in self.__vertex_partitions:
+            app_key_and_mask = pre.get_fixed_key_and_mask(part_id)
+            if app_key_and_mask is None:
+                self.__check_no_fixed(pre, part_id)
+            else:
+                outgoing = list(
+                    pre.splitter.get_out_going_vertices(part_id))
+                if len(outgoing) == 1:
+                    self.__allocate_one_fixed(pre, part_id, app_key_and_mask,
+                                              outgoing[0], routing_info)
+                elif len(outgoing) > 1:
+                    self.__allocate_many_fixed(pre, part_id, app_key_and_mask,
+                                               outgoing, routing_info)
                 else:
-                    if is_fixed_m_key:
-                        raise PacmanRouteInfoAllocationException(
-                            "A fixed key has been found for one machine vertex"
-                            f" but not for all machine vertices of {pre}")
-                    is_unfixed_m_key = True
+                    raise PacmanRouteInfoAllocationException(
+                    "Application {pre} has fixed key {key_and_mask} "
+                    "for partition {identifier} but no out_going_vertices")
 
-            if app_key_and_mask is not None:
-                if not is_fixed_m_key:
-                    if len(outgoing) > 1:
-                        raise PacmanRouteInfoAllocationException(
-                            f"On {pre} only a fixed app key has been provided,"
-                            " but there is more than one machine vertex.")
-                    # pylint:disable=undefined-loop-variable
-                    self.__fixed_partitions[
-                        identifier, vert] = app_key_and_mask
-                self.__fixed_partitions[identifier, pre] = app_key_and_mask
-
-    def __calculate_zones(self):
+    def __calculate_zones(self, routing_info: RoutingInfo) -> None:
         """
         Computes the size for the zones.
 
@@ -217,6 +239,8 @@ class ZonedRoutingInfoAllocator(object):
         progress = ProgressBar(
             len(self.__vertex_partitions), "Calculating zones")
         for pre, identifier in progress.over(self.__vertex_partitions):
+            if routing_info.has_info_from(pre, identifier):
+                continue
             max_keys = 0
             machine_vertices = pre.splitter.get_out_going_vertices(identifier)
             for m_vtx in machine_vertices:
@@ -225,13 +249,12 @@ class ZonedRoutingInfoAllocator(object):
 
             if max_keys > 0:
                 atom_bits = allocator_bits_needed(max_keys)
-                if (identifier, pre) not in self.__fixed_partitions:
-                    self.__max_bits_atoms = max(self.__max_bits_atoms, atom_bits)
-                    machine_bits = allocator_bits_needed(len(machine_vertices))
-                    self.__max_bits_machine = max(
-                        self.__max_bits_machine, machine_bits)
-                    self.__min_bits_atoms_and_mac = max(
-                        self.__min_bits_atoms_and_mac, machine_bits + atom_bits)
+                self.__max_bits_atoms = max(self.__max_bits_atoms, atom_bits)
+                machine_bits = allocator_bits_needed(len(machine_vertices))
+                self.__max_bits_machine = max(
+                    self.__max_bits_machine, machine_bits)
+                self.__min_bits_atoms_and_mac = max(
+                    self.__min_bits_atoms_and_mac, machine_bits + atom_bits)
                 self.__atom_bits_per_app_part[pre, identifier] = atom_bits
             else:
                 self.__atom_bits_per_app_part[pre, identifier] = 0
@@ -259,7 +282,7 @@ class ZonedRoutingInfoAllocator(object):
                     self.__size_mac_atoms_bits - self.__max_bits_machine)
             self.__target_machine_bits = self.__max_bits_machine
 
-    def __set_fixed_used(self, routing_infos: RoutingInfo) -> None:
+    def __set_fixed_used(self, routing_info: RoutingInfo) -> None:
         """
         Block the use of ``AP`` indexes that would clash with fixed keys
         """
@@ -276,7 +299,10 @@ class ZonedRoutingInfoAllocator(object):
         # Case (3): the mask that overlaps AP is complex; all possible
         #           combinations of AP within the 0s of the mask will be
         #           blocked from use
-        for (partition_id, vertex), key_and_mask in self.__fixed_partitions.items():
+        for pre, identifier in self.__vertex_partitions:
+            if not routing_info.has_info_from(pre, identifier):
+                continue
+            key_and_mask = routing_info.get_info_from(pre, identifier)
             # Get the key and mask that overlap with the A-P key and mask
             key = key_and_mask.key >> self.__min_bits_atoms_and_mac
             mask = key_and_mask.mask >> self.__min_bits_atoms_and_mac
@@ -289,20 +315,16 @@ class ZonedRoutingInfoAllocator(object):
             # mask
             overlap = False
             for k, n_keys in get_key_ranges(key, mask):
-                self.__fixed_used.update(range(k, k + n_keys))
+                self.__ap_keys_blocked_by_fixed.update(range(k, k + n_keys))
                 overlap = True
 
             if overlap:
-                routing_infos.add_overlap(partition_id, vertex)
-                # for one app one outgoing the outgoing may not have fixed keys
-                if isinstance(vertex, ApplicationVertex):
-                    outgoing = list(
-                        vertex.splitter.get_out_going_vertices(partition_id))
-                    if len(outgoing) == 0:
-                        routing_infos.add_overlap(partition_id, outgoing)
+                routing_info.add_overlap(identifier, pre)
+                for outgoing in pre.splitter.get_out_going_vertices(identifier):
+                    routing_info.add_overlap(identifier, outgoing)
 
             ap_keys_available = 2**self.__size_app_part_bits
-            ap_keys_available -= len(self.__fixed_used)
+            ap_keys_available -= len(self.__ap_keys_blocked_by_fixed)
             if ap_keys_available < len(self.__vertex_partitions):
                 #  Oops need more bits
                 self.__size_app_part_bits += 1
@@ -311,30 +333,17 @@ class ZonedRoutingInfoAllocator(object):
                     raise PacmanRouteInfoAllocationException(
                         "Unable to allocate with fixed keys")
                 # clear used
-                self.__fixed_used = set()
+                self.__ap_keys_blocked_by_fixed = set()
                 # No need to clear routing_infos overlap as all will repeat
-                self.__set_fixed_used(routing_infos)
+                self.__set_fixed_used(routing_info)
 
-    def __allocate_all_fixed(self,  routing_infos: RoutingInfo) -> None:
-        progress = ProgressBar(
-            len(self.__fixed_partitions), "Allocating routing keys")
-        for (part_id, vertex), key_and_mask in progress.over(
-                self.__fixed_partitions.items()):
-            if isinstance(vertex, ApplicationVertex):
-                n_bits_atoms = self.__atom_bits_per_app_part[vertex, part_id]
-                routing_infos.add_routing_info(AppVertexRoutingInfo(
-                    key_and_mask, part_id, vertex,
-                    self.__mask(n_bits_atoms), n_bits_atoms,
-                    len(vertex.machine_vertices)-1))
-            elif isinstance(vertex, MachineVertex):
-                routing_infos.add_routing_info(MachineVertexRoutingInfo(
-                    key_and_mask, part_id, vertex, vertex.index))
-
-    def __allocate(self, routing_infos: RoutingInfo) -> None:
+    def __allocate(self, routing_info: RoutingInfo) -> None:
         progress = ProgressBar(
             len(self.__vertex_partitions), "Allocating routing keys")
         app_part_index = 0
         for pre, identifier in progress.over(self.__vertex_partitions):
+            if routing_info.has_info_from(pre, identifier):
+                continue
             # Get a list of machine vertices ordered by pre-slice
             splitter = pre.splitter
             machine_vertices = list(splitter.get_out_going_vertices(
@@ -344,57 +353,40 @@ class ZonedRoutingInfoAllocator(object):
 
             n_bits_atoms = self.__atom_bits_per_app_part[pre, identifier]
 
-            id_mv =(identifier, machine_vertices[0])
-            fixed = id_mv in self.__fixed_partitions
+            while app_part_index in self.__ap_keys_blocked_by_fixed:
+                    app_part_index += 1
 
-            if fixed:
-                for machine_index, machine_vertex in enumerate(
-                        machine_vertices):
-                    id_mv = (identifier, machine_vertex)
-                    key_and_mask = self.__fixed_partitions[id_mv]
-                    routing_infos.add_routing_info(MachineVertexRoutingInfo(
-                        key_and_mask, identifier, machine_vertex,
-                        machine_index))
-
+            machine_vertices.sort(key=lambda x: x.vertex_slice.lo_atom)
+            if n_bits_atoms <= self.__target_atom_bits:
+                # OK it fits use global sizes
+                n_bits_machine = self.__target_machine_bits
+                n_bits_atoms = self.__target_atom_bits
             else:
-                while app_part_index in self.__fixed_used:
-                        app_part_index += 1
+                n_bits_machine = self.__size_mac_atoms_bits - n_bits_atoms
+                needed = allocator_bits_needed(len(machine_vertices))
+                assert (n_bits_machine >= needed)
 
-                machine_vertices.sort(key=lambda x: x.vertex_slice.lo_atom)
-                if n_bits_atoms <= self.__target_atom_bits:
-                    # OK it fits use global sizes
-                    n_bits_machine = self.__target_machine_bits
-                    n_bits_atoms = self.__target_atom_bits
-                else:
-                    n_bits_machine = self.__size_mac_atoms_bits - n_bits_atoms
-                    needed = allocator_bits_needed(len(machine_vertices))
-                    assert (n_bits_machine >= needed)
-
-                for machine_index, machine_vertex in enumerate(machine_vertices):
-                    mask = self.__mask(n_bits_atoms)
-                    key = app_part_index
-                    key = (key << n_bits_machine) | machine_index
-                    key = key << n_bits_atoms
-                    key_and_mask = BaseKeyAndMask(base_key=key, mask=mask)
-                    routing_infos.add_routing_info(MachineVertexRoutingInfo(
-                        key_and_mask, identifier, machine_vertex,
-                        machine_index))
+            for machine_index, machine_vertex in enumerate(machine_vertices):
+                mask = self.__mask(n_bits_atoms)
+                key = app_part_index
+                key = (key << n_bits_machine) | machine_index
+                key = key << n_bits_atoms
+                key_and_mask = BaseKeyAndMask(base_key=key, mask=mask)
+                routing_info.add_routing_info(MachineVertexRoutingInfo(
+                    key_and_mask, identifier, machine_vertex,
+                    machine_index))
 
             # Add application-level routing information
-            id_pr = (identifier, pre)
-            if id_pr in self.__fixed_partitions:
-                key_and_mask = self.__fixed_partitions[id_pr]
-            else:
-                key = app_part_index << (n_bits_atoms + n_bits_machine)
-                mask = self.__mask(n_bits_atoms + n_bits_machine)
-                key_and_mask = BaseKeyAndMask(key, mask)
-            routing_infos.add_routing_info(AppVertexRoutingInfo(
+            key = app_part_index << (n_bits_atoms + n_bits_machine)
+            mask = self.__mask(n_bits_atoms + n_bits_machine)
+            key_and_mask = BaseKeyAndMask(key, mask)
+            routing_info.add_routing_info(AppVertexRoutingInfo(
                 key_and_mask, identifier, pre,
                 self.__mask(n_bits_atoms), n_bits_atoms,
                 len(machine_vertices) - 1))
             app_part_index += 1
 
-        return routing_infos
+        return routing_info
 
     @staticmethod
     def __mask(bits: int) -> int:

--- a/pacman/operations/routing_info_allocator_algorithms/zoned_routing_info_allocator.py
+++ b/pacman/operations/routing_info_allocator_algorithms/zoned_routing_info_allocator.py
@@ -294,7 +294,7 @@ class ZonedRoutingInfoAllocator(object):
         Which of the top bits could be used by this key and mask
 
         :param key: application vertex key
-        :param mask: application vertext mask
+        :param mask: application vertex mask
         :param ap_zone: number of bits in the application partition zone
         :return: Set of top zone values that need to be blocked.
         """

--- a/pacman/operations/routing_info_allocator_algorithms/zoned_routing_info_allocator.py
+++ b/pacman/operations/routing_info_allocator_algorithms/zoned_routing_info_allocator.py
@@ -137,14 +137,16 @@ class ZonedRoutingInfoAllocator(object):
             for p in get_app_partitions())
         self.__vertex_partitions.update(extra_allocations)
 
+        routing_infos = RoutingInfo()
         self.__find_fixed()
         self.__calculate_zones()
-        self.__check_zones()
+        self.__check_zones(routing_infos)
 
         if self.__all_fixed:
-            return self.__allocate_all_fixed()
-
-        return self.__allocate()
+            self.__allocate_all_fixed(routing_infos)
+        else:
+            self.__allocate(routing_infos)
+        return routing_infos
 
     def __find_fixed(self) -> None:
         """
@@ -237,7 +239,7 @@ class ZonedRoutingInfoAllocator(object):
             else:
                 self.__atom_bits_per_app_part[pre, identifier] = 0
 
-    def __check_zones(self) -> None:
+    def __check_zones(self, routing_infos: RoutingInfo) -> None:
         # See if it could fit even before considering fixed
         app_part_bits = allocator_bits_needed(
             len(self.__atom_bits_per_app_part))
@@ -248,7 +250,7 @@ class ZonedRoutingInfoAllocator(object):
                 f"{self.__n_bits_atoms_and_mac} bits")
 
         # Reserve fixed and check it still works
-        self.__set_fixed_used()
+        self.__set_fixed_used(routing_infos)
         app_part_bits = allocator_bits_needed(
             len(self.__atom_bits_per_app_part) + len(self.__fixed_used))
         if app_part_bits + self.__n_bits_atoms_and_mac > BITS_IN_KEY:
@@ -274,7 +276,7 @@ class ZonedRoutingInfoAllocator(object):
                 self.__n_bits_atoms_and_mac = \
                     self.__n_bits_machine + self.__n_bits_atoms
 
-    def __set_fixed_used(self) -> None:
+    def __set_fixed_used(self, routing_infos: RoutingInfo) -> None:
         """
         Block the use of ``AP`` indexes that would clash with fixed keys
         """
@@ -293,7 +295,7 @@ class ZonedRoutingInfoAllocator(object):
         #           blocked from use
 
         n_app_part_bits = BITS_IN_KEY - self.__n_bits_atoms_and_mac
-        for key_and_mask in self.__fixed_partitions.values():
+        for (partition_id, vertex), key_and_mask in self.__fixed_partitions.items():
             # Get the key and mask that overlap with the A-P key and mask
             key = key_and_mask.key >> self.__n_bits_atoms_and_mac
             mask = key_and_mask.mask >> self.__n_bits_atoms_and_mac
@@ -304,11 +306,21 @@ class ZonedRoutingInfoAllocator(object):
 
             # Generate all possible combinations of keys for the remaining
             # mask
+            overlap = False
             for k, n_keys in get_key_ranges(key, mask):
                 self.__fixed_used.update(range(k, k + n_keys))
+                overlap = True
 
-    def __allocate_all_fixed(self) -> RoutingInfo:
-        routing_infos = RoutingInfo()
+            if overlap:
+                routing_infos.add_overlap(partition_id, vertex)
+                # for one app one outgoing the outgoing may not have fixed keys
+                if isinstance(vertex, ApplicationVertex):
+                    outgoing = list(
+                        vertex.splitter.get_out_going_vertices(partition_id))
+                    if len(outgoing) == 0:
+                        routing_infos.add_overlap(partition_id, outgoing)
+
+    def __allocate_all_fixed(self,  routing_infos: RoutingInfo) -> None:
         progress = ProgressBar(
             len(self.__fixed_partitions), "Allocating routing keys")
         for (part_id, vertex), key_and_mask in progress.over(
@@ -322,12 +334,10 @@ class ZonedRoutingInfoAllocator(object):
             elif isinstance(vertex, MachineVertex):
                 routing_infos.add_routing_info(MachineVertexRoutingInfo(
                     key_and_mask, part_id, vertex, vertex.index))
-        return routing_infos
 
-    def __allocate(self) -> RoutingInfo:
+    def __allocate(self, routing_infos: RoutingInfo) -> None:
         progress = ProgressBar(
             len(self.__vertex_partitions), "Allocating routing keys")
-        routing_infos = RoutingInfo()
         app_part_index = 0
         for pre, identifier in progress.over(self.__vertex_partitions):
             while app_part_index in self.__fixed_used:

--- a/pacman/operations/routing_info_allocator_algorithms/zoned_routing_info_allocator.py
+++ b/pacman/operations/routing_info_allocator_algorithms/zoned_routing_info_allocator.py
@@ -234,7 +234,6 @@ class ZonedRoutingInfoAllocator(object):
         """
         self.__size_app_part_bits =  allocator_bits_needed(
             len(self.__vertex_partitions))
-        self.__size_mac_atoms_bits = BITS_IN_KEY - self.__size_app_part_bits
 
         progress = ProgressBar(
             len(self.__vertex_partitions), "Calculating zones")

--- a/pacman/operations/routing_info_allocator_algorithms/zoned_routing_info_allocator.py
+++ b/pacman/operations/routing_info_allocator_algorithms/zoned_routing_info_allocator.py
@@ -95,8 +95,6 @@ class ZonedRoutingInfoAllocator(object):
         "__n_bits_atoms",
         # Flag to say operating in flexible mode
         "__flexible",
-        # List of (key, n_keys) needed for fixed
-        "__fixed_keys",
         # Map of (partition identifier, machine_vertex) to fixed_key_and_mask
         "__fixed_partitions",
         # Set of app_part indexes used by fixed

--- a/pacman/operations/routing_info_allocator_algorithms/zoned_routing_info_allocator.py
+++ b/pacman/operations/routing_info_allocator_algorithms/zoned_routing_info_allocator.py
@@ -65,19 +65,25 @@ class ZonedRoutingInfoAllocator(object):
     The split between the ``M`` and ``X`` may vary depending on how the
     allocator is called.
 
-    In "global" mode the widths of the fields are predetermined and fixed
+    In normal mode the widths of the fields are predetermined and fixed
     such that every key will have every field in the same place in the key,
     and the mask is the same for every vertex.
-    The global approach is particularly sensitive to the one large and
-    many small vertices limit.
 
-    In "flexible" mode the size of the ``M`` and ``X`` will change for each
-    application/partition. Every vertex for a application/partition pair
-    but different pairs may have different masks.
-    This should result in less gaps between the machine vertexes.
-    Even in non-flexible mode if the sizes are too big to keep ``M`` and
-    ``X`` the same size they will be allowed to change for those vertexes
-    will a very high number of atoms.
+    The AP part will be as small as possible represent all AP Keys.
+    If there are fixed keys using the higher bits this may increase.
+    The atoms zone will be large enough for the vertex with the most atoms.
+    The remaining bits will be the machine zone.
+
+    In some cases, when there is a mix of
+    machine vertices with a large number of atoms (ex. retinas)
+    and application vertices with a large number of machine vertices,
+    a global split of machine zone and atom zone will not fit.
+    In These case the target machine size will be big enough for
+    application vertices with a large number of machine vertices
+    with the remaining bits being the target atom zone.
+    Most vertices will be able to use this split.
+    The few vertices with a large number of atoms will then not respect the
+    split between machine and atoms zones.
     """
 
     __slots__ = (
@@ -88,46 +94,55 @@ class ZonedRoutingInfoAllocator(object):
         "__atom_bits_per_app_part",
         # maximum number of bites to represent the keys and masks
         # for a single app vertex / partition name zone
-        "__n_bits_atoms_and_mac",
-        # Maximum number of bits to represent the machine assuming global
-        "__n_bits_machine",
-        # Maximum number of bits to represent the machine assuming global
-        "__n_bits_atoms",
-        # Flag to say operating in flexible mode
-        "__flexible",
+        # This is therefor the minimum size for the combine zone
+        "__min_bits_atoms_and_mac",
+        # Maximum number of bits to represent the machine for any vertex
+        "__max_bits_machine",
+        # Maximum number of bits to represent the atoms for any vertex
+        "__max_bits_atoms",
         # Map of (partition identifier, machine_vertex) to fixed_key_and_mask
         "__fixed_partitions",
         # Set of app_part indexes used by fixed
         "__fixed_used",
         # True if all partitions are fixed
-        "__all_fixed")
+        "__all_fixed",
+        # Size of the App vertex / Partition name zone
+        "__size_app_part_bits",
+        # Size of the machine and atoms part
+        "__size_mac_atoms_bits",
+        # Size of the machine part for vertex that fit the normal case
+        "__target_machine_bits",
+        # Size of the atoms part for vertex that fit the normal case
+        "__target_atom_bits"
+    )
 
-    def __init__(self, flexible: bool = False):
-        """
-        :param flexible: Determines if flexible can be use.
-            If False, global settings will be attempted
-        """
+    def __init__(self) -> None:
+        # Storage objects to be filled
         self.__vertex_partitions: OrderedSet[
             Tuple[ApplicationVertex, str]] = OrderedSet()
-        self.__n_bits_atoms_and_mac = 0
-        self.__n_bits_machine = 0
-        self.__n_bits_atoms = 0
         self.__atom_bits_per_app_part: Dict[
             Tuple[ApplicationVertex, str], int] = dict()
-        self.__flexible = flexible
         self.__fixed_partitions: Dict[
             Tuple[str, AbstractVertex], BaseKeyAndMask] = dict()
         self.__fixed_used: Set[int] = set()
+
+        # Start at with values for an empty graph then as needed
+        self.__min_bits_atoms_and_mac = 0
+        self.__max_bits_machine = 0
+        self.__max_bits_atoms = 0
+
+        # temp values to init without optional
+        self.__size_app_part_bits = -10000
+        self.__size_mac_atoms_bits = -10000
+        self.__target_machine_bits = -10000
+        self.__target_atom_bits = -10000
+
         self.__all_fixed = True
 
-    def allocate(self, extra_allocations: _XAlloc) -> RoutingInfo:
+    def allocate(self) -> RoutingInfo:
         """
         Perform routing information allocation.
 
-        :param extra_allocations:
-            Additional (vertex, partition identifier) pairs to allocate
-            keys to.  These might not appear in partitions in the graph
-            due to being added by the system.
         :return: The routing information
         :raise PacmanRouteInfoAllocationException:
             If something goes wrong with the allocation
@@ -135,7 +150,6 @@ class ZonedRoutingInfoAllocator(object):
         self.__vertex_partitions = OrderedSet(
             (p.pre_vertex, p.identifier)
             for p in get_app_partitions())
-        self.__vertex_partitions.update(extra_allocations)
 
         routing_infos = RoutingInfo()
         self.__find_fixed()
@@ -201,27 +215,19 @@ class ZonedRoutingInfoAllocator(object):
                         identifier, vert] = app_key_and_mask
                 self.__fixed_partitions[identifier, pre] = app_key_and_mask
 
-    def __calculate_zones(self) -> None:
+    def __calculate_zones(self):
         """
         Computes the size for the zones.
 
-        .. note::
-            Even Partitions with FixedKeysAndMasks a included here.
-            This does waste a little space.
-            However makes this and the allocate code slightly simpler
-            It also keeps the ``AP`` zone working for these partitions too
-
-        :raises PacmanRouteInfoAllocationException:
         """
+        self.__size_app_part_bits =  allocator_bits_needed(
+            len(self.__vertex_partitions))
+
         progress = ProgressBar(
             len(self.__vertex_partitions), "Calculating zones")
-
-        # search for size of regions
         for pre, identifier in progress.over(self.__vertex_partitions):
-            machine_vertices = pre.splitter.get_out_going_vertices(identifier)
-            if not machine_vertices:
-                continue
             max_keys = 0
+            machine_vertices = pre.splitter.get_out_going_vertices(identifier)
             for m_vtx in machine_vertices:
                 max_keys = max(max_keys, m_vtx.get_n_keys_for_partition(
                     identifier))
@@ -229,52 +235,38 @@ class ZonedRoutingInfoAllocator(object):
             if max_keys > 0:
                 atom_bits = allocator_bits_needed(max_keys)
                 if (identifier, pre) not in self.__fixed_partitions:
-                    self.__n_bits_atoms = max(self.__n_bits_atoms, atom_bits)
+                    self.__max_bits_atoms = max(self.__max_bits_atoms, atom_bits)
                     machine_bits = allocator_bits_needed(len(machine_vertices))
-                    self.__n_bits_machine = max(
-                        self.__n_bits_machine, machine_bits)
-                    self.__n_bits_atoms_and_mac = max(
-                        self.__n_bits_atoms_and_mac, machine_bits + atom_bits)
+                    self.__max_bits_machine = max(
+                        self.__max_bits_machine, machine_bits)
+                    self.__min_bits_atoms_and_mac = max(
+                        self.__min_bits_atoms_and_mac, machine_bits + atom_bits)
                 self.__atom_bits_per_app_part[pre, identifier] = atom_bits
             else:
                 self.__atom_bits_per_app_part[pre, identifier] = 0
 
     def __check_zones(self, routing_infos: RoutingInfo) -> None:
         # See if it could fit even before considering fixed
-        app_part_bits = allocator_bits_needed(
-            len(self.__atom_bits_per_app_part))
-        if app_part_bits + self.__n_bits_atoms_and_mac > BITS_IN_KEY:
+        if (self.__size_app_part_bits + self.__min_bits_atoms_and_mac >
+                BITS_IN_KEY):
             raise PacmanRouteInfoAllocationException(
                 "Unable to use ZonedRoutingInfoAllocator please select a "
-                f"different allocator as it needs {app_part_bits} + "
-                f"{self.__n_bits_atoms_and_mac} bits")
+                f"different allocator as it needs {self.__app_part_bits} + "
+                f"{self.__min_bits_atoms_and_mac} bits")
 
         # Reserve fixed and check it still works
         self.__set_fixed_used(routing_infos)
-        app_part_bits = allocator_bits_needed(
-            len(self.__atom_bits_per_app_part) + len(self.__fixed_used))
-        if app_part_bits + self.__n_bits_atoms_and_mac > BITS_IN_KEY:
-            raise PacmanRouteInfoAllocationException(
-                "Unable to use ZonedRoutingInfoAllocator please select a "
-                f"different allocator as it needs {app_part_bits} + "
-                f"{self.__n_bits_atoms_and_mac} bits")
 
-        if not self.__flexible:
-            # If using global see if the fixed M and X zones are too big
-            if app_part_bits + self.__n_bits_machine + self.__n_bits_atoms > \
-                    BITS_IN_KEY:
-                # We know from above test that all will fit if flexible
-                # Reduce the suggested size of n_bits_atoms
-                self.__n_bits_atoms = \
-                    BITS_IN_KEY - app_part_bits - self.__n_bits_machine
-                self.__n_bits_atoms_and_mac = BITS_IN_KEY - app_part_bits
-                logger.warning(
-                    "The ZonedRoutingInfoAllocator could not use the global "
-                    "approach for all vertexes.")
-            else:
-                # Set the size of atoms and machine for biggest of each
-                self.__n_bits_atoms_and_mac = \
-                    self.__n_bits_machine + self.__n_bits_atoms
+        self.__size_mac_atoms_bits = (
+                BITS_IN_KEY - self.__size_app_part_bits)
+        if self.__size_mac_atoms_bits >= (self.__max_bits_machine + self.__max_bits_atoms):
+            self.__target_atom_bits = self.__max_bits_atoms
+            self.__target_machine_bits = (
+                    self.__size_mac_atoms_bits - self.__max_bits_atoms)
+        else:
+            self.__target_atom_bits = (
+                    self.__size_mac_atoms_bits - self.__max_bits_machine)
+            self.__target_machine_bits = self.__max_bits_machine
 
     def __set_fixed_used(self, routing_infos: RoutingInfo) -> None:
         """
@@ -293,16 +285,14 @@ class ZonedRoutingInfoAllocator(object):
         # Case (3): the mask that overlaps AP is complex; all possible
         #           combinations of AP within the 0s of the mask will be
         #           blocked from use
-
-        n_app_part_bits = BITS_IN_KEY - self.__n_bits_atoms_and_mac
         for (partition_id, vertex), key_and_mask in self.__fixed_partitions.items():
             # Get the key and mask that overlap with the A-P key and mask
-            key = key_and_mask.key >> self.__n_bits_atoms_and_mac
-            mask = key_and_mask.mask >> self.__n_bits_atoms_and_mac
+            key = key_and_mask.key >> self.__min_bits_atoms_and_mac
+            mask = key_and_mask.mask >> self.__min_bits_atoms_and_mac
 
             # Make the mask all 1s in the MSBs where it has been shifted
-            mask |= (((1 << self.__n_bits_atoms_and_mac) - 1) <<
-                     n_app_part_bits)
+            mask |= (((1 << self.__min_bits_atoms_and_mac) - 1) <<
+                     self.__size_app_part_bits)
 
             # Generate all possible combinations of keys for the remaining
             # mask
@@ -319,6 +309,20 @@ class ZonedRoutingInfoAllocator(object):
                         vertex.splitter.get_out_going_vertices(partition_id))
                     if len(outgoing) == 0:
                         routing_infos.add_overlap(partition_id, outgoing)
+
+            ap_keys_available = 2**self.__size_app_part_bits
+            ap_keys_available -= len(self.__fixed_used)
+            if ap_keys_available < len(self.__vertex_partitions):
+                #  Oops need more bits
+                self.__size_app_part_bits += 1
+                if (self.__size_app_part_bits + self.__min_bits_atoms_and_mac >
+                        BITS_IN_KEY):
+                    raise PacmanRouteInfoAllocationException(
+                        "Unable to allocate with fixed keys")
+                # clear used
+                self.__fixed_used = set()
+                # No need to clear routing_infos overlap as all will repeat
+                self.__set_fixed_used(routing_infos)
 
     def __allocate_all_fixed(self,  routing_infos: RoutingInfo) -> None:
         progress = ProgressBar(
@@ -340,41 +344,50 @@ class ZonedRoutingInfoAllocator(object):
             len(self.__vertex_partitions), "Allocating routing keys")
         app_part_index = 0
         for pre, identifier in progress.over(self.__vertex_partitions):
-            while app_part_index in self.__fixed_used:
-                app_part_index += 1
             # Get a list of machine vertices ordered by pre-slice
             splitter = pre.splitter
             machine_vertices = list(splitter.get_out_going_vertices(
                 identifier))
             if not machine_vertices:
                 continue
-            machine_vertices.sort(key=lambda x: x.vertex_slice.lo_atom)
-            n_bits_atoms = self.__atom_bits_per_app_part[pre, identifier]
-            if self.__flexible:
-                n_bits_machine = self.__n_bits_atoms_and_mac - n_bits_atoms
-            else:
-                if n_bits_atoms <= self.__n_bits_atoms:
-                    # OK it fits use global sizes
-                    n_bits_atoms = self.__n_bits_atoms
-                    n_bits_machine = self.__n_bits_machine
-                else:
-                    # Nope need more bits! Use the flexible approach here
-                    n_bits_machine = self.__n_bits_atoms_and_mac - n_bits_atoms
 
-            for machine_index, machine_vertex in enumerate(machine_vertices):
-                id_mv = (identifier, machine_vertex)
-                if id_mv in self.__fixed_partitions:
-                    # Ignore zone calculations and just use fixed
+            id_mv =(identifier, machine_vertices[0])
+            fixed = id_mv in self.__fixed_partitions
+
+            if fixed:
+                for machine_index, machine_vertex in enumerate(
+                        machine_vertices):
+                    id_mv = (identifier, machine_vertex)
                     key_and_mask = self.__fixed_partitions[id_mv]
+                    routing_infos.add_routing_info(MachineVertexRoutingInfo(
+                        key_and_mask, identifier, machine_vertex,
+                        machine_index))
+                continue  # for pre
+
+            else:
+                while app_part_index in self.__fixed_used:
+                        app_part_index += 1
+
+                machine_vertices.sort(key=lambda x: x.vertex_slice.lo_atom)
+                n_bits_atoms = self.__atom_bits_per_app_part[pre, identifier]
+                if n_bits_atoms <= self.__target_atom_bits:
+                    # OK it fits use global sizes
+                    n_bits_machine = self.__target_machine_bits
+                    n_bits_atoms = self.__target_atom_bits
                 else:
+                    n_bits_machine = self.__size_mac_atoms_bits - n_bits_atoms
+                    needed = allocator_bits_needed(len(machine_vertices))
+                    assert (n_bits_machine >= needed)
+
+                for machine_index, machine_vertex in enumerate(machine_vertices):
                     mask = self.__mask(n_bits_atoms)
                     key = app_part_index
                     key = (key << n_bits_machine) | machine_index
                     key = key << n_bits_atoms
                     key_and_mask = BaseKeyAndMask(base_key=key, mask=mask)
-                routing_infos.add_routing_info(MachineVertexRoutingInfo(
-                    key_and_mask, identifier, machine_vertex,
-                    machine_index))
+                    routing_infos.add_routing_info(MachineVertexRoutingInfo(
+                        key_and_mask, identifier, machine_vertex,
+                        machine_index))
 
             # Add application-level routing information
             id_pr = (identifier, pre)
@@ -395,30 +408,3 @@ class ZonedRoutingInfoAllocator(object):
     @staticmethod
     def __mask(bits: int) -> int:
         return FULL_MASK - ((2 ** bits) - 1)
-
-
-def flexible_allocate(extra_allocations: _XAlloc) -> RoutingInfo:
-    """
-    Allocated with fixed bits for the Application/Partition index but
-    with the size of the atom and machine bit changing.
-
-    :param extra_allocations:
-        Additional (vertex, partition identifier) pairs to allocate
-        keys to.  These might not appear in partitions in the graph
-        due to being added by the system.
-    :return: The routing information, including the keys to be used.
-    :raise PacmanRouteInfoAllocationException:
-    """
-    return ZonedRoutingInfoAllocator(True).allocate(extra_allocations)
-
-
-def global_allocate(extra_allocations: _XAlloc) -> RoutingInfo:
-    """
-    :param extra_allocations:
-        Additional (vertex, partition identifier) pairs to allocate
-        keys to.  These might not appear in partitions in the graph
-        due to being added by the system.
-    :return: The routing information, including the keys to be used.
-    :raise PacmanRouteInfoAllocationException:
-    """
-    return ZonedRoutingInfoAllocator().allocate(extra_allocations)

--- a/pacman/operations/routing_info_allocator_algorithms/zoned_routing_info_allocator.py
+++ b/pacman/operations/routing_info_allocator_algorithms/zoned_routing_info_allocator.py
@@ -19,7 +19,7 @@ from spinn_utilities.progress_bar import ProgressBar
 from spinn_utilities.ordered_set import OrderedSet
 from pacman.model.routing_info import (
     RoutingInfo, MachineVertexRoutingInfo, BaseKeyAndMask,
-    AppVertexRoutingInfo, VertexRoutingInfo)
+    AppVertexRoutingInfo)
 from pacman.model.graphs.application import ApplicationVertex
 from pacman.model.graphs.machine import MachineVertex
 from pacman.utilities.utility_calls import (
@@ -289,18 +289,19 @@ class ZonedRoutingInfoAllocator(object):
 
     @classmethod
     def calc_overlaps(
-            cls, key_and_mask: VertexRoutingInfo, ap_zone: int) -> Set[int]:
+            cls, key: int, mask: int, ap_zone: int) -> Set[int]:
         """
         Which of the top bits could be used by this key and mask
 
-        :param key_and_mask: key and mask values (typically from fixed)
+        :param key: application vertex key
+        :param mask: application vertext mask
         :param ap_zone: number of bits in the application partition zone
         :return: Set of top zone values that need to be blocked.
         """
         mac_zone = BITS_IN_KEY - ap_zone
         # Get the key and mask that overlap with the A-P key and mask
-        key = key_and_mask.key >> mac_zone
-        mask = key_and_mask.mask >> mac_zone
+        key = key >> mac_zone
+        mask = mask >> mac_zone
         # Make the mask all 1s in the MSBs where it has been shifted
         mask |= (((1 << mac_zone) - 1) << ap_zone)
 
@@ -331,7 +332,8 @@ class ZonedRoutingInfoAllocator(object):
                 continue
             key_and_mask = routing_info.get_info_from(pre, identifier)
             blocked = self.calc_overlaps(
-                key_and_mask, self.__size_app_part_bits)
+                key_and_mask.key, key_and_mask.mask,
+                self.__size_app_part_bits)
 
             if blocked:
                 self.__ap_keys_blocked_by_fixed.update(blocked)

--- a/pacman/operations/routing_info_allocator_algorithms/zoned_routing_info_allocator.py
+++ b/pacman/operations/routing_info_allocator_algorithms/zoned_routing_info_allocator.py
@@ -19,8 +19,7 @@ from spinn_utilities.progress_bar import ProgressBar
 from spinn_utilities.ordered_set import OrderedSet
 from pacman.model.routing_info import (
     RoutingInfo, MachineVertexRoutingInfo, BaseKeyAndMask,
-    AppVertexRoutingInfo)
-from pacman.model.graphs import AbstractVertex
+    AppVertexRoutingInfo, VertexRoutingInfo)
 from pacman.model.graphs.application import ApplicationVertex
 from pacman.model.graphs.machine import MachineVertex
 from pacman.utilities.utility_calls import (
@@ -266,26 +265,32 @@ class ZonedRoutingInfoAllocator(object):
                 BITS_IN_KEY):
             raise PacmanRouteInfoAllocationException(
                 "Unable to use ZonedRoutingInfoAllocator please select a "
-                f"different allocator as it needs {self.__app_part_bits} + "
-                f"{self.__min_bits_atoms_and_mac} bits")
+                f"different allocator as it needs {self.__size_app_part_bits} "
+                f"+ {self.__min_bits_atoms_and_mac} bits")
 
         # Reserve fixed and check it still works
         self.__set_fixed_used(routing_infos)
 
         self.__size_mac_atoms_bits = (
                 BITS_IN_KEY - self.__size_app_part_bits)
-        if self.__size_mac_atoms_bits >= (self.__max_bits_machine + self.__max_bits_atoms):
+
+        if self.__size_mac_atoms_bits >= (
+                self.__max_bits_machine + self.__max_bits_atoms):
+            # Fits nicely add extra bits to the machine zone
             self.__target_atom_bits = self.__max_bits_atoms
             self.__target_machine_bits = (
                     self.__size_mac_atoms_bits - self.__max_bits_atoms)
         else:
+            # Does not fit so remove bits from the atom zone
+            # Likely only a few very big machine vertices will need them
+            # they will then flow into the machine zone
             self.__target_atom_bits = (
                     self.__size_mac_atoms_bits - self.__max_bits_machine)
             self.__target_machine_bits = self.__max_bits_machine
 
     @classmethod
     def calc_overlaps(
-            cls, key_and_mask: BaseKeyAndMask, ap_zone: int) -> Set[int]:
+            cls, key_and_mask: VertexRoutingInfo, ap_zone: int) -> Set[int]:
         """
         Which of the top bits could be used by this key and mask
 
@@ -407,7 +412,6 @@ class ZonedRoutingInfoAllocator(object):
             self.__max_bits_machine, self.__max_bits_atoms,
             self.__size_app_part_bits, self.__size_mac_atoms_bits,
             self.__target_machine_bits, self.__target_atom_bits)
-        return routing_info
 
     @staticmethod
     def __mask(bits: int) -> int:

--- a/pacman/operations/routing_info_allocator_algorithms/zoned_routing_info_allocator.py
+++ b/pacman/operations/routing_info_allocator_algorithms/zoned_routing_info_allocator.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import logging
-from typing import Dict, FrozenSet, Iterable, Set, Tuple, cast
+from typing import Dict, Iterable, Set, Tuple, cast
 from spinn_utilities.log import FormatAdapter
 from spinn_utilities.progress_bar import ProgressBar
 from spinn_utilities.ordered_set import OrderedSet
@@ -101,7 +101,6 @@ class ZonedRoutingInfoAllocator(object):
         "__fixed_used",
         # True if all partitions are fixed
         "__all_fixed")
-    __FROZEN: FrozenSet = frozenset()
 
     def __init__(self, flexible: bool = False):
         """
@@ -118,7 +117,7 @@ class ZonedRoutingInfoAllocator(object):
         self.__flexible = flexible
         self.__fixed_partitions: Dict[
             Tuple[str, AbstractVertex], BaseKeyAndMask] = dict()
-        self.__fixed_used: Set[int] = cast(Set, self.__FROZEN)
+        self.__fixed_used: Set[int] = set()
         self.__all_fixed = True
 
     def allocate(self, extra_allocations: _XAlloc) -> RoutingInfo:
@@ -293,7 +292,6 @@ class ZonedRoutingInfoAllocator(object):
         #           combinations of AP within the 0s of the mask will be
         #           blocked from use
 
-        self.__fixed_used = set()
         n_app_part_bits = BITS_IN_KEY - self.__n_bits_atoms_and_mac
         for key_and_mask in self.__fixed_partitions.values():
             # Get the key and mask that overlap with the A-P key and mask

--- a/pacman/operations/routing_info_allocator_algorithms/zoned_routing_info_allocator.py
+++ b/pacman/operations/routing_info_allocator_algorithms/zoned_routing_info_allocator.py
@@ -92,11 +92,11 @@ class ZonedRoutingInfoAllocator(object):
         # For each App vertex / Partition name zone keep track of the number of
         # bites required for the mask for each machine vertex
         "__atom_bits_per_app_part",
-        # maximum number of bites to represent the keys and masks
+        # Minimun size needed for the machine and atoms zone
+        # This is the maximum represent the keys and masks
         # for a single app vertex / partition name zone
-        # This is therefor the minimum size for the combine zone
         "__min_bits_atoms_and_mac",
-        # Maximum number of bits to represent the machine for any vertex
+        # Maximum number of bits to represent the machines for any vertex
         "__max_bits_machine",
         # Maximum number of bits to represent the atoms for any vertex
         "__max_bits_atoms",
@@ -319,9 +319,9 @@ class ZonedRoutingInfoAllocator(object):
                 overlap = True
 
             if overlap:
-                routing_info.add_overlap(identifier, pre)
+                routing_info.add_ap_overlap(identifier, pre)
                 for outgoing in pre.splitter.get_out_going_vertices(identifier):
-                    routing_info.add_overlap(identifier, outgoing)
+                    routing_info.add_ap_overlap(identifier, outgoing)
 
             ap_keys_available = 2**self.__size_app_part_bits
             ap_keys_available -= len(self.__ap_keys_blocked_by_fixed)
@@ -361,11 +361,13 @@ class ZonedRoutingInfoAllocator(object):
                 # OK it fits use global sizes
                 n_bits_machine = self.__target_machine_bits
                 n_bits_atoms = self.__target_atom_bits
+                overlap = False
             else:
                 n_bits_machine = self.__size_mac_atoms_bits - n_bits_atoms
                 needed = allocator_bits_needed(len(machine_vertices))
                 assert (n_bits_machine >= needed)
-
+                overlap = True
+                routing_info.add_mx_overlap(identifier, pre)
             for machine_index, machine_vertex in enumerate(machine_vertices):
                 mask = self.__mask(n_bits_atoms)
                 key = app_part_index
@@ -375,6 +377,8 @@ class ZonedRoutingInfoAllocator(object):
                 routing_info.add_routing_info(MachineVertexRoutingInfo(
                     key_and_mask, identifier, machine_vertex,
                     machine_index))
+                if overlap:
+                    routing_info.add_mx_overlap(identifier, machine_vertex)
 
             # Add application-level routing information
             key = app_part_index << (n_bits_atoms + n_bits_machine)
@@ -386,6 +390,11 @@ class ZonedRoutingInfoAllocator(object):
                 len(machine_vertices) - 1))
             app_part_index += 1
 
+        routing_info.add_zones(
+            self.__min_bits_atoms_and_mac,
+            self.__max_bits_machine, self.__max_bits_atoms,
+            self.__size_app_part_bits, self.__size_mac_atoms_bits,
+            self.__target_machine_bits, self.__target_atom_bits)
         return routing_info
 
     @staticmethod

--- a/unittests/operations_tests/routing_info_algorithms_tests/test_zoned_routing_allocator.py
+++ b/unittests/operations_tests/routing_info_algorithms_tests/test_zoned_routing_allocator.py
@@ -17,6 +17,7 @@ from spinn_utilities.overrides import overrides
 
 from pacman.config_setup import unittest_setup
 from pacman.data import PacmanDataView
+from pacman.exceptions import PacmanRouteInfoAllocationException
 from pacman.operations.routing_info_allocator_algorithms.\
     zoned_routing_info_allocator import ZonedRoutingInfoAllocator
 from pacman.model.graphs.application import ApplicationEdge, ApplicationVertex
@@ -27,7 +28,6 @@ from pacman.model.graphs.machine.machine_vertex import MachineVertex
 from pacman.model.partitioner_splitters import AbstractSplitterCommon
 from pacman.model.routing_info import RoutingInfo, MachineVertexRoutingInfo
 from pacman.utilities.utility_objs.chip_counter import ChipCounter
-
 
 class MockSplitter(AbstractSplitterCommon):
 
@@ -558,3 +558,43 @@ def test_blocked_low() -> None:
     assert len(blocked) == 1
     for block in [0x000]:
         assert block in blocked
+
+
+def create_many_machine_mask() -> None:
+    fixed_machine_keys_by_partition: \
+        Optional[Dict[Tuple[MachineVertex, str], BaseKeyAndMask]] = dict()
+    fixed_app_vertex = MockAppVertex(
+        splitter=MockSplitter(), fixed_key=BaseKeyAndMask(0, 0xffffff00),
+        fixed_machine_keys_by_partition=fixed_machine_keys_by_partition)
+    PacmanDataView.add_vertex(fixed_app_vertex)
+    # Create a single output vertex (which won't send)
+    out_app_vertex = MockAppVertex(splitter=MockSplitter())
+    PacmanDataView.add_vertex(out_app_vertex)
+
+    PacmanDataView.add_edge(
+        ApplicationEdge(fixed_app_vertex, out_app_vertex), "Test")
+
+    # Create a single big machine vertex
+    fixed_mac_vertex1 = TestMacVertex(
+        label="fixed 1", n_keys_required={"Test": 8},
+        app_vertex=fixed_app_vertex)
+    fixed_app_vertex.remember_machine_vertex(fixed_mac_vertex1)
+    fixed_machine_keys_by_partition[(fixed_mac_vertex1, "Test")] = (
+        BaseKeyAndMask(0, 0xfffffff0))
+
+    fixed_mac_vertex2 = TestMacVertex(
+        label="fixed 2", n_keys_required={"Test": 8},
+        app_vertex=fixed_app_vertex)
+    fixed_app_vertex.remember_machine_vertex(fixed_mac_vertex2)
+    fixed_machine_keys_by_partition[(fixed_mac_vertex2, "Test")] = (
+        BaseKeyAndMask(0, 0xffffff0f))
+
+
+def test_many_machine_mask() -> None:
+    unittest_setup()
+    create_many_machine_mask()
+    try:
+        ZonedRoutingInfoAllocator().allocate()
+        raise Exception("PacmanRouteInfoAllocationExceptio not raise")
+    except PacmanRouteInfoAllocationException:
+        pass

--- a/unittests/operations_tests/routing_info_algorithms_tests/test_zoned_routing_allocator.py
+++ b/unittests/operations_tests/routing_info_algorithms_tests/test_zoned_routing_allocator.py
@@ -303,6 +303,8 @@ def test_global_allocator() -> None:
     app_mask = 0xFFFF8000
     check_keys_for_application_partition_pairs(routing_info, app_mask)
 
+    assert not routing_info.has_overlap()
+
 
 def test_flexible_allocator_no_fixed() -> None:
     unittest_setup()
@@ -317,6 +319,8 @@ def test_flexible_allocator_no_fixed() -> None:
     app_mask = 0xFFFF8000
     check_keys_for_application_partition_pairs(routing_info, app_mask)
 
+    assert not routing_info.has_overlap()
+
 
 def test_fixed_only() -> None:
     unittest_setup()
@@ -325,13 +329,24 @@ def test_fixed_only() -> None:
     routing_info = global_allocate([])
     assert len(list(routing_info)) == 4
 
+    assert routing_info.has_overlap()
+    # all overlap
+    for partition in PacmanDataView.iterate_partitions():
+        assert routing_info.check_overlap(
+            partition.identifier, partition.pre_vertex)
 
 def test_overlap() -> None:
     # This should work here; overlap is allowed provided routes don't overlap
     # (which is found elsewhere)
     unittest_setup()
     create_graphs_only_fixed(overlap=True)
-    flexible_allocate([])
+    routing_info = flexible_allocate([])
+
+    assert routing_info.has_overlap()
+    # all overlap
+    for partition in PacmanDataView.iterate_partitions():
+        assert routing_info.check_overlap(
+            partition.identifier, partition.pre_vertex)
 
 
 def test_no_edge() -> None:
@@ -340,6 +355,7 @@ def test_no_edge() -> None:
     flexible_allocate([])
     routing_info = global_allocate([])
     assert len(list(routing_info)) == 0
+    assert not routing_info.has_overlap()
 
 
 def test_flexible_allocator_with_fixed() -> None:
@@ -353,6 +369,8 @@ def test_flexible_allocator_with_fixed() -> None:
     # all but the bottom 8 + 7 = 15 bits should be the same
     app_mask = 0xFFFF8000
     check_keys_for_application_partition_pairs(routing_info, app_mask)
+
+    assert routing_info.has_overlap()
 
 
 def create_big(with_fixed: bool) -> None:
@@ -407,6 +425,8 @@ def test_big_flexible_no_fixed() -> None:
     app_mask = 0xFFE00000
     check_keys_for_application_partition_pairs(routing_info, app_mask)
 
+    assert not routing_info.has_overlap()
+
 
 def test_big_global_no_fixed() -> None:
     unittest_setup()
@@ -424,6 +444,8 @@ def test_big_global_no_fixed() -> None:
     app_mask = 0x80000000
     check_keys_for_application_partition_pairs(routing_info, app_mask)
 
+    assert not routing_info.has_overlap()
+
 
 def test_big_flexible_fixed() -> None:
     unittest_setup()
@@ -435,6 +457,8 @@ def test_big_flexible_fixed() -> None:
     # all but the bottom 18 bits should be the same
     app_mask = 0xFFFC0000
     check_keys_for_application_partition_pairs(routing_info, app_mask)
+
+    assert routing_info.has_overlap()
 
 
 def test_big_global_fixed() -> None:
@@ -452,3 +476,5 @@ def test_big_global_fixed() -> None:
     # all but the top 1 bits should be the same
     app_mask = 0xFFFC0000
     check_keys_for_application_partition_pairs(routing_info, app_mask)
+
+    assert routing_info.has_overlap()

--- a/unittests/operations_tests/routing_info_algorithms_tests/test_zoned_routing_allocator.py
+++ b/unittests/operations_tests/routing_info_algorithms_tests/test_zoned_routing_allocator.py
@@ -579,15 +579,15 @@ def create_many_machine_mask() -> None:
         label="fixed 1", n_keys_required={"Test": 8},
         app_vertex=fixed_app_vertex)
     fixed_app_vertex.remember_machine_vertex(fixed_mac_vertex1)
-    fixed_machine_keys_by_partition[(fixed_mac_vertex1, "Test")] = (
-        BaseKeyAndMask(0, 0xfffffff0))
+    fixed_machine_keys_by_partition[
+        fixed_mac_vertex1, "Test"] = BaseKeyAndMask(0, 0xfffffff0)
 
     fixed_mac_vertex2 = TestMacVertex(
         label="fixed 2", n_keys_required={"Test": 8},
         app_vertex=fixed_app_vertex)
     fixed_app_vertex.remember_machine_vertex(fixed_mac_vertex2)
-    fixed_machine_keys_by_partition[(fixed_mac_vertex2, "Test")] = (
-        BaseKeyAndMask(0, 0xffffff0f))
+    fixed_machine_keys_by_partition[
+        fixed_mac_vertex2, "Test"] = BaseKeyAndMask(0, 0xffffff0f)
 
 
 def test_many_machine_mask() -> None:

--- a/unittests/operations_tests/routing_info_algorithms_tests/test_zoned_routing_allocator.py
+++ b/unittests/operations_tests/routing_info_algorithms_tests/test_zoned_routing_allocator.py
@@ -306,7 +306,7 @@ def test_allocator_no_fixed() -> None:
     assert not routing_info.has_ap_overlap()
     assert not routing_info.has_mx_overlap()
 
-    assert routing_info.min_bits_atoms_and_mac == 15
+    assert routing_info.min_bits_machine_and_atoms == 15
     assert routing_info.max_bits_machine == 7
     assert routing_info.max_bits_atoms == 8
     assert routing_info.size_app_part_bits == 7
@@ -327,7 +327,7 @@ def test_fixed_only() -> None:
         assert routing_info.check_ap_overlap(
             partition.identifier, partition.pre_vertex)
 
-    assert routing_info.min_bits_atoms_and_mac == 0
+    assert routing_info.min_bits_machine_and_atoms == 0
     assert routing_info.max_bits_machine == 0
     assert routing_info.max_bits_atoms == 0
     assert routing_info.size_app_part_bits == 2
@@ -352,7 +352,7 @@ def test_overlap() -> None:
         assert routing_info.check_ap_overlap(
             partition.identifier, partition.pre_vertex)
 
-    assert routing_info.min_bits_atoms_and_mac == 0
+    assert routing_info.min_bits_machine_and_atoms == 0
     assert routing_info.max_bits_machine == 0
     assert routing_info.max_bits_atoms == 0
     assert routing_info.size_app_part_bits == 2
@@ -371,7 +371,7 @@ def test_no_edge() -> None:
     assert len(list(routing_info)) == 0
     assert not routing_info.has_ap_overlap()
 
-    assert routing_info.min_bits_atoms_and_mac == 0
+    assert routing_info.min_bits_machine_and_atoms == 0
     assert routing_info.max_bits_machine == 0
     assert routing_info.max_bits_atoms == 0
     assert routing_info.size_app_part_bits == 0
@@ -395,7 +395,7 @@ def test_allocator_with_fixed() -> None:
     app_mask = 0xFFFF8000
     check_keys_for_application_partition_pairs(routing_info, app_mask)
 
-    assert routing_info.min_bits_atoms_and_mac == 15
+    assert routing_info.min_bits_machine_and_atoms == 15
     assert routing_info.max_bits_machine == 7
     assert routing_info.max_bits_atoms == 8
     assert routing_info.size_app_part_bits == 7
@@ -466,7 +466,7 @@ def test_big_no_fixed() -> None:
     assert not routing_info.has_ap_overlap()
     assert 2 == len(list(routing_info.get_mx_overlaps()))
 
-    assert routing_info.min_bits_atoms_and_mac == 21
+    assert routing_info.min_bits_machine_and_atoms == 21
     assert routing_info.max_bits_machine == 11
     assert routing_info.max_bits_atoms == 21
     assert routing_info.size_app_part_bits == 1
@@ -494,7 +494,7 @@ def test_big_fixed() -> None:
     assert 2 == len(list(routing_info.get_ap_overlaps()))
     assert 2 == len(list(routing_info.get_mx_overlaps()))
 
-    assert routing_info.min_bits_atoms_and_mac == 18
+    assert routing_info.min_bits_machine_and_atoms == 18
     assert routing_info.max_bits_machine == 11
     assert routing_info.max_bits_atoms == 7  # Big is fixed
     assert routing_info.size_app_part_bits == 12  # After overlaps

--- a/unittests/operations_tests/routing_info_algorithms_tests/test_zoned_routing_allocator.py
+++ b/unittests/operations_tests/routing_info_algorithms_tests/test_zoned_routing_allocator.py
@@ -23,6 +23,7 @@ from pacman.model.graphs.application import ApplicationEdge, ApplicationVertex
 from pacman.model.graphs.common import Slice
 from pacman.model.resources import AbstractSDRAM
 from pacman.model.routing_info.base_key_and_mask import BaseKeyAndMask
+from pacman.model.routing_info.vertex_routing_info import VertexRoutingInfo
 from pacman.model.graphs.machine.machine_vertex import MachineVertex
 from pacman.model.partitioner_splitters import AbstractSplitterCommon
 from pacman.model.routing_info import RoutingInfo, MachineVertexRoutingInfo
@@ -496,7 +497,8 @@ def test_blocked_simple() -> None:
     mask = 0xFF000000
     key = 0x10000000
     key_and_mask = BaseKeyAndMask(key, mask)
-    blocked = ZonedRoutingInfoAllocator.calc_overlaps(key_and_mask, 12)
+    info = VertexRoutingInfo(key_and_mask, "bacon")
+    blocked = ZonedRoutingInfoAllocator.calc_overlaps(info, 12)
     assert len(blocked) == 16
     for block in [0x100, 0x101, 0x102, 0x103, 0x104, 0x105, 0x106, 0x107,
                   0x108, 0x109, 0x10a, 0x10b, 0x10c, 0x10d, 0x10e, 0x10f]:
@@ -507,7 +509,8 @@ def test_blocked_fancy() -> None:
     mask = 0xF0F00000
     key = 0x10000000
     key_and_mask = BaseKeyAndMask(key, mask)
-    blocked = ZonedRoutingInfoAllocator.calc_overlaps(key_and_mask, 12)
+    info = VertexRoutingInfo(key_and_mask, "bacon")
+    blocked = ZonedRoutingInfoAllocator.calc_overlaps(info, 12)
     assert len(blocked) == 16
     for block in [0x100, 0x110, 0x120, 0x130, 0x140, 0x150, 0x160, 0x170,
                   0x180, 0x190, 0x1a0, 0x1b0, 0x1c0, 0x1d0, 0x1e0, 0x1f0]:

--- a/unittests/operations_tests/routing_info_algorithms_tests/test_zoned_routing_allocator.py
+++ b/unittests/operations_tests/routing_info_algorithms_tests/test_zoned_routing_allocator.py
@@ -305,6 +305,14 @@ def test_allocator_no_fixed() -> None:
 
     assert not routing_info.has_ap_overlap()
 
+    assert routing_info.min_bits_atoms_and_mac == 15
+    assert routing_info.max_bits_machine == 7
+    assert routing_info.max_bits_atoms == 8
+    assert routing_info.size_app_part_bits == 7
+    assert routing_info.size_mac_atoms_bits == 25
+    assert routing_info.target_machine_bits == 17
+    assert routing_info.target_atom_bits == 8
+
 
 def test_fixed_only() -> None:
     unittest_setup()
@@ -318,17 +326,13 @@ def test_fixed_only() -> None:
         assert routing_info.check_ap_overlap(
             partition.identifier, partition.pre_vertex)
 
-    [min_bits_atoms_and_mac,
-     max_bits_machine, max_bits_atoms,
-     size_app_part_bits, size_mac_atoms_bits,
-     target_machine_bits, target_atom_bits] = routing_info.get_zones()
-    assert min_bits_atoms_and_mac == 0
-    assert max_bits_machine == 0
-    assert max_bits_atoms == 0
-    assert size_app_part_bits == 3
-    assert size_mac_atoms_bits == 29
-    assert target_machine_bits == 29
-    assert target_atom_bits == 0
+    assert routing_info.min_bits_atoms_and_mac == 0
+    assert routing_info.max_bits_machine == 0
+    assert routing_info.max_bits_atoms == 0
+    assert routing_info.size_app_part_bits == 2
+    assert routing_info.size_mac_atoms_bits == 30
+    assert routing_info.target_machine_bits == 30
+    assert routing_info.target_atom_bits == 0
 
 
 def test_overlap() -> None:
@@ -344,17 +348,13 @@ def test_overlap() -> None:
         assert routing_info.check_ap_overlap(
             partition.identifier, partition.pre_vertex)
 
-    [min_bits_atoms_and_mac,
-     max_bits_machine, max_bits_atoms,
-     size_app_part_bits, size_mac_atoms_bits,
-     target_machine_bits, target_atom_bits] = routing_info.get_zones()
-    assert min_bits_atoms_and_mac == 0
-    assert max_bits_machine == 0
-    assert max_bits_atoms == 0
-    assert size_app_part_bits == 17
-    assert size_mac_atoms_bits == 15
-    assert target_machine_bits == 15
-    assert target_atom_bits == 0
+    assert routing_info.min_bits_atoms_and_mac == 0
+    assert routing_info.max_bits_machine == 0
+    assert routing_info.max_bits_atoms == 0
+    assert routing_info.size_app_part_bits == 2
+    assert routing_info.size_mac_atoms_bits == 30
+    assert routing_info.target_machine_bits == 30
+    assert routing_info.target_atom_bits == 0
 
 
 def test_no_edge() -> None:
@@ -363,18 +363,14 @@ def test_no_edge() -> None:
     routing_info = ZonedRoutingInfoAllocator().allocate()
     assert len(list(routing_info)) == 0
     assert not routing_info.has_ap_overlap()
-    [min_bits_atoms_and_mac,
-     max_bits_machine, max_bits_atoms,
-     size_app_part_bits, size_mac_atoms_bits,
-     target_machine_bits, target_atom_bits] = routing_info.get_zones()
-    assert min_bits_atoms_and_mac == 0
-    assert max_bits_machine == 0
-    assert max_bits_atoms == 0
-    assert size_app_part_bits == 0
-    assert size_mac_atoms_bits == 32
-    assert target_machine_bits == 32
-    assert target_atom_bits == 0
 
+    assert routing_info.min_bits_atoms_and_mac == 0
+    assert routing_info.max_bits_machine == 0
+    assert routing_info.max_bits_atoms == 0
+    assert routing_info.size_app_part_bits == 0
+    assert routing_info.size_mac_atoms_bits == 32
+    assert routing_info.target_machine_bits == 32
+    assert routing_info.target_atom_bits == 0
 
 
 def test_allocator_with_fixed() -> None:
@@ -390,18 +386,14 @@ def test_allocator_with_fixed() -> None:
     check_keys_for_application_partition_pairs(routing_info, app_mask)
 
     assert routing_info.has_ap_overlap()
-    [min_bits_atoms_and_mac,
-     max_bits_machine, max_bits_atoms,
-     size_app_part_bits, size_mac_atoms_bits,
-     target_machine_bits, target_atom_bits] = routing_info.get_zones()
-    assert min_bits_atoms_and_mac == 15
-    assert max_bits_machine == 7
-    assert max_bits_atoms == 8
-    assert size_app_part_bits == 10
-    assert size_mac_atoms_bits == 22
-    assert target_machine_bits == 14
-    assert target_atom_bits == 8
 
+    assert routing_info.min_bits_atoms_and_mac == 15
+    assert routing_info.max_bits_machine == 7
+    assert routing_info.max_bits_atoms == 8
+    assert routing_info.size_app_part_bits == 7
+    assert routing_info.size_mac_atoms_bits == 25
+    assert routing_info.target_machine_bits == 17
+    assert routing_info.target_atom_bits == 8
 
 
 def create_big(with_fixed: bool) -> None:
@@ -443,7 +435,8 @@ def create_big(with_fixed: bool) -> None:
             app_vertex=mid_app_vertex)
         mid_app_vertex.remember_machine_vertex(mid_mac_vertex)
 
-def test_big_global_no_fixed() -> None:
+
+def test_big_no_fixed() -> None:
     unittest_setup()
     create_big(False)
     routing_info = ZonedRoutingInfoAllocator().allocate()
@@ -462,20 +455,16 @@ def test_big_global_no_fixed() -> None:
     assert not routing_info.has_ap_overlap()
     assert routing_info.has_mx_overlap()
 
-    [min_bits_atoms_and_mac,
-     max_bits_machine, max_bits_atoms,
-     size_app_part_bits, size_mac_atoms_bits,
-     target_machine_bits, target_atom_bits] = routing_info.get_zones()
-    assert min_bits_atoms_and_mac == 21
-    assert max_bits_machine == 11
-    assert max_bits_atoms == 21
-    assert size_app_part_bits == 1
-    assert size_mac_atoms_bits == 31
-    assert target_machine_bits == 11
-    assert target_atom_bits == 20
+    assert routing_info.min_bits_atoms_and_mac == 21
+    assert routing_info.max_bits_machine == 11
+    assert routing_info.max_bits_atoms == 21
+    assert routing_info.size_app_part_bits == 1
+    assert routing_info.size_mac_atoms_bits == 31
+    assert routing_info.target_machine_bits == 11
+    assert routing_info.target_atom_bits == 20
 
 
-def test_big_global_fixed() -> None:
+def test_big_fixed() -> None:
     unittest_setup()
     create_big(True)
     routing_info = ZonedRoutingInfoAllocator().allocate()
@@ -494,14 +483,32 @@ def test_big_global_fixed() -> None:
     assert routing_info.has_ap_overlap()
     assert not routing_info.has_mx_overlap()
 
-    [min_bits_atoms_and_mac,
-     max_bits_machine, max_bits_atoms,
-     size_app_part_bits, size_mac_atoms_bits,
-     target_machine_bits, target_atom_bits] = routing_info.get_zones()
-    assert min_bits_atoms_and_mac == 18
-    assert max_bits_machine == 11
-    assert max_bits_atoms == 7  # Big is fixed
-    assert size_app_part_bits == 13  # After overlaps
-    assert size_mac_atoms_bits == 19
-    assert target_machine_bits == 12
-    assert target_atom_bits == 7
+    assert routing_info.min_bits_atoms_and_mac == 18
+    assert routing_info.max_bits_machine == 11
+    assert routing_info.max_bits_atoms == 7  # Big is fixed
+    assert routing_info.size_app_part_bits == 12 # After overlaps
+    assert routing_info.size_mac_atoms_bits == 20
+    assert routing_info.target_machine_bits == 13
+    assert routing_info.target_atom_bits == 7
+
+
+def test_blocked_simple() -> None:
+    mask = 0xFF000000
+    key = 0x10000000
+    key_and_mask = BaseKeyAndMask(key, mask)
+    blocked = ZonedRoutingInfoAllocator.calc_overlaps(key_and_mask, 12)
+    assert len(blocked) == 16
+    for block in [0x100, 0x101, 0x102, 0x103, 0x104, 0x105, 0x106, 0x107,
+                  0x108, 0x109, 0x10a, 0x10b, 0x10c, 0x10d, 0x10e, 0x10f]:
+        assert block in blocked
+
+
+def test_blocked_fancy() -> None:
+    mask = 0xF0F00000
+    key = 0x10000000
+    key_and_mask = BaseKeyAndMask(key, mask)
+    blocked = ZonedRoutingInfoAllocator.calc_overlaps(key_and_mask, 12)
+    assert len(blocked) == 16
+    for block in [0x100, 0x110, 0x120, 0x130, 0x140, 0x150, 0x160, 0x170,
+                  0x180, 0x190, 0x1a0, 0x1b0, 0x1c0, 0x1d0, 0x1e0, 0x1f0]:
+        assert block in blocked

--- a/unittests/operations_tests/routing_info_algorithms_tests/test_zoned_routing_allocator.py
+++ b/unittests/operations_tests/routing_info_algorithms_tests/test_zoned_routing_allocator.py
@@ -407,12 +407,13 @@ def test_allocator_with_fixed() -> None:
     assert 146 == len(list(routing_info.get_mx_overlaps()))
 
 
-def create_big(with_fixed: bool) -> None:
+def create_big(fixed_mask: Optional[int]) -> None:
     # This test shows how easy it is to trip up the allocator with a retina
     # Create a single "big" vertex
-    fixed_key = None
-    if with_fixed:
-        fixed_key = BaseKeyAndMask(0x0, 0x180000)
+    if fixed_mask is None:
+        fixed_key = None
+    else:
+        fixed_key = BaseKeyAndMask(0x0, fixed_mask)
     big_app_vertex = MockAppVertex(
         splitter=MockSplitter(), fixed_key=fixed_key)
     PacmanDataView.add_vertex(big_app_vertex)
@@ -449,7 +450,7 @@ def create_big(with_fixed: bool) -> None:
 
 def test_big_no_fixed() -> None:
     unittest_setup()
-    create_big(False)
+    create_big(None)
     routing_info = ZonedRoutingInfoAllocator().allocate()
 
     # 1 for app 11 for machine so where possible use 20 for atoms
@@ -475,9 +476,9 @@ def test_big_no_fixed() -> None:
     assert routing_info.target_atom_bits == 20
 
 
-def test_big_fixed() -> None:
+def test_big_fixed_high() -> None:
     unittest_setup()
-    create_big(True)
+    create_big(0x180000)
     routing_info = ZonedRoutingInfoAllocator().allocate()
 
     # 7 bit atoms is 7 as it ignore the retina
@@ -502,6 +503,33 @@ def test_big_fixed() -> None:
     assert routing_info.target_machine_bits == 13
     assert routing_info.target_atom_bits == 7
 
+def test_big_fixed_low() -> None:
+    unittest_setup()
+    create_big(0xFFF00000)
+    routing_info = ZonedRoutingInfoAllocator().allocate()
+
+    # 7 bit atoms is 7 as it ignore the retina
+    mask = 0xFFFFFF80
+    check_masks_all_the_same(routing_info, mask)
+
+    # The number of bits is 1 + 11 + 21, so it will not fit
+    # So flexible for the retina
+    # Others mask all bit minimum app bits (1)
+    # all but the top 1 bits should be the same
+    app_mask = 0xFFFC0000
+    check_keys_for_application_partition_pairs(routing_info, app_mask)
+
+    assert 2 == len(list(routing_info.get_ap_overlaps()))
+    assert 2 == len(list(routing_info.get_mx_overlaps()))
+
+    assert routing_info.min_bits_machine_and_atoms == 18
+    assert routing_info.max_bits_machine == 11
+    assert routing_info.max_bits_atoms == 7  # Big is fixed
+    assert routing_info.size_app_part_bits == 2
+    assert routing_info.size_mac_atoms_bits == 30
+    assert routing_info.target_machine_bits == 23
+    assert routing_info.target_atom_bits == 7
+
 
 def test_blocked_simple() -> None:
     mask = 0xFF000000
@@ -520,4 +548,13 @@ def test_blocked_fancy() -> None:
     assert len(blocked) == 16
     for block in [0x100, 0x110, 0x120, 0x130, 0x140, 0x150, 0x160, 0x170,
                   0x180, 0x190, 0x1a0, 0x1b0, 0x1c0, 0x1d0, 0x1e0, 0x1f0]:
+        assert block in blocked
+
+
+def test_blocked_low() -> None:
+    mask = 0xFFF00000
+    key = 0x00000000
+    blocked = ZonedRoutingInfoAllocator.calc_overlaps(key, mask, 12)
+    assert len(blocked) == 1
+    for block in [0x000]:
         assert block in blocked

--- a/unittests/operations_tests/routing_info_algorithms_tests/test_zoned_routing_allocator.py
+++ b/unittests/operations_tests/routing_info_algorithms_tests/test_zoned_routing_allocator.py
@@ -486,7 +486,7 @@ def test_big_fixed() -> None:
     assert routing_info.min_bits_atoms_and_mac == 18
     assert routing_info.max_bits_machine == 11
     assert routing_info.max_bits_atoms == 7  # Big is fixed
-    assert routing_info.size_app_part_bits == 12 # After overlaps
+    assert routing_info.size_app_part_bits == 12  # After overlaps
     assert routing_info.size_mac_atoms_bits == 20
     assert routing_info.target_machine_bits == 13
     assert routing_info.target_atom_bits == 7

--- a/unittests/operations_tests/routing_info_algorithms_tests/test_zoned_routing_allocator.py
+++ b/unittests/operations_tests/routing_info_algorithms_tests/test_zoned_routing_allocator.py
@@ -18,7 +18,7 @@ from spinn_utilities.overrides import overrides
 from pacman.config_setup import unittest_setup
 from pacman.data import PacmanDataView
 from pacman.operations.routing_info_allocator_algorithms.\
-    zoned_routing_info_allocator import (flexible_allocate, global_allocate)
+    zoned_routing_info_allocator import ZonedRoutingInfoAllocator
 from pacman.model.graphs.application import ApplicationEdge, ApplicationVertex
 from pacman.model.graphs.common import Slice
 from pacman.model.resources import AbstractSDRAM
@@ -248,6 +248,9 @@ def check_masks_all_the_same(routing_info: RoutingInfo, mask: int) -> None:
     seen_keys = set()
     for r_info in routing_info:
         if isinstance(r_info.vertex, MachineVertex):
+            print(f"{hex(r_info.mask)} {r_info.machine_vertex.label}")
+    for r_info in routing_info:
+        if isinstance(r_info.vertex, MachineVertex):
             assert isinstance(r_info, MachineVertexRoutingInfo)
             assert (r_info.mask == mask or
                     r_info.machine_vertex.label == "RETINA")
@@ -286,14 +289,14 @@ def check_keys_for_application_partition_pairs(
                 assert (key & app_mask) != 0
 
 
-def test_global_allocator() -> None:
+def test_allocator_no_fixed() -> None:
     unittest_setup()
 
     # Allocate something and check it does the right thing
     create_graphs1(False)
 
     # The number of bits is 7 + 5 + 8 = 20, so it shouldn't fail
-    routing_info = global_allocate([])
+    routing_info = ZonedRoutingInfoAllocator().allocate()
 
     # Last 8 for atom id
     mask = 0xFFFFFF00
@@ -306,27 +309,10 @@ def test_global_allocator() -> None:
     assert not routing_info.has_overlap()
 
 
-def test_flexible_allocator_no_fixed() -> None:
-    unittest_setup()
-
-    # Allocate something and check it does the right thing
-    create_graphs1(False)
-
-    # The number of bits is 8 + 7 + 6 = 21, so it shouldn't fail
-    routing_info = flexible_allocate([])
-
-    # all but the bottom 8 + 7 = 15 bits should be the same
-    app_mask = 0xFFFF8000
-    check_keys_for_application_partition_pairs(routing_info, app_mask)
-
-    assert not routing_info.has_overlap()
-
-
 def test_fixed_only() -> None:
     unittest_setup()
     create_graphs_only_fixed(overlap=False)
-    flexible_allocate([])
-    routing_info = global_allocate([])
+    routing_info = ZonedRoutingInfoAllocator().allocate()
     assert len(list(routing_info)) == 4
 
     assert routing_info.has_overlap()
@@ -335,12 +321,13 @@ def test_fixed_only() -> None:
         assert routing_info.check_overlap(
             partition.identifier, partition.pre_vertex)
 
+
 def test_overlap() -> None:
     # This should work here; overlap is allowed provided routes don't overlap
     # (which is found elsewhere)
     unittest_setup()
     create_graphs_only_fixed(overlap=True)
-    routing_info = flexible_allocate([])
+    routing_info = ZonedRoutingInfoAllocator().allocate()
 
     assert routing_info.has_overlap()
     # all overlap
@@ -352,19 +339,18 @@ def test_overlap() -> None:
 def test_no_edge() -> None:
     unittest_setup()
     create_graphs_no_edge()
-    flexible_allocate([])
-    routing_info = global_allocate([])
+    routing_info = ZonedRoutingInfoAllocator().allocate()
     assert len(list(routing_info)) == 0
     assert not routing_info.has_overlap()
 
 
-def test_flexible_allocator_with_fixed() -> None:
+def test_allocator_with_fixed() -> None:
     unittest_setup()
     # Allocate something and check it does the right thing
     create_graphs1(True)
 
     # The number of bits is 6 + 7 + 8 = 21, so it shouldn't fail
-    routing_info = flexible_allocate([])
+    routing_info = ZonedRoutingInfoAllocator().allocate()
 
     # all but the bottom 8 + 7 = 15 bits should be the same
     app_mask = 0xFFFF8000
@@ -412,26 +398,10 @@ def create_big(with_fixed: bool) -> None:
             app_vertex=mid_app_vertex)
         mid_app_vertex.remember_machine_vertex(mid_mac_vertex)
 
-
-def test_big_flexible_no_fixed() -> None:
-    unittest_setup()
-    create_big(False)
-
-    # The number of bits is 1 + 11 + 21 = 33, so it shouldn't fail
-    routing_info = flexible_allocate([])
-
-    # The number of bits is 1 + 21 = 22, so it shouldn't fail
-    # all but the bottom 21 bits should be the same
-    app_mask = 0xFFE00000
-    check_keys_for_application_partition_pairs(routing_info, app_mask)
-
-    assert not routing_info.has_overlap()
-
-
 def test_big_global_no_fixed() -> None:
     unittest_setup()
     create_big(False)
-    routing_info = global_allocate([])
+    routing_info = ZonedRoutingInfoAllocator().allocate()
 
     # 1 for app 11 for machine so where possible use 20 for atoms
     mask = 0xFFF00000
@@ -446,25 +416,10 @@ def test_big_global_no_fixed() -> None:
 
     assert not routing_info.has_overlap()
 
-
-def test_big_flexible_fixed() -> None:
-    unittest_setup()
-    create_big(True)
-
-    # The number of bits is 1 + 11 + 21 = 33, so it shouldn't fail
-    routing_info = flexible_allocate([])
-
-    # all but the bottom 18 bits should be the same
-    app_mask = 0xFFFC0000
-    check_keys_for_application_partition_pairs(routing_info, app_mask)
-
-    assert routing_info.has_overlap()
-
-
 def test_big_global_fixed() -> None:
     unittest_setup()
     create_big(True)
-    routing_info = global_allocate([])
+    routing_info = ZonedRoutingInfoAllocator().allocate()
 
     # 7 bit atoms is 7 as it ignore the retina
     mask = 0xFFFFFF80

--- a/unittests/operations_tests/routing_info_algorithms_tests/test_zoned_routing_allocator.py
+++ b/unittests/operations_tests/routing_info_algorithms_tests/test_zoned_routing_allocator.py
@@ -248,9 +248,6 @@ def check_masks_all_the_same(routing_info: RoutingInfo, mask: int) -> None:
     seen_keys = set()
     for r_info in routing_info:
         if isinstance(r_info.vertex, MachineVertex):
-            print(f"{hex(r_info.mask)} {r_info.machine_vertex.label}")
-    for r_info in routing_info:
-        if isinstance(r_info.vertex, MachineVertex):
             assert isinstance(r_info, MachineVertexRoutingInfo)
             assert (r_info.mask == mask or
                     r_info.machine_vertex.label == "RETINA")

--- a/unittests/operations_tests/routing_info_algorithms_tests/test_zoned_routing_allocator.py
+++ b/unittests/operations_tests/routing_info_algorithms_tests/test_zoned_routing_allocator.py
@@ -304,6 +304,7 @@ def test_allocator_no_fixed() -> None:
     check_keys_for_application_partition_pairs(routing_info, app_mask)
 
     assert not routing_info.has_ap_overlap()
+    assert not routing_info.has_mx_overlap()
 
     assert routing_info.min_bits_atoms_and_mac == 15
     assert routing_info.max_bits_machine == 7
@@ -334,6 +335,9 @@ def test_fixed_only() -> None:
     assert routing_info.target_machine_bits == 30
     assert routing_info.target_atom_bits == 0
 
+    assert 4 == len(list(routing_info.get_ap_overlaps()))
+    assert 4 == len(list(routing_info.get_mx_overlaps()))
+
 
 def test_overlap() -> None:
     # This should work here; overlap is allowed provided routes don't overlap
@@ -356,6 +360,9 @@ def test_overlap() -> None:
     assert routing_info.target_machine_bits == 30
     assert routing_info.target_atom_bits == 0
 
+    assert 4 == len(list(routing_info.get_ap_overlaps()))
+    assert 4 == len(list(routing_info.get_mx_overlaps()))
+
 
 def test_no_edge() -> None:
     unittest_setup()
@@ -372,6 +379,9 @@ def test_no_edge() -> None:
     assert routing_info.target_machine_bits == 32
     assert routing_info.target_atom_bits == 0
 
+    assert not routing_info.has_ap_overlap()
+    assert not routing_info.has_mx_overlap()
+
 
 def test_allocator_with_fixed() -> None:
     unittest_setup()
@@ -385,8 +395,6 @@ def test_allocator_with_fixed() -> None:
     app_mask = 0xFFFF8000
     check_keys_for_application_partition_pairs(routing_info, app_mask)
 
-    assert routing_info.has_ap_overlap()
-
     assert routing_info.min_bits_atoms_and_mac == 15
     assert routing_info.max_bits_machine == 7
     assert routing_info.max_bits_atoms == 8
@@ -394,6 +402,9 @@ def test_allocator_with_fixed() -> None:
     assert routing_info.size_mac_atoms_bits == 25
     assert routing_info.target_machine_bits == 17
     assert routing_info.target_atom_bits == 8
+
+    assert 146 == len(list(routing_info.get_ap_overlaps()))
+    assert 146 == len(list(routing_info.get_mx_overlaps()))
 
 
 def create_big(with_fixed: bool) -> None:
@@ -453,7 +464,7 @@ def test_big_no_fixed() -> None:
     check_keys_for_application_partition_pairs(routing_info, app_mask)
 
     assert not routing_info.has_ap_overlap()
-    assert routing_info.has_mx_overlap()
+    assert 2 == len(list(routing_info.get_mx_overlaps()))
 
     assert routing_info.min_bits_atoms_and_mac == 21
     assert routing_info.max_bits_machine == 11
@@ -480,8 +491,8 @@ def test_big_fixed() -> None:
     app_mask = 0xFFFC0000
     check_keys_for_application_partition_pairs(routing_info, app_mask)
 
-    assert routing_info.has_ap_overlap()
-    assert not routing_info.has_mx_overlap()
+    assert 2 == len(list(routing_info.get_ap_overlaps()))
+    assert 2 == len(list(routing_info.get_mx_overlaps()))
 
     assert routing_info.min_bits_atoms_and_mac == 18
     assert routing_info.max_bits_machine == 11

--- a/unittests/operations_tests/routing_info_algorithms_tests/test_zoned_routing_allocator.py
+++ b/unittests/operations_tests/routing_info_algorithms_tests/test_zoned_routing_allocator.py
@@ -23,7 +23,6 @@ from pacman.model.graphs.application import ApplicationEdge, ApplicationVertex
 from pacman.model.graphs.common import Slice
 from pacman.model.resources import AbstractSDRAM
 from pacman.model.routing_info.base_key_and_mask import BaseKeyAndMask
-from pacman.model.routing_info.vertex_routing_info import VertexRoutingInfo
 from pacman.model.graphs.machine.machine_vertex import MachineVertex
 from pacman.model.partitioner_splitters import AbstractSplitterCommon
 from pacman.model.routing_info import RoutingInfo, MachineVertexRoutingInfo
@@ -496,9 +495,7 @@ def test_big_fixed() -> None:
 def test_blocked_simple() -> None:
     mask = 0xFF000000
     key = 0x10000000
-    key_and_mask = BaseKeyAndMask(key, mask)
-    info = VertexRoutingInfo(key_and_mask, "bacon")
-    blocked = ZonedRoutingInfoAllocator.calc_overlaps(info, 12)
+    blocked = ZonedRoutingInfoAllocator.calc_overlaps(key, mask, 12)
     assert len(blocked) == 16
     for block in [0x100, 0x101, 0x102, 0x103, 0x104, 0x105, 0x106, 0x107,
                   0x108, 0x109, 0x10a, 0x10b, 0x10c, 0x10d, 0x10e, 0x10f]:
@@ -508,9 +505,7 @@ def test_blocked_simple() -> None:
 def test_blocked_fancy() -> None:
     mask = 0xF0F00000
     key = 0x10000000
-    key_and_mask = BaseKeyAndMask(key, mask)
-    info = VertexRoutingInfo(key_and_mask, "bacon")
-    blocked = ZonedRoutingInfoAllocator.calc_overlaps(info, 12)
+    blocked = ZonedRoutingInfoAllocator.calc_overlaps(key, mask, 12)
     assert len(blocked) == 16
     for block in [0x100, 0x110, 0x120, 0x130, 0x140, 0x150, 0x160, 0x170,
                   0x180, 0x190, 0x1a0, 0x1b0, 0x1c0, 0x1d0, 0x1e0, 0x1f0]:

--- a/unittests/operations_tests/routing_info_algorithms_tests/test_zoned_routing_allocator.py
+++ b/unittests/operations_tests/routing_info_algorithms_tests/test_zoned_routing_allocator.py
@@ -303,7 +303,7 @@ def test_allocator_no_fixed() -> None:
     app_mask = 0xFFFF8000
     check_keys_for_application_partition_pairs(routing_info, app_mask)
 
-    assert not routing_info.has_overlap()
+    assert not routing_info.has_ap_overlap()
 
 
 def test_fixed_only() -> None:
@@ -312,11 +312,23 @@ def test_fixed_only() -> None:
     routing_info = ZonedRoutingInfoAllocator().allocate()
     assert len(list(routing_info)) == 4
 
-    assert routing_info.has_overlap()
+    assert routing_info.has_ap_overlap()
     # all overlap
     for partition in PacmanDataView.iterate_partitions():
-        assert routing_info.check_overlap(
+        assert routing_info.check_ap_overlap(
             partition.identifier, partition.pre_vertex)
+
+    [min_bits_atoms_and_mac,
+     max_bits_machine, max_bits_atoms,
+     size_app_part_bits, size_mac_atoms_bits,
+     target_machine_bits, target_atom_bits] = routing_info.get_zones()
+    assert min_bits_atoms_and_mac == 0
+    assert max_bits_machine == 0
+    assert max_bits_atoms == 0
+    assert size_app_part_bits == 3
+    assert size_mac_atoms_bits == 29
+    assert target_machine_bits == 29
+    assert target_atom_bits == 0
 
 
 def test_overlap() -> None:
@@ -326,11 +338,23 @@ def test_overlap() -> None:
     create_graphs_only_fixed(overlap=True)
     routing_info = ZonedRoutingInfoAllocator().allocate()
 
-    assert routing_info.has_overlap()
+    assert routing_info.has_ap_overlap()
     # all overlap
     for partition in PacmanDataView.iterate_partitions():
-        assert routing_info.check_overlap(
+        assert routing_info.check_ap_overlap(
             partition.identifier, partition.pre_vertex)
+
+    [min_bits_atoms_and_mac,
+     max_bits_machine, max_bits_atoms,
+     size_app_part_bits, size_mac_atoms_bits,
+     target_machine_bits, target_atom_bits] = routing_info.get_zones()
+    assert min_bits_atoms_and_mac == 0
+    assert max_bits_machine == 0
+    assert max_bits_atoms == 0
+    assert size_app_part_bits == 17
+    assert size_mac_atoms_bits == 15
+    assert target_machine_bits == 15
+    assert target_atom_bits == 0
 
 
 def test_no_edge() -> None:
@@ -338,7 +362,19 @@ def test_no_edge() -> None:
     create_graphs_no_edge()
     routing_info = ZonedRoutingInfoAllocator().allocate()
     assert len(list(routing_info)) == 0
-    assert not routing_info.has_overlap()
+    assert not routing_info.has_ap_overlap()
+    [min_bits_atoms_and_mac,
+     max_bits_machine, max_bits_atoms,
+     size_app_part_bits, size_mac_atoms_bits,
+     target_machine_bits, target_atom_bits] = routing_info.get_zones()
+    assert min_bits_atoms_and_mac == 0
+    assert max_bits_machine == 0
+    assert max_bits_atoms == 0
+    assert size_app_part_bits == 0
+    assert size_mac_atoms_bits == 32
+    assert target_machine_bits == 32
+    assert target_atom_bits == 0
+
 
 
 def test_allocator_with_fixed() -> None:
@@ -346,14 +382,26 @@ def test_allocator_with_fixed() -> None:
     # Allocate something and check it does the right thing
     create_graphs1(True)
 
-    # The number of bits is 6 + 7 + 8 = 21, so it shouldn't fail
+    # The number of bits is 6 + 7 + 8 = 21, so it should fit
     routing_info = ZonedRoutingInfoAllocator().allocate()
 
     # all but the bottom 8 + 7 = 15 bits should be the same
     app_mask = 0xFFFF8000
     check_keys_for_application_partition_pairs(routing_info, app_mask)
 
-    assert routing_info.has_overlap()
+    assert routing_info.has_ap_overlap()
+    [min_bits_atoms_and_mac,
+     max_bits_machine, max_bits_atoms,
+     size_app_part_bits, size_mac_atoms_bits,
+     target_machine_bits, target_atom_bits] = routing_info.get_zones()
+    assert min_bits_atoms_and_mac == 15
+    assert max_bits_machine == 7
+    assert max_bits_atoms == 8
+    assert size_app_part_bits == 10
+    assert size_mac_atoms_bits == 22
+    assert target_machine_bits == 14
+    assert target_atom_bits == 8
+
 
 
 def create_big(with_fixed: bool) -> None:
@@ -411,7 +459,21 @@ def test_big_global_no_fixed() -> None:
     app_mask = 0x80000000
     check_keys_for_application_partition_pairs(routing_info, app_mask)
 
-    assert not routing_info.has_overlap()
+    assert not routing_info.has_ap_overlap()
+    assert routing_info.has_mx_overlap()
+
+    [min_bits_atoms_and_mac,
+     max_bits_machine, max_bits_atoms,
+     size_app_part_bits, size_mac_atoms_bits,
+     target_machine_bits, target_atom_bits] = routing_info.get_zones()
+    assert min_bits_atoms_and_mac == 21
+    assert max_bits_machine == 11
+    assert max_bits_atoms == 21
+    assert size_app_part_bits == 1
+    assert size_mac_atoms_bits == 31
+    assert target_machine_bits == 11
+    assert target_atom_bits == 20
+
 
 def test_big_global_fixed() -> None:
     unittest_setup()
@@ -429,4 +491,17 @@ def test_big_global_fixed() -> None:
     app_mask = 0xFFFC0000
     check_keys_for_application_partition_pairs(routing_info, app_mask)
 
-    assert routing_info.has_overlap()
+    assert routing_info.has_ap_overlap()
+    assert not routing_info.has_mx_overlap()
+
+    [min_bits_atoms_and_mac,
+     max_bits_machine, max_bits_atoms,
+     size_app_part_bits, size_mac_atoms_bits,
+     target_machine_bits, target_atom_bits] = routing_info.get_zones()
+    assert min_bits_atoms_and_mac == 18
+    assert max_bits_machine == 11
+    assert max_bits_atoms == 7  # Big is fixed
+    assert size_app_part_bits == 13  # After overlaps
+    assert size_mac_atoms_bits == 19
+    assert target_machine_bits == 12
+    assert target_atom_bits == 7

--- a/unittests/operations_tests/routing_table_generator_tests/test_basic.py
+++ b/unittests/operations_tests/routing_table_generator_tests/test_basic.py
@@ -92,7 +92,7 @@ class TestBasic(unittest.TestCase):
         writer.set_placements(place_application_graph(system_placements))
         writer.set_routing_table_by_partition(route_application_graph())
         allocator = ZonedRoutingInfoAllocator()
-        writer.set_routing_infos(allocator.allocate([]))
+        writer.set_routing_infos(allocator.allocate())
 
     def test_empty(self) -> None:
         writer = PacmanDataWriter.mock()

--- a/unittests/operations_tests/routing_table_generator_tests/test_merged.py
+++ b/unittests/operations_tests/routing_table_generator_tests/test_merged.py
@@ -100,7 +100,7 @@ class TestMerged(unittest.TestCase):
         writer.set_placements(place_application_graph(system_placements))
         writer.set_routing_table_by_partition(route_application_graph())
         allocator = ZonedRoutingInfoAllocator()
-        writer.set_routing_infos(allocator.allocate([]))
+        writer.set_routing_infos(allocator.allocate())
 
     def test_empty(self) -> None:
         writer = PacmanDataWriter.mock()


### PR DESCRIPTION
ZonedRoutingInfoAllocator updated

-flexible option removed as the global one handles as many cases better
-This is now very similar to the previous global

- zones values given better names and a few extra added to make code clearer
- zone values added to RoutingInfo
- overlap app vetex, patition pairs added to RoutingInfo
   - ap will be only some fixed
   - mx will be ALL fixed and some vertices with many atoms

Fixed Routes are do at the start avoiding the need to cash data
- cleaned up to be clearer that for each fapp vertex
  - The App must specify fix if any machine does
  - For App with more than 1 fixed each must specify fixed

The Application/Partition zone is now always at the top and as small as possible
- just the bits needed for 1 key per AppVetrex/ parition Id pair
- This zone will be enlarge if there is a lot of fixed zone overlaps
- extra bits will be in the machine zone

Clearer that (except fixed) all vertices will respect the AP zone

Test adjusted to show zone

Removed test where when both flexible and zone where tested with the same graph
