### PR TITLE
Spin gen enums

### DIFF
--- a/unittests/model_tests/routing_table_tests/test_routing_tables_model.py
+++ b/unittests/model_tests/routing_table_tests/test_routing_tables_model.py
@@ -19,7 +19,7 @@ from spinn_utilities.config_holder import set_config
 
 from spinn_machine import MulticastRoutingEntry, RoutingEntry
 from spinn_machine.exceptions import SpinnMachineInvalidParameterException
-from spinn_machine.version import MANY_BOARD_TYPES, Spin1Gen
+from spinn_machine.version import MANY_BOARD_TYPES
 
 from pacman.config_setup import unittest_setup
 from pacman.model.routing_tables import (

--- a/unittests/model_tests/routing_table_tests/test_routing_tables_model.py
+++ b/unittests/model_tests/routing_table_tests/test_routing_tables_model.py
@@ -216,7 +216,7 @@ class TestRoutingTable(unittest.TestCase):
             source_vertex, partition_id, 0, 0)
 
     def test_multicast_routing_table_by_partition_entry(self) -> None:
-        set_config("Machine", "version", str(Spin1Gen.value))
+        set_config("Machine", "version", str(Spin1Gen.FIVE.value))
         with self.assertRaises(SpinnMachineInvalidParameterException):
             RoutingEntry(link_ids=range(6), processor_ids=range(18),
                          incoming_processor=4, incoming_link=3)

--- a/unittests/model_tests/routing_table_tests/test_routing_tables_model.py
+++ b/unittests/model_tests/routing_table_tests/test_routing_tables_model.py
@@ -13,9 +13,13 @@
 # limitations under the License.
 
 import unittest
-from pacman.config_setup import unittest_setup
+
+from spinn_utilities.config_holder import set_config
 from spinn_machine import MulticastRoutingEntry, RoutingEntry
 from spinn_machine.exceptions import SpinnMachineInvalidParameterException
+from spinn_machine.version import SPIN1_GEN
+
+from pacman.config_setup import unittest_setup
 from pacman.model.routing_tables import (
     UnCompressedMulticastRoutingTable, MulticastRoutingTables)
 from pacman.model.routing_tables.multicast_routing_tables import (
@@ -190,6 +194,7 @@ class TestRoutingTable(unittest.TestCase):
             MulticastRoutingTables(mrt)
 
     def test_multicast_routing_table_by_partition(self) -> None:
+        set_config("Machine", "version", str(SPIN1_GEN.FIVE))
         mrt = MulticastRoutingTableByPartition()
         partition_id = "foo"
         source_vertex = SimpleMachineVertex(sdram=None)
@@ -211,6 +216,7 @@ class TestRoutingTable(unittest.TestCase):
             source_vertex, partition_id, 0, 0)
 
     def test_multicast_routing_table_by_partition_entry(self) -> None:
+        set_config("Machine", "version", str(SPIN1_GEN.FIVE))
         with self.assertRaises(SpinnMachineInvalidParameterException):
             RoutingEntry(link_ids=range(6), processor_ids=range(18),
                          incoming_processor=4, incoming_link=3)

--- a/unittests/model_tests/routing_table_tests/test_routing_tables_model.py
+++ b/unittests/model_tests/routing_table_tests/test_routing_tables_model.py
@@ -194,7 +194,7 @@ class TestRoutingTable(unittest.TestCase):
             MulticastRoutingTables(mrt)
 
     def test_multicast_routing_table_by_partition(self) -> None:
-        set_config("Machine", "version", str(Spin1Gen.FIVE))
+        set_config("Machine", "version", str(Spin1Gen.FIVE.value))
         mrt = MulticastRoutingTableByPartition()
         partition_id = "foo"
         source_vertex = SimpleMachineVertex(sdram=None)
@@ -216,7 +216,7 @@ class TestRoutingTable(unittest.TestCase):
             source_vertex, partition_id, 0, 0)
 
     def test_multicast_routing_table_by_partition_entry(self) -> None:
-        set_config("Machine", "version", str(Spin1Gen.FIVE))
+        set_config("Machine", "version", str(Spin1Gen.value))
         with self.assertRaises(SpinnMachineInvalidParameterException):
             RoutingEntry(link_ids=range(6), processor_ids=range(18),
                          incoming_processor=4, incoming_link=3)

--- a/unittests/model_tests/routing_table_tests/test_routing_tables_model.py
+++ b/unittests/model_tests/routing_table_tests/test_routing_tables_model.py
@@ -17,7 +17,7 @@ import unittest
 from spinn_utilities.config_holder import set_config
 from spinn_machine import MulticastRoutingEntry, RoutingEntry
 from spinn_machine.exceptions import SpinnMachineInvalidParameterException
