### PR TITLE
Validate routes uncompressed

### DIFF
--- a/pacman/operations/multi_cast_router_check_functionality/valid_routes_checker.py
+++ b/pacman/operations/multi_cast_router_check_functionality/valid_routes_checker.py
@@ -177,11 +177,11 @@ def _search_route(
             f"[{dest.x}:{dest.y}:{dest.p}]"
             for dest in failed_to_reach_destinations)
         error_message += (
-            "failed to locate all destinations with vertex "
+            "Failed to locate all destinations with vertex "
             f"{source_placement.vertex.label} on processor "
             f"[{source_placement.x}:{source_placement.y}:{source_placement.p}]"
             f" with keys {key_and_mask} as it did not reach destinations "
-            f"{failures}")
+            f"{failures}\n")
 
     # check for error if the trace went to a destination it shouldn't have
     if located_destinations:
@@ -189,11 +189,10 @@ def _search_route(
              f"[{dest.x}:{dest.y}:{dest.p}]"
              for dest in located_destinations)
         error_message += (
-            "trace went to more failed to locate all destinations with "
+            "Extra destinations for "
             f"vertex {source_placement.vertex.label} on processor "
             f"[{source_placement.x}:{source_placement.y}:{source_placement.p}]"
-            f" with keys {key_and_mask} as it didn't reach destinations "
-            f"{failures}")
+            f" with keys {key_and_mask} it incorrectly went to {failures}\n")
 
     if failed_to_cover_all_keys_routers:
         failures = ", ".join(

--- a/pacman/operations/multi_cast_router_check_functionality/valid_routes_checker.py
+++ b/pacman/operations/multi_cast_router_check_functionality/valid_routes_checker.py
@@ -38,7 +38,7 @@ from pacman.model.routing_tables import (
 
 
 logger = FormatAdapter(logging.getLogger(__name__))
-range_masks = {FULL_MASK - ((2 ** i) - 1) for i in range(33)}
+range_masks = {FULL_MASK - ((2 ** i) - 1) for i in range(1, 33)}
 
 
 class PlacementTuple(NamedTuple):

--- a/pacman/operations/multi_cast_router_check_functionality/valid_routes_checker.py
+++ b/pacman/operations/multi_cast_router_check_functionality/valid_routes_checker.py
@@ -23,14 +23,13 @@ from spinn_utilities.log import FormatAdapter
 from spinn_machine import Chip, MulticastRoutingEntry
 from pacman.data import PacmanDataView
 from pacman.exceptions import (
-    PacmanConfigurationException, PacmanNotPlacedError, PacmanRoutingException)
+    PacmanConfigurationException, PacmanRoutingException)
 from pacman.model.graphs.application import ApplicationVertex
 from pacman.model.graphs import AbstractVirtual
 from pacman.utilities.constants import FULL_MASK
 from pacman.utilities.algorithm_utilities.routing_algorithm_utilities import (
     get_app_partitions)
-from pacman.model.graphs.machine import (
-    MachineFPGAVertex, MachineSpiNNakerLinkVertex, MachineVertex)
+from pacman.model.graphs.machine import MachineVertex
 from pacman.model.placements import Placement
 from pacman.model.routing_info import BaseKeyAndMask
 from pacman.model.routing_tables import (
@@ -90,25 +89,18 @@ def validate_routes(routing_tables: MulticastRoutingTables) -> None:
                     source, partition.identifier)
 
             for tgt, srcs in target_vertices:
-                try:
-                    place = PacmanDataView.get_placement_of_vertex(tgt)
-                    for src in srcs:
-                        if isinstance(src, ApplicationVertex):
-                            for s in src.splitter.get_out_going_vertices(
-                                    partition.identifier):
-                                destinations[s].add(PlacementTuple(
-                                    x=place.x, y=place.y, p=place.p))
-                        else:
-                            destinations[src].add(PlacementTuple(
+                if isinstance(tgt, AbstractVirtual):
+                    continue
+                place = PacmanDataView.get_placement_of_vertex(tgt)
+                for src in srcs:
+                    if isinstance(src, ApplicationVertex):
+                        for s in src.splitter.get_out_going_vertices(
+                                partition.identifier):
+                            destinations[s].add(PlacementTuple(
                                 x=place.x, y=place.y, p=place.p))
-                except PacmanNotPlacedError:
-                    if (isinstance(tgt, MachineSpiNNakerLinkVertex) or
-                            isinstance(tgt, MachineFPGAVertex)):
-                        logger.exception(
-                            f"Unable to validate routes with {tgt}")
-                        return
                     else:
-                        raise
+                        destinations[src].add(PlacementTuple(
+                            x=place.x, y=place.y, p=place.p))
 
         outgoing: OrderedSet[MachineVertex] = OrderedSet(
             source.splitter.get_out_going_vertices(partition.identifier))


### PR DESCRIPTION
fixes https://github.com/SpiNNakerManchester/PACMAN/issues/442

range_masks should not include the mass 0xFFFFFFFF
These are used by the CommandSender and so are a special case

AbstractVirtual will not have routes.

Tested with https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/pull/1348 as validate_routes_uncompressed = True.

Now debug so it only runs as needed