-from spinn_machine.version import SPIN1_GEN
+from spinn_machine.version import Spin1Gen
 
 from pacman.config_setup import unittest_setup
 from pacman.model.routing_tables import (
@@ -194,7 +194,7 @@ class TestRoutingTable(unittest.TestCase):
             MulticastRoutingTables(mrt)
 
     def test_multicast_routing_table_by_partition(self) -> None:
-        set_config("Machine", "version", str(SPIN1_GEN.FIVE))
+        set_config("Machine", "version", str(Spin1Gen.FIVE))
         mrt = MulticastRoutingTableByPartition()
         partition_id = "foo"
         source_vertex = SimpleMachineVertex(sdram=None)
@@ -216,7 +216,7 @@ class TestRoutingTable(unittest.TestCase):
             source_vertex, partition_id, 0, 0)
 
     def test_multicast_routing_table_by_partition_entry(self) -> None:
-        set_config("Machine", "version", str(SPIN1_GEN.FIVE))
+        set_config("Machine", "version", str(Spin1Gen.FIVE))
         with self.assertRaises(SpinnMachineInvalidParameterException):
             RoutingEntry(link_ids=range(6), processor_ids=range(18),
                          incoming_processor=4, incoming_link=3)

--- a/unittests/operations_tests/router_algorithms_tests/test_routers.py
+++ b/unittests/operations_tests/router_algorithms_tests/test_routers.py
@@ -27,7 +27,7 @@ from spinn_utilities.typing.coords import XY
 
 from spinn_machine import Machine, RoutingEntry
 from spinn_machine.link_data_objects import AbstractLinkData
-from spinn_machine.version import SPIN1_GEN
+from spinn_machine.version import Spin1Gen
 from spinn_machine.version.version_strings import VersionStrings
 from spinn_machine.virtual_machine import (
     virtual_machine_by_boards, virtual_machine_by_cores)
@@ -813,7 +813,7 @@ def test_spinnaker_link(params: Params) -> None:
     algorithm, n_vertices, n_m_vertices = params
     unittest_setup()
     # TODO SPIN2 spinnaker links
-    set_config("Machine", "version", str(SPIN1_GEN.FIVE))
+    set_config("Machine", "version", str(Spin1Gen.FIVE))
     writer = PacmanDataWriter.mock()
     in_device = ApplicationSpiNNakerLinkVertex(100, 0)
     in_device.splitter = SplitterExternalDevice()

--- a/unittests/operations_tests/router_algorithms_tests/test_routers.py
+++ b/unittests/operations_tests/router_algorithms_tests/test_routers.py
@@ -605,10 +605,10 @@ def test_simple(_: str, ver_num: str) -> None:
     routing_tables = _route_and_time()
     _check_edges(routing_tables)
 
-
-def test_self() -> None:
+@parameterized.expand(MANY_BOARD_TYPES)
+def test_self(_: str, ver_num: str) -> None:
     unittest_setup()
-    set_config("Machine", "version", "5")
+    set_config("Machine", "version", ver_num)
     writer = PacmanDataWriter.mock()
     source_vertex = _make_vertices(writer, 1000, N_M_VERTICES, "self")
     writer.add_edge(ApplicationEdge(source_vertex, source_vertex), "Test")
@@ -802,7 +802,7 @@ def test_internal_and_split(_: str, ver_num: str) -> None:
 
 def test_spinnaker_link() -> None:
     unittest_setup()
-    # TODO SPIN2 spinnaker links
+    # Needs more than 4 Chips. Spin2 has different links
     set_config("Machine", "version", str(Spin1Gen.FIVE.value))
     writer = PacmanDataWriter.mock()
     in_device = ApplicationSpiNNakerLinkVertex(100, 0)
@@ -826,8 +826,8 @@ def test_spinnaker_link() -> None:
 
 def test_fpga_link() -> None:
     unittest_setup()
-    # TODO spin2 fpga
-    set_config("Machine", "version", "5")
+    # Needs more than 4 Chips and Spin2 has different links
+    set_config("Machine", "version", str(Spin1Gen.FIVE.value))
     writer = PacmanDataWriter.mock()
     in_device = ApplicationFPGAVertex(
         100, [FPGAConnection(0, 0, None, None)], None)
@@ -853,8 +853,8 @@ def test_fpga_link() -> None:
 
 def test_fpga_link_overlap() -> None:
     unittest_setup()
-    # TODO Spin2 links
-    set_config("Machine", "version", "5")
+    # Needs more than 4 Chips and Spin2 has different links
+    set_config("Machine", "version", str(Spin1Gen.FIVE.value))
     writer = PacmanDataWriter.mock()
     set_config("Machine", "down_chips", "6,1")
     in_device = ApplicationFPGAVertex(

--- a/unittests/operations_tests/router_algorithms_tests/test_routers.py
+++ b/unittests/operations_tests/router_algorithms_tests/test_routers.py
@@ -813,7 +813,7 @@ def test_spinnaker_link(params: Params) -> None:
     algorithm, n_vertices, n_m_vertices = params
     unittest_setup()
     # TODO SPIN2 spinnaker links
-    set_config("Machine", "version", str(Spin1Gen.FIVE))
+    set_config("Machine", "version", str(Spin1Gen.FIVE.value))
     writer = PacmanDataWriter.mock()
     in_device = ApplicationSpiNNakerLinkVertex(100, 0)
     in_device.splitter = SplitterExternalDevice()

--- a/unittests/operations_tests/router_algorithms_tests/test_routers.py
+++ b/unittests/operations_tests/router_algorithms_tests/test_routers.py
@@ -27,7 +27,7 @@ from spinn_utilities.typing.coords import XY
 
 from spinn_machine import Machine, RoutingEntry
 from spinn_machine.link_data_objects import AbstractLinkData
-from spinn_machine.version import FIVE
+from spinn_machine.version import SPIN1_GEN
 from spinn_machine.version.version_strings import VersionStrings
 from spinn_machine.virtual_machine import (
     virtual_machine_by_boards, virtual_machine_by_cores)
@@ -813,7 +813,7 @@ def test_spinnaker_link(params: Params) -> None:
     algorithm, n_vertices, n_m_vertices = params
     unittest_setup()
     # TODO SPIN2 spinnaker links
-    set_config("Machine", "version", str(FIVE))
+    set_config("Machine", "version", str(SPIN1_GEN.FIVE))
     writer = PacmanDataWriter.mock()
     in_device = ApplicationSpiNNakerLinkVertex(100, 0)
     in_device.splitter = SplitterExternalDevice()

--- a/unittests/operations_tests/router_algorithms_tests/test_routers.py
+++ b/unittests/operations_tests/router_algorithms_tests/test_routers.py
@@ -605,6 +605,7 @@ def test_simple(_: str, ver_num: str) -> None:
     routing_tables = _route_and_time()
     _check_edges(routing_tables)
 
+
 @parameterized.expand(MANY_BOARD_TYPES)
 def test_self(_: str, ver_num: str) -> None:
     unittest_setup()

--- a/unittests/operations_tests/router_compressor_tests/test_checked_unordered_pair_compression.py
+++ b/unittests/operations_tests/router_compressor_tests/test_checked_unordered_pair_compression.py
@@ -32,7 +32,7 @@ class TestUnorderedPairCompressor(unittest.TestCase):
     def setUp(self) -> None:
         unittest_setup()
         # This tests needs exactly version 5 as on Spin2 it would fit
-        set_config("Machine", "version", str(Spin1Gen.FIVE))
+        set_config("Machine", "version", str(Spin1Gen.FIVE.value))
 
     def test_onordered_pair_big(self) -> None:
 

--- a/unittests/operations_tests/router_compressor_tests/test_checked_unordered_pair_compression.py
+++ b/unittests/operations_tests/router_compressor_tests/test_checked_unordered_pair_compression.py
@@ -18,7 +18,7 @@ import unittest
 
 from spinn_utilities.config_holder import set_config
 from spinn_machine import virtual_machine
-from spinn_machine.version import FIVE
+from spinn_machine.version import SPIN1_GEN
 from pacman.config_setup import unittest_setup
 from pacman.data.pacman_data_writer import PacmanDataWriter
 from pacman.model.routing_tables.multicast_routing_tables import (from_json)
@@ -32,7 +32,7 @@ class TestUnorderedPairCompressor(unittest.TestCase):
     def setUp(self) -> None:
         unittest_setup()
         # This tests needs exactly version 5 as on Spin2 it would fit
-        set_config("Machine", "version", str(FIVE))
+        set_config("Machine", "version", str(SPIN1_GEN.FIVE))
 
     def test_onordered_pair_big(self) -> None:
 

--- a/unittests/operations_tests/router_compressor_tests/test_checked_unordered_pair_compression.py
+++ b/unittests/operations_tests/router_compressor_tests/test_checked_unordered_pair_compression.py
@@ -18,7 +18,7 @@ import unittest
 
 from spinn_utilities.config_holder import set_config
 from spinn_machine import virtual_machine
-from spinn_machine.version import SPIN1_GEN
+from spinn_machine.version import Spin1Gen
 from pacman.config_setup import unittest_setup
 from pacman.data.pacman_data_writer import PacmanDataWriter
 from pacman.model.routing_tables.multicast_routing_tables import (from_json)
@@ -32,7 +32,7 @@ class TestUnorderedPairCompressor(unittest.TestCase):
     def setUp(self) -> None:
         unittest_setup()
         # This tests needs exactly version 5 as on Spin2 it would fit
-        set_config("Machine", "version", str(SPIN1_GEN.FIVE))
+        set_config("Machine", "version", str(Spin1Gen.FIVE))
 
     def test_onordered_pair_big(self) -> None:
 

--- a/unittests/operations_tests/router_compressor_tests/test_ordered_covering_compression.py
+++ b/unittests/operations_tests/router_compressor_tests/test_ordered_covering_compression.py
@@ -18,7 +18,7 @@ import unittest
 
 from spinn_utilities.config_holder import set_config
 from spinn_machine import virtual_machine
-from spinn_machine.version import SPIN1_GEN
+from spinn_machine.version import Spin1Gen
 from pacman.config_setup import unittest_setup
 from pacman.data.pacman_data_writer import PacmanDataWriter
 from pacman.model.routing_tables.multicast_routing_tables import (from_json)
@@ -33,7 +33,7 @@ class TestOrderedCoveringCompressor(unittest.TestCase):
     def setUp(self) -> None:
         unittest_setup()
         # tests against version 5 as Spin2 would not need compression
-        set_config("Machine", "version", str(SPIN1_GEN.FIVE))
+        set_config("Machine", "version", str(Spin1Gen.FIVE))
 
     def test_oc_big(self) -> None:
         class_file = sys.modules[self.__module__].__file__

--- a/unittests/operations_tests/router_compressor_tests/test_ordered_covering_compression.py
+++ b/unittests/operations_tests/router_compressor_tests/test_ordered_covering_compression.py
@@ -33,7 +33,7 @@ class TestOrderedCoveringCompressor(unittest.TestCase):
     def setUp(self) -> None:
         unittest_setup()
         # tests against version 5 as Spin2 would not need compression
-        set_config("Machine", "version", str(Spin1Gen.FIVE))
+        set_config("Machine", "version", str(Spin1Gen.FIVE.value))
 
     def test_oc_big(self) -> None:
         class_file = sys.modules[self.__module__].__file__

--- a/unittests/operations_tests/router_compressor_tests/test_ordered_covering_compression.py
+++ b/unittests/operations_tests/router_compressor_tests/test_ordered_covering_compression.py
@@ -18,7 +18,7 @@ import unittest
 
 from spinn_utilities.config_holder import set_config
 from spinn_machine import virtual_machine
-from spinn_machine.version import FIVE
+from spinn_machine.version import SPIN1_GEN
 from pacman.config_setup import unittest_setup
 from pacman.data.pacman_data_writer import PacmanDataWriter
 from pacman.model.routing_tables.multicast_routing_tables import (from_json)
@@ -33,7 +33,7 @@ class TestOrderedCoveringCompressor(unittest.TestCase):
     def setUp(self) -> None:
         unittest_setup()
         # tests against version 5 as Spin2 would not need compression
-        set_config("Machine", "version", str(FIVE))
+        set_config("Machine", "version", str(SPIN1_GEN.FIVE))
 
     def test_oc_big(self) -> None:
         class_file = sys.modules[self.__module__].__file__

--- a/unittests/operations_tests/router_compressor_tests/test_pair_compression.py
+++ b/unittests/operations_tests/router_compressor_tests/test_pair_compression.py
@@ -18,7 +18,7 @@ import unittest
 
 from spinn_utilities.config_holder import set_config
 from spinn_machine import virtual_machine
-from spinn_machine.version import FIVE
+from spinn_machine.version import SPIN1_GEN
 from pacman.config_setup import unittest_setup
 from pacman.data.pacman_data_writer import PacmanDataWriter
 from pacman.model.routing_tables.multicast_routing_tables import (from_json)
@@ -32,7 +32,7 @@ class TestPairCompressor(unittest.TestCase):
     def setUp(self) -> None:
         unittest_setup()
         # tests against version 5 as Spin2 would not need compression
-        set_config("Machine", "version", str(FIVE))
+        set_config("Machine", "version", str(SPIN1_GEN.FIVE))
 
     def do_pair_big(self, c_sort: bool) -> None:
         class_file = sys.modules[self.__module__].__file__

--- a/unittests/operations_tests/router_compressor_tests/test_pair_compression.py
+++ b/unittests/operations_tests/router_compressor_tests/test_pair_compression.py
@@ -32,7 +32,7 @@ class TestPairCompressor(unittest.TestCase):
     def setUp(self) -> None:
         unittest_setup()
         # tests against version 5 as Spin2 would not need compression
-        set_config("Machine", "version", str(Spin1Gen.FIVE))
+        set_config("Machine", "version", str(Spin1Gen.FIVE.value))
 
     def do_pair_big(self, c_sort: bool) -> None:
         class_file = sys.modules[self.__module__].__file__

--- a/unittests/operations_tests/router_compressor_tests/test_pair_compression.py
+++ b/unittests/operations_tests/router_compressor_tests/test_pair_compression.py
@@ -18,7 +18,7 @@ import unittest
 
 from spinn_utilities.config_holder import set_config
 from spinn_machine import virtual_machine
-from spinn_machine.version import SPIN1_GEN
+from spinn_machine.version import Spin1Gen
 from pacman.config_setup import unittest_setup
 from pacman.data.pacman_data_writer import PacmanDataWriter
 from pacman.model.routing_tables.multicast_routing_tables import (from_json)
@@ -32,7 +32,7 @@ class TestPairCompressor(unittest.TestCase):
     def setUp(self) -> None:
         unittest_setup()
         # tests against version 5 as Spin2 would not need compression
-        set_config("Machine", "version", str(SPIN1_GEN.FIVE))
+        set_config("Machine", "version", str(Spin1Gen.FIVE))
 
     def do_pair_big(self, c_sort: bool) -> None:
         class_file = sys.modules[self.__module__].__file__

--- a/unittests/operations_tests/router_compressor_tests/test_range_compressor.py
+++ b/unittests/operations_tests/router_compressor_tests/test_range_compressor.py
@@ -16,7 +16,7 @@ import os
 import sys
 import unittest
 from spinn_utilities.config_holder import set_config
-from spinn_machine.version import FIVE
+from spinn_machine.version import SPIN1_GEN
 from pacman.config_setup import unittest_setup
 from pacman.data.pacman_data_writer import PacmanDataWriter
 from pacman.model.routing_tables import MulticastRoutingTables
@@ -33,7 +33,7 @@ class TestRangeCompressor(unittest.TestCase):
     def setUp(self) -> None:
         unittest_setup()
         # tests against version 5 as Spin2 would not need compression
-        set_config("Machine", "version", str(FIVE))
+        set_config("Machine", "version", str(SPIN1_GEN.FIVE))
         set_config(
             "Mapping", "router_table_compress_as_far_as_possible", str(True))
 

--- a/unittests/operations_tests/router_compressor_tests/test_range_compressor.py
+++ b/unittests/operations_tests/router_compressor_tests/test_range_compressor.py
@@ -16,7 +16,7 @@ import os
 import sys
 import unittest
 from spinn_utilities.config_holder import set_config
-from spinn_machine.version import SPIN1_GEN
+from spinn_machine.version import Spin1Gen
 from pacman.config_setup import unittest_setup
 from pacman.data.pacman_data_writer import PacmanDataWriter
 from pacman.model.routing_tables import MulticastRoutingTables
@@ -33,7 +33,7 @@ class TestRangeCompressor(unittest.TestCase):
     def setUp(self) -> None:
         unittest_setup()
         # tests against version 5 as Spin2 would not need compression
-        set_config("Machine", "version", str(SPIN1_GEN.FIVE))
+        set_config("Machine", "version", str(Spin1Gen.FIVE))
         set_config(
             "Mapping", "router_table_compress_as_far_as_possible", str(True))
 

--- a/unittests/operations_tests/router_compressor_tests/test_range_compressor.py
+++ b/unittests/operations_tests/router_compressor_tests/test_range_compressor.py
@@ -33,7 +33,7 @@ class TestRangeCompressor(unittest.TestCase):
     def setUp(self) -> None:
         unittest_setup()
         # tests against version 5 as Spin2 would not need compression
-        set_config("Machine", "version", str(Spin1Gen.FIVE))
+        set_config("Machine", "version", str(Spin1Gen.FIVE.value))
         set_config(
             "Mapping", "router_table_compress_as_far_as_possible", str(True))
 

--- a/unittests/operations_tests/router_compressor_tests/test_unordered_pair_compression.py
+++ b/unittests/operations_tests/router_compressor_tests/test_unordered_pair_compression.py
@@ -18,7 +18,7 @@ import unittest
 
 from spinn_utilities.config_holder import set_config
 from spinn_machine import virtual_machine
-from spinn_machine.version import FIVE
+from spinn_machine.version import SPIN1_GEN
 from pacman.config_setup import unittest_setup
 from pacman.data.pacman_data_writer import PacmanDataWriter
 from pacman.model.routing_tables.multicast_routing_tables import (from_json)
@@ -33,7 +33,7 @@ class TestUnorderedPairCompressor(unittest.TestCase):
     def setUp(self) -> None:
         unittest_setup()
         # tests against version 5 as Spin2 would not need compression
-        set_config("Machine", "version", str(FIVE))
+        set_config("Machine", "version", str(SPIN1_GEN.FIVE))
 
     def test_onordered_pair_big(self) -> None:
         file_path = sys.modules[self.__module__].__file__

--- a/unittests/operations_tests/router_compressor_tests/test_unordered_pair_compression.py
+++ b/unittests/operations_tests/router_compressor_tests/test_unordered_pair_compression.py
@@ -18,7 +18,7 @@ import unittest
 
 from spinn_utilities.config_holder import set_config
 from spinn_machine import virtual_machine
-from spinn_machine.version import SPIN1_GEN
+from spinn_machine.version import Spin1Gen
 from pacman.config_setup import unittest_setup
 from pacman.data.pacman_data_writer import PacmanDataWriter
 from pacman.model.routing_tables.multicast_routing_tables import (from_json)
@@ -33,7 +33,7 @@ class TestUnorderedPairCompressor(unittest.TestCase):
     def setUp(self) -> None:
         unittest_setup()
         # tests against version 5 as Spin2 would not need compression
-        set_config("Machine", "version", str(SPIN1_GEN.FIVE))
+        set_config("Machine", "version", str(Spin1Gen.FIVE))
 
     def test_onordered_pair_big(self) -> None:
         file_path = sys.modules[self.__module__].__file__

--- a/unittests/operations_tests/router_compressor_tests/test_unordered_pair_compression.py
+++ b/unittests/operations_tests/router_compressor_tests/test_unordered_pair_compression.py
@@ -33,7 +33,7 @@ class TestUnorderedPairCompressor(unittest.TestCase):
     def setUp(self) -> None:
         unittest_setup()
         # tests against version 5 as Spin2 would not need compression
-        set_config("Machine", "version", str(Spin1Gen.FIVE))
+        set_config("Machine", "version", str(Spin1Gen.FIVE.value))
 
     def test_onordered_pair_big(self) -> None:
         file_path = sys.modules[self.__module__].__file__

--- a/unittests/operations_tests/routing_table_generator_tests/test_basic.py
+++ b/unittests/operations_tests/routing_table_generator_tests/test_basic.py
@@ -161,7 +161,8 @@ class TestBasic(unittest.TestCase):
             basic_routing_table_generator()
 
     @parameterized.expand(MANY_BOARD_TYPES)
-    def test_non_overlapping_different_chips(self, _: str, ver_num: str) -> None:
+    def test_non_overlapping_different_chips(
+            self, _: str, ver_num: str) -> None:
         set_config("Machine", "version", ver_num)
         # Two vertices with non-overlapping routes can use the same key
         writer = PacmanDataWriter.mock()

--- a/unittests/operations_tests/routing_table_generator_tests/test_basic.py
+++ b/unittests/operations_tests/routing_table_generator_tests/test_basic.py
@@ -14,8 +14,14 @@
 
 import unittest
 from typing import Optional, cast
+
+from parameterized import parameterized
 from typing_extensions import Self
+
 from spinn_utilities.config_holder import set_config
+
+from spinn_machine.version import BIG_BOARD_TYPES, MANY_BOARD_TYPES, Spin1Gen
+
 from pacman.config_setup import unittest_setup
 from pacman.data.pacman_data_writer import PacmanDataWriter
 from pacman.model.graphs.application import ApplicationEdge
@@ -61,9 +67,6 @@ class TestBasic(unittest.TestCase):
 
     def setUp(self) -> None:
         unittest_setup()
-        # TODO check after
-        #  https://github.com/SpiNNakerManchester/PACMAN/pull/555
-        set_config("Machine", "version", "5")
 
     def create_graphs3(self, writer: PacmanDataWriter) -> None:
         v1 = SimpleTestVertex(
@@ -94,7 +97,9 @@ class TestBasic(unittest.TestCase):
         allocator = ZonedRoutingInfoAllocator()
         writer.set_routing_infos(allocator.allocate())
 
-    def test_empty(self) -> None:
+    @parameterized.expand(MANY_BOARD_TYPES)
+    def test_empty(self, _: str, ver_num: str) -> None:
+        set_config("Machine", "version", ver_num)
         writer = PacmanDataWriter.mock()
         self.make_infos(writer)
         data = basic_routing_table_generator()
@@ -102,6 +107,8 @@ class TestBasic(unittest.TestCase):
         self.assertEqual(0, len(list(data.routing_tables)))
 
     def test_graph3_with_system(self) -> None:
+        # Hard coded values that only work on version 5
+        set_config("Machine", "version", str(Spin1Gen.FIVE.value))
         writer = PacmanDataWriter.mock()
         self.create_graphs3(writer)
         system_plaements = Placements()
@@ -114,6 +121,8 @@ class TestBasic(unittest.TestCase):
         self.assertEqual(5, len(list(data.routing_tables)))
 
     def test_overlapping(self) -> None:
+        # Hard coded values that only work on version 5
+        set_config("Machine", "version", str(Spin1Gen.FIVE.value))
         # Two vertices in the same router can't send with the same key
         writer = PacmanDataWriter.mock()
         v_target = SimpleTestVertex(1, splitter=SplitterFixedLegacy())
@@ -131,7 +140,9 @@ class TestBasic(unittest.TestCase):
         with self.assertRaises(KeyError):
             basic_routing_table_generator()
 
-    def test_overlapping_different_chips(self) -> None:
+    @parameterized.expand(BIG_BOARD_TYPES)  # Needs multiple chips
+    def test_overlapping_different_chips(self, _: str, ver_num: str) -> None:
+        set_config("Machine", "version", ver_num)
         # Two vertices in the same router can't send with the same key
         writer = PacmanDataWriter.mock()
         v_target = SimpleTestVertex(1, splitter=SplitterFixedLegacy())
@@ -149,7 +160,9 @@ class TestBasic(unittest.TestCase):
         with self.assertRaises(KeyError):
             basic_routing_table_generator()
 
-    def test_non_overlapping_different_chips(self) -> None:
+    @parameterized.expand(MANY_BOARD_TYPES)
+    def test_non_overlapping_different_chips(self, _: str, ver_num: str) -> None:
+        set_config("Machine", "version", ver_num)
         # Two vertices with non-overlapping routes can use the same key
         writer = PacmanDataWriter.mock()
         v_target_1 = FixedKeyAppVertex(None)

--- a/unittests/operations_tests/routing_table_generator_tests/test_merged.py
+++ b/unittests/operations_tests/routing_table_generator_tests/test_merged.py
@@ -15,7 +15,11 @@
 from typing import Optional
 import unittest
 
+from parameterized import parameterized
+
 from spinn_utilities.config_holder import set_config
+
+from spinn_machine.version import BIG_BOARD_TYPES, MANY_BOARD_TYPES, Spin1Gen
 
 from pacman.config_setup import unittest_setup
 from pacman.data.pacman_data_writer import PacmanDataWriter
@@ -43,9 +47,6 @@ class TestMerged(unittest.TestCase):
 
     def setUp(self) -> None:
         unittest_setup()
-        # TODO check after
-        #  https://github.com/SpiNNakerManchester/PACMAN/pull/555
-        set_config("Machine", "version", "5")
 
     def create_graphs1(self, writer: PacmanDataWriter) -> None:
         v1 = SimpleTestVertex(
@@ -102,14 +103,18 @@ class TestMerged(unittest.TestCase):
         allocator = ZonedRoutingInfoAllocator()
         writer.set_routing_infos(allocator.allocate())
 
-    def test_empty(self) -> None:
+    @parameterized.expand(MANY_BOARD_TYPES)
+    def test_empty(self, _: str, ver_num: str) -> None:
+        set_config("Machine", "version", ver_num)
         writer = PacmanDataWriter.mock()
         self.make_infos(writer)
         data = merged_routing_table_generator()
         self.assertEqual(0, data.get_max_number_of_entries())
         self.assertEqual(0, len(list(data.routing_tables)))
 
-    def test_graph1(self) -> None:
+    @parameterized.expand(MANY_BOARD_TYPES)
+    def test_graph1(self, _: str, ver_num: str) -> None:
+        set_config("Machine", "version", ver_num)
         writer = PacmanDataWriter.mock()
         self.create_graphs1(writer)
         self.make_infos(writer)
@@ -118,6 +123,8 @@ class TestMerged(unittest.TestCase):
         self.assertEqual(1, len(list(data.routing_tables)))
 
     def test_graph2(self) -> None:
+        # test has specific version 5 values
+        set_config("Machine", "version", str(Spin1Gen.FIVE.value))
         writer = PacmanDataWriter.mock()
         self.create_graphs3(writer)
         self.make_infos(writer)
@@ -126,6 +133,8 @@ class TestMerged(unittest.TestCase):
         self.assertEqual(5, len(list(data.routing_tables)))
 
     def test_graph3_with_system(self) -> None:
+        # test has specific version 5 values
+        set_config("Machine", "version", str(Spin1Gen.FIVE.value))
         writer = PacmanDataWriter.mock()
         self.create_graphs3(writer)
         system_plaements = Placements()
@@ -136,7 +145,9 @@ class TestMerged(unittest.TestCase):
         self.assertEqual(6, data.get_max_number_of_entries())
         self.assertEqual(5, len(list(data.routing_tables)))
 
-    def test_bad_infos(self) -> None:
+    @parameterized.expand(MANY_BOARD_TYPES)
+    def test_bad_infos(self, _: str, ver_num: str) -> None:
+        set_config("Machine", "version", ver_num)
         writer = PacmanDataWriter.mock()
         self.create_graphs1(writer)
         self.make_infos(writer)
@@ -160,7 +171,9 @@ class TestMerged(unittest.TestCase):
             check.append(ten.pop())
         self.assertEqual(10, len(check))
 
-    def test_overlapping(self) -> None:
+    @parameterized.expand(MANY_BOARD_TYPES)
+    def test_overlapping(self, _: str, ver_num: str) -> None:
+        set_config("Machine", "version", ver_num)
         # Two vertices in the same router can't send with the same key
         writer = PacmanDataWriter.mock()
         v_target = SimpleTestVertex(1, splitter=SplitterFixedLegacy())
@@ -172,13 +185,15 @@ class TestMerged(unittest.TestCase):
         writer.add_edge(ApplicationEdge(v1, v_target), "Test")
         writer.add_edge(ApplicationEdge(v2, v_target), "Test")
         system_placements = Placements()
-        system_placements.add_placement(Placement(v1.machine_vertex, 0, 0, 1))
-        system_placements.add_placement(Placement(v2.machine_vertex, 0, 0, 2))
+        system_placements.add_placement(Placement(v1.machine_vertex, 0, 0, 3))
+        system_placements.add_placement(Placement(v2.machine_vertex, 0, 0, 4))
         self.make_infos(writer, system_placements)
         with self.assertRaises(KeyError):
             merged_routing_table_generator()
 
-    def test_overlapping_different_chips(self) -> None:
+    @parameterized.expand(BIG_BOARD_TYPES)  # Needs multiple Chips
+    def test_overlapping_different_chips(self, _: str, ver_num: str) -> None:
+        set_config("Machine", "version", ver_num)
         # Two vertices in the same router can't send with the same key
         writer = PacmanDataWriter.mock()
         v_target = SimpleTestVertex(1, splitter=SplitterFixedLegacy())
@@ -196,7 +211,9 @@ class TestMerged(unittest.TestCase):
         with self.assertRaises(KeyError):
             merged_routing_table_generator()
 
-    def test_non_overlapping_different_chips(self) -> None:
+    @parameterized.expand(MANY_BOARD_TYPES)
+    def test_non_overlapping_different_chips(self, _: str, ver_num: str) -> None:
+        set_config("Machine", "version", ver_num)
         # Two vertices with non-overlapping routes can use the same key
         writer = PacmanDataWriter.mock()
         v_target_1 = FixedKeyAppVertex(None)

--- a/unittests/operations_tests/routing_table_generator_tests/test_merged.py
+++ b/unittests/operations_tests/routing_table_generator_tests/test_merged.py
@@ -212,7 +212,8 @@ class TestMerged(unittest.TestCase):
             merged_routing_table_generator()
 
     @parameterized.expand(MANY_BOARD_TYPES)
-    def test_non_overlapping_different_chips(self, _: str, ver_num: str) -> None:
+    def test_non_overlapping_different_chips(
+            self, _: str, ver_num: str) -> None:
         set_config("Machine", "version", ver_num)
         # Two vertices with non-overlapping routes can use the same key
         writer = PacmanDataWriter.mock()

--- a/unittests/test_fixed_route_router.py
+++ b/unittests/test_fixed_route_router.py
@@ -19,7 +19,7 @@ from parameterized import parameterized
 from spinn_utilities.config_holder import set_config
 
 from spinn_machine import Machine, RoutingEntry, virtual_machine
-from spinn_machine.version import BIG_BOARD_TYPES, Spin1Gen
+from spinn_machine.version import BIG_BOARD_TYPES, Spin1Gen, Spin2Gen
 
 from pacman.config_setup import unittest_setup
 from pacman.data.pacman_data_writer import PacmanDataWriter
@@ -76,11 +76,14 @@ def _check_setup(width: int, height: int) -> None:
 
 @pytest.mark.parametrize(
     "version, width,height",
-    [(3, 2, 2),
-     (5, 8, 8),
-     (5, 12, 12),
-     (5, 16, 16),
-     (201, 1, 1)])
+    [(Spin1Gen.THREE.value, 2, 2),
+     (Spin1Gen.FIVE.value, 8, 8),
+     (Spin1Gen.FIVE.value, 12, 12),
+     (Spin1Gen.FIVE.value, 16, 16),
+     (Spin2Gen.SPIN2_1CHIP.value, 1, 1),
+     (Spin2Gen.SPIN2_48CHIP.value, 8, 8),
+     (Spin2Gen.SPIN2_48CHIP.value, 12, 12),
+     (Spin2Gen.SPIN2_48CHIP.value, 16, 16)])
 @pytest.mark.parametrize(
     "with_down_links,with_down_chips",
     [(False, False),

--- a/unittests/test_fixed_route_router.py
+++ b/unittests/test_fixed_route_router.py
@@ -18,7 +18,7 @@ from typing import Dict, Set, Tuple
 from spinn_utilities.config_holder import set_config
 
 from spinn_machine import Machine, RoutingEntry, virtual_machine
-from spinn_machine.version import SPIN1_GEN
+from spinn_machine.version import Spin1Gen
 
 from pacman.config_setup import unittest_setup
 from pacman.data.pacman_data_writer import PacmanDataWriter
@@ -111,7 +111,7 @@ def test_all_working(width: int, height: int,  version: int,
 
 def test_unreachable() -> None:
     unittest_setup()
-    set_config("Machine", "version", str(SPIN1_GEN.FIVE))
+    set_config("Machine", "version", str(Spin1Gen.FIVE))
     set_config("Machine", "down_chips", "0,2:1,3:1,4")
     with pytest.raises(PacmanRoutingException):
         _check_setup(8, 8)

--- a/unittests/test_fixed_route_router.py
+++ b/unittests/test_fixed_route_router.py
@@ -111,7 +111,7 @@ def test_all_working(width: int, height: int,  version: int,
 
 def test_unreachable() -> None:
     unittest_setup()
-    set_config("Machine", "version", str(Spin1Gen.FIVE))
+    set_config("Machine", "version", str(Spin1Gen.FIVE.value))
     set_config("Machine", "down_chips", "0,2:1,3:1,4")
     with pytest.raises(PacmanRoutingException):
         _check_setup(8, 8)

--- a/unittests/test_fixed_route_router.py
+++ b/unittests/test_fixed_route_router.py
@@ -18,7 +18,7 @@ from typing import Dict, Set, Tuple
 from spinn_utilities.config_holder import set_config
 
 from spinn_machine import Machine, RoutingEntry, virtual_machine
-from spinn_machine.version import FIVE
+from spinn_machine.version import SPIN1_GEN
 
 from pacman.config_setup import unittest_setup
 from pacman.data.pacman_data_writer import PacmanDataWriter
@@ -111,7 +111,7 @@ def test_all_working(width: int, height: int,  version: int,
 
 def test_unreachable() -> None:
     unittest_setup()
-    set_config("Machine", "version", str(FIVE))
+    set_config("Machine", "version", str(SPIN1_GEN.FIVE))
     set_config("Machine", "down_chips", "0,2:1,3:1,4")
     with pytest.raises(PacmanRoutingException):
         _check_setup(8, 8)


### PR DESCRIPTION
part of https://github.com/SpiNNakerManchester/SpiNNMachine/pull/316

also replaces hard coded version numbers and where possible tests both spin1 and spin2